### PR TITLE
fix(decorator): add method property to RequestExecutor execute function

### DIFF
--- a/packages/decorator/README.md
+++ b/packages/decorator/README.md
@@ -93,7 +93,6 @@ Defines API metadata for a class.
 **Example:**
 
 ```typescript
-
 @api('/api/v1', {
   headers: { 'X-API-Version': '1.0' },
   timeout: 5000,
@@ -213,7 +212,6 @@ class UserService {
 ### Inheritance Support
 
 ```typescript
-
 @api('/base')
 class BaseService {
   @get('/status')
@@ -234,7 +232,6 @@ class UserService extends BaseService {
 ### Complex Parameter Handling
 
 ```typescript
-
 @api('/api')
 class ComplexService {
   @post('/batch')

--- a/packages/decorator/README.zh-CN.md
+++ b/packages/decorator/README.zh-CN.md
@@ -92,7 +92,6 @@ const response = await userService.createUser({ name: 'John' });
 **示例：**
 
 ```typescript
-
 @api('/api/v1', {
   headers: { 'X-API-Version': '1.0' },
   timeout: 5000,
@@ -212,7 +211,6 @@ class UserService {
 ### 继承支持
 
 ```typescript
-
 @api('/base')
 class BaseService {
   @get('/status')
@@ -233,7 +231,6 @@ class UserService extends BaseService {
 ### 复杂参数处理
 
 ```typescript
-
 @api('/api')
 class ComplexService {
   @post('/batch')

--- a/packages/decorator/src/requestExecutor.ts
+++ b/packages/decorator/src/requestExecutor.ts
@@ -132,6 +132,7 @@ export class FunctionMetadata implements NamedCapable {
       }
     });
     return {
+      method: this.endpoint.method,
       pathParams,
       queryParams,
       headers,

--- a/packages/decorator/test/apiDecorator.test.ts
+++ b/packages/decorator/test/apiDecorator.test.ts
@@ -36,8 +36,7 @@ describe('apiDecorator', () => {
   describe('metadata definition', () => {
     it('should define API metadata on class', () => {
       @api('/api', { headers: { 'X-Test': 'test' }, timeout: 5000 })
-      class TestService {
-      }
+      class TestService {}
 
       const metadata = Reflect.getMetadata(API_METADATA_KEY, TestService);
       expect(metadata).toEqual({
@@ -49,8 +48,7 @@ describe('apiDecorator', () => {
 
     it('should handle empty basePath', () => {
       @api()
-      class TestService {
-      }
+      class TestService {}
 
       const metadata = Reflect.getMetadata(API_METADATA_KEY, TestService);
       expect(metadata).toEqual({
@@ -64,8 +62,7 @@ describe('apiDecorator', () => {
         timeout: 5000,
         fetcher: 'custom',
       })
-      class TestService {
-      }
+      class TestService {}
 
       const metadata = Reflect.getMetadata(API_METADATA_KEY, TestService);
       expect(metadata).toEqual({
@@ -222,6 +219,7 @@ describe('apiDecorator', () => {
       const response = await instance.getUser(1);
 
       expect(mockFetch).toHaveBeenCalledWith('/api/users/{id}', {
+        method: 'GET',
         pathParams: { id: 1 },
         queryParams: {},
         headers: {},
@@ -235,8 +233,7 @@ describe('apiDecorator', () => {
   describe('class structure handling', () => {
     it('should handle class with no methods', () => {
       @api('/test')
-      class TestService {
-      }
+      class TestService {}
 
       const metadata = Reflect.getMetadata(API_METADATA_KEY, TestService);
       expect(metadata).toBeDefined();


### PR DESCRIPTION
- Include the method property in the object returned by the execute function
- This ensures that the HTTP method (GET, POST, etc.) is properly set when making requests