### PR TITLE
feat(types): add type-safe json() method to Response interface

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fetcher/examples",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Examples for Fetcher HTTP client library",
   "keywords": [

--- a/examples/src/basic-usage.ts
+++ b/examples/src/basic-usage.ts
@@ -18,12 +18,14 @@ const fetcher = new Fetcher({
   baseURL: 'https://jsonplaceholder.typicode.com',
   timeout: 5000,
 });
-
+type Post = {
+  id: string;
+};
 // Basic GET request
 fetcher
   .get('/posts/1')
-  .then((response: Response) => response.json())
-  .then((data: unknown) => {
+  .then((response: Response) => response.json<Post>())
+  .then((data: Post) => {
     console.log('Basic GET request:', data);
   })
   .catch((error: unknown) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcher",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A modern HTTP client library based on fetch API",
   "private": true,
   "type": "module",

--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-cosec",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "CoSec authentication integration for Fetcher HTTP client",
   "keywords": [
     "fetch",

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-decorator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript decorators for clean API service definitions with Fetcher HTTP client",
   "keywords": [
     "fetch",

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventstream",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Server-Sent Events (SSE) support for Fetcher HTTP client",
   "keywords": [
     "fetch",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Ultra-lightweight (1.9kB) HTTP client with built-in path parameters and Axios-like API",
   "keywords": [
     "fetch",

--- a/packages/fetcher/src/types.ts
+++ b/packages/fetcher/src/types.ts
@@ -62,4 +62,17 @@ export interface NamedCapable {
   name: string;
 }
 
-
+/**
+ * Global extension of Response interface
+ * Adds type-safe json() method support to Response objects
+ */
+declare global {
+  interface Response {
+    /**
+     * Parse response body as JSON in a type-safe manner
+     * @template T The type of returned data, defaults to any
+     * @returns Promise<T> The parsed JSON data
+     */
+    json<T = any>(): Promise<T>;
+  }
+}

--- a/packages/fetcher/test/fetcher.test.ts
+++ b/packages/fetcher/test/fetcher.test.ts
@@ -341,4 +341,37 @@ describe('Fetcher', () => {
       }),
     );
   });
+
+  it('should support generic response json type', async () => {
+    interface User {
+      id: number;
+      name: string;
+      email: string;
+    }
+
+    const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
+    const mockData: User = {
+      id: 1,
+      name: 'John Doe',
+      email: 'john@example.com',
+    };
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(mockData)));
+
+    const response = await fetcher.get('/users/1');
+    const userData = await response.json<User>();
+
+    // Type assertion to verify generic type support
+    const typedUser: User = userData;
+    expect(typedUser.id).toBe(1);
+    expect(typedUser.name).toBe('John Doe');
+    expect(typedUser.email).toBe('john@example.com');
+
+    expect(userData).toEqual(mockData);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/users/1',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+  });
 });


### PR DESCRIPTION
- Extend the Response interface with a generic json() method
- Update basic-usage.ts to demonstrate type-safe response handling
- Add unit test to verify generic type support for response json()