### PR TITLE
feat(core): refactor interceptors and introduce FetchExchange

### DIFF
--- a/examples/src/interceptorExample.ts
+++ b/examples/src/interceptorExample.ts
@@ -1,5 +1,5 @@
-import { Fetcher, RequestInterceptor } from '@ahoo-wang/fetcher';
-import { updateOutput, showLoading } from './basicGetExample';
+import { Fetcher, FetchExchange, Interceptor } from '@ahoo-wang/fetcher';
+import { showLoading, updateOutput } from './basicGetExample';
 
 // Create a Fetcher instance
 const fetcher = new Fetcher({
@@ -19,16 +19,17 @@ export function initInterceptorExample(): void {
 
       // Add request interceptor
       const requestInterceptorId = fetcher.interceptors.request.use({
-        intercept(request: Request) {
-          return {
-            ...request,
+        intercept(exchange: FetchExchange) {
+          exchange.request = {
+            ...exchange.request,
             headers: {
-              ...request.headers,
+              ...exchange.request.headers,
               'X-Custom-Header': 'Added by interceptor',
             },
           };
+          return exchange;
         },
-      } as RequestInterceptor);
+      } as Interceptor);
 
       try {
         const response: Response = await fetcher.get('/posts/1');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcher",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A modern HTTP client library based on fetch API",
   "private": true,
   "workspaces": [

--- a/packages/eventstream/README.md
+++ b/packages/eventstream/README.md
@@ -136,17 +136,17 @@ Converts a Response object with a `text/event-stream` body to a readable stream 
 
 A response interceptor that automatically adds an `eventStream()` method to responses with `text/event-stream` content type.
 
-#### `intercept(response: Response): Response`
+#### `intercept(exchange: FetchExchange): FetchExchange`
 
 Intercepts a response and adds the `eventStream()` method if the content type is `text/event-stream`.
 
 **Parameters:**
 
-- `response`: The HTTP response to intercept
+- `exchange`: The fetch exchange containing the response to intercept
 
 **Returns:**
 
-- `Response`: The intercepted response with added `eventStream()` method
+- `FetchExchange`: The intercepted exchange with response potentially modified to include `eventStream()` method
 
 ### ServerSentEvent
 

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventstream",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Support for text/event-stream in Fetcher",
   "keywords": [
     "fetch",

--- a/packages/eventstream/src/eventStreamInterceptor.ts
+++ b/packages/eventstream/src/eventStreamInterceptor.ts
@@ -1,13 +1,16 @@
 import { toServerSentEventStream } from './eventStreamConverter';
 import {
   ContentTypeHeader,
-  ContentTypeValues,
-  ResponseInterceptor,
+  ContentTypeValues, FetchExchange, Interceptor,
 } from '@ahoo-wang/fetcher';
 
-export class EventStreamInterceptor implements ResponseInterceptor {
-  intercept(response: Response): Response {
+export class EventStreamInterceptor implements Interceptor {
+  intercept(exchange: FetchExchange): FetchExchange {
     // Check if the response is an event stream
+    const response = exchange.response;
+    if (!response) {
+      return exchange;
+    }
     const contentType = response.headers.get(ContentTypeHeader);
     if (
       contentType &&
@@ -16,6 +19,6 @@ export class EventStreamInterceptor implements ResponseInterceptor {
       // Add eventStream method to response
       response.eventStream = () => toServerSentEventStream(response);
     }
-    return response;
+    return exchange;
   }
 }

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Core library providing basic HTTP client functionality for Fetcher",
   "keywords": [
     "fetch",

--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -1,11 +1,10 @@
-import { RequestInterceptor } from './interceptor';
-import { FetcherRequest } from './fetcher';
+import { FetchExchange, Interceptor } from './interceptor';
 import { ContentTypeHeader, ContentTypeValues } from './types';
 
 /**
  * 请求体拦截器，负责将普通对象转换为JSON字符串
  */
-export class RequestBodyInterceptor implements RequestInterceptor {
+export class RequestBodyInterceptor implements Interceptor {
   /**
    * 尝试转换请求体为合法的 fetch API body 类型
    *
@@ -25,18 +24,19 @@ export class RequestBodyInterceptor implements RequestInterceptor {
    *
    * 对于不支持的 object 类型（如普通对象），将自动转换为 JSON 字符串
    *
-   * @param request 请求参数
+   * @param exchange
    * @returns 转换后的请求
    */
-  intercept(request: FetcherRequest): FetcherRequest {
+  intercept(exchange: FetchExchange): FetchExchange {
+    const request = exchange.request;
     // 如果没有请求体，直接返回
     if (request.body === undefined || request.body === null) {
-      return request;
+      return exchange;
     }
 
     // 如果请求体不是对象，直接返回
     if (typeof request.body !== 'object') {
-      return request;
+      return exchange;
     }
 
     // 检查是否为支持的类型
@@ -49,7 +49,7 @@ export class RequestBodyInterceptor implements RequestInterceptor {
       request.body instanceof FormData ||
       request.body instanceof ReadableStream
     ) {
-      return request;
+      return exchange;
     }
 
     // 对于普通对象，转换为 JSON 字符串
@@ -68,6 +68,6 @@ export class RequestBodyInterceptor implements RequestInterceptor {
       headers[ContentTypeHeader] = ContentTypeValues.APPLICATION_JSON;
     }
 
-    return modifiedRequest;
+    return { ...exchange, request: modifiedRequest };
   }
 }

--- a/packages/fetcher/test/requestBodyInterceptor.test.ts
+++ b/packages/fetcher/test/requestBodyInterceptor.test.ts
@@ -1,198 +1,295 @@
 import { describe, it, expect } from 'vitest';
 import { RequestBodyInterceptor } from '../src/requestBodyInterceptor';
-import { FetcherRequest } from '../src';
 import { ContentTypeHeader, ContentTypeValues } from '../src';
+import { Fetcher, FetchExchange } from '../src';
 
 describe('RequestBodyInterceptor', () => {
   const interceptor = new RequestBodyInterceptor();
+  const mockFetcher = new Fetcher();
 
   it('should not modify request without body', () => {
-    const request: FetcherRequest = {
-      method: 'POST',
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with null body', () => {
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: null,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: null,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with string body', () => {
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: 'plain text' as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: 'plain text' as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with number body', () => {
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: 42 as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: 42 as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with boolean body', () => {
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: true as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: true as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with ArrayBuffer body', () => {
     const arrayBuffer = new ArrayBuffer(8);
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: arrayBuffer as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: arrayBuffer as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with Blob body', () => {
     const blob = new Blob(['hello'], { type: 'text/plain' });
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: blob as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: blob as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with FormData body', () => {
     const formData = new FormData();
     formData.append('key', 'value');
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: formData as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: formData as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with URLSearchParams body', () => {
     const params = new URLSearchParams({ key: 'value' });
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: params as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: params as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with ReadableStream body', () => {
     const stream = new ReadableStream();
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: stream as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: stream as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with File body', () => {
     const file = new File(['content'], 'test.txt', { type: 'text/plain' });
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: file as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: file as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with DataView body', () => {
     const buffer = new ArrayBuffer(16);
     const dataView = new DataView(buffer);
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: dataView as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: dataView as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should not modify request with TypedArray body', () => {
     const uint8Array = new Uint8Array([1, 2, 3]);
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: uint8Array as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: uint8Array as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).toBe(request);
+    const result = interceptor.intercept(exchange);
+    expect(result).toBe(exchange);
   });
 
   it('should convert plain object to JSON string and set Content-Type header', () => {
     const requestBody = { name: 'John', age: 30 };
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: requestBody as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: requestBody as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).not.toBe(request); // Should return a new object
-    expect(result.body).toBe(JSON.stringify(requestBody));
+    const result = interceptor.intercept(exchange);
+    expect(result).not.toBe(exchange); // Should return a new object
+    expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.headers as Record<string, string>;
+    const headers = result.request.headers as Record<string, string>;
     expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
   it('should not override existing Content-Type header', () => {
     const requestBody = { name: 'John', age: 30 };
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: requestBody as any,
-      headers: {
-        [ContentTypeHeader]: 'text/plain',
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: requestBody as any,
+        headers: {
+          [ContentTypeHeader]: 'text/plain',
+        },
       },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).not.toBe(request); // Should return a new object
-    expect(result.body).toBe(JSON.stringify(requestBody));
+    const result = interceptor.intercept(exchange);
+    expect(result).not.toBe(exchange); // Should return a new object
+    expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that existing Content-Type header is preserved
-    const headers = result.headers as Record<string, string>;
+    const headers = result.request.headers as Record<string, string>;
     expect(headers[ContentTypeHeader]).toBe('text/plain');
   });
 
   it('should handle array body by converting to JSON', () => {
     const requestBody = [1, 2, 3];
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: requestBody as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: requestBody as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).not.toBe(request); // Should return a new object
-    expect(result.body).toBe(JSON.stringify(requestBody));
+    const result = interceptor.intercept(exchange);
+    expect(result).not.toBe(exchange); // Should return a new object
+    expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.headers as Record<string, string>;
+    const headers = result.request.headers as Record<string, string>;
     expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
@@ -206,50 +303,68 @@ describe('RequestBodyInterceptor', () => {
         },
       },
     };
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: requestBody as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: requestBody as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).not.toBe(request); // Should return a new object
-    expect(result.body).toBe(JSON.stringify(requestBody));
+    const result = interceptor.intercept(exchange);
+    expect(result).not.toBe(exchange); // Should return a new object
+    expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.headers as Record<string, string>;
+    const headers = result.request.headers as Record<string, string>;
     expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
   it('should handle empty object body', () => {
     const requestBody = {};
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: requestBody as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: requestBody as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).not.toBe(request); // Should return a new object
-    expect(result.body).toBe(JSON.stringify(requestBody));
+    const result = interceptor.intercept(exchange);
+    expect(result).not.toBe(exchange); // Should return a new object
+    expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.headers as Record<string, string>;
+    const headers = result.request.headers as Record<string, string>;
     expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
   it('should handle null prototype object body', () => {
     const requestBody = Object.create(null);
     requestBody.name = 'John';
-    const request: FetcherRequest = {
-      method: 'POST',
-      body: requestBody as any,
+    const exchange: FetchExchange = {
+      fetcher: mockFetcher,
+      url: 'http://example.com',
+      request: {
+        method: 'POST',
+        body: requestBody as any,
+      },
+      response: undefined,
+      error: undefined,
     };
 
-    const result = interceptor.intercept(request);
-    expect(result).not.toBe(request); // Should return a new object
-    expect(result.body).toBe(JSON.stringify(requestBody));
+    const result = interceptor.intercept(exchange);
+    expect(result).not.toBe(exchange); // Should return a new object
+    expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.headers as Record<string, string>;
+    const headers = result.request.headers as Record<string, string>;
     expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 });


### PR DESCRIPTION
- Refactor interceptor interfaces to use a unified Interceptor type
- Introduce FetchExchange as the data structure passed between interceptors
- Update interceptor tests to use FetchExchange
- Modify EventStreamInterceptor to work with FetchExchange
- Update Fetcher to use FetchExchange in interceptors
- Adjust READMEs and package.json versions to reflect changes