### PR TITLE
docs(fetcher): update constructor examples in README

### DIFF
--- a/packages/fetcher/README.md
+++ b/packages/fetcher/README.md
@@ -199,7 +199,7 @@ Core HTTP client class that provides various HTTP methods.
 #### Constructor
 
 ```typescript
-new Fetcher(options: FetcherOptions = defaultOptions)
+new Fetcher(defaultOptions)
 ```
 
 **Parameters:**
@@ -227,12 +227,7 @@ name.
 #### Constructor
 
 ```typescript
-new NamedFetcher(name
-:
-string, options
-:
-FetcherOptions = defaultOptions
-)
+new NamedFetcher(name, defaultOptions)
 ```
 
 **Parameters:**

--- a/packages/fetcher/README.zh-CN.md
+++ b/packages/fetcher/README.zh-CN.md
@@ -199,8 +199,9 @@ const errorInterceptorId = fetcher.interceptors.error.use({
 #### 构造函数
 
 ```typescript
-new Fetcher(options?: FetcherOptions)
+new Fetcher(defaultOptions)
 ```
+
 
 **参数：**
 
@@ -226,10 +227,7 @@ Fetcher 类的扩展，它会自动使用提供的名称在全局 fetcherRegistr
 #### 构造函数
 
 ```typescript
-new NamedFetcher(name
-:
-string, options ? : FetcherOptions
-)
+new NamedFetcher(name, defaultOptions)
 ```
 
 **参数：**


### PR DESCRIPTION
- Remove optional parameter syntax from Fetcher constructor
- Simplify NamedFetcher constructor example
- Update examples in both English and Chinese README files