### PR TITLE
feat(decorator): add @request() decorator and enhance request merging 

### DIFF
--- a/packages/decorator/README.md
+++ b/packages/decorator/README.md
@@ -63,10 +63,7 @@ class UserService {
   }
 
   @get('/{id}')
-  getUser(
-    @path() id: number,
-    @query() include: string,
-  ): Promise<Response> {
+  getUser(@path() id: number, @query() include: string): Promise<Response> {
     throw new Error('Implementation will be generated automatically.');
   }
 }
@@ -192,6 +189,12 @@ parameter name.
 
 - `name`: Name of the header (optional - auto-extracted if not provided)
 
+#### `@request()`
+
+Defines a request parameter that will be used as the base request object. This allows you to pass a complete
+FetcherRequest
+object to customize the request configuration.
+
 **Example:**
 
 ```typescript
@@ -202,6 +205,11 @@ class UserService {
     @query() limit: number,
     @header('Authorization') auth: string,
   ): Promise<Response> {
+    throw new Error('Implementation will be generated automatically.');
+  }
+
+  @post('/users')
+  createUsers(@request() request: FetcherRequest): Promise<Response> {
     throw new Error('Implementation will be generated automatically.');
   }
 
@@ -245,6 +253,33 @@ class ComplexService {
     @header('X-Request-ID') requestId: string,
     @query() dryRun: boolean = false,
   ): Promise<Response> {
+    throw new Error('Implementation will be generated automatically.');
+  }
+}
+```
+
+### Request Merging
+
+When using the `@request()` decorator, the provided `FetcherRequest` object is merged with endpoint-specific
+configuration using a sophisticated merging strategy:
+
+- **Nested objects** (path, query, headers) are recursively merged, with parameter values taking precedence
+- **Primitive values** (method, body, timeout, signal) from the parameter request override endpoint values
+- **Empty objects** are handled gracefully, falling back to endpoint configuration
+
+```typescript
+
+@api('/users')
+class UserService {
+  @post('/')
+  createUsers(
+    @body() user: User,
+    @request() request: FetcherRequest,
+  ): Promise<Response> {
+    // The final request will merge:
+    // - Endpoint method (POST)
+    // - Body parameter (user object)
+    // - Any configuration from the request parameter
     throw new Error('Implementation will be generated automatically.');
   }
 }

--- a/packages/decorator/README.zh-CN.md
+++ b/packages/decorator/README.zh-CN.md
@@ -62,10 +62,7 @@ class UserService {
   }
 
   @get('/{id}')
-  getUser(
-    @path() id: number,
-    @query() include: string,
-  ): Promise<Response> {
+  getUser(@path() id: number, @query() include: string): Promise<Response> {
     throw new Error('实现将自动生成');
   }
 }
@@ -188,6 +185,10 @@ class UserService {
 
 - `name`: 头部名称（可选 - 如果未提供则自动提取）
 
+#### `@request()`
+
+定义请求参数，将用作基础请求对象。这允许您传递一个完整的 FetcherRequest 对象来自定义请求配置。
+
 **示例：**
 
 ```typescript
@@ -198,6 +199,11 @@ class UserService {
     @query() limit: number,
     @header('Authorization') auth: string,
   ): Promise<Response> {
+    throw new Error('实现将自动生成');
+  }
+
+  @post('/users')
+  createUsers(@request() request: FetcherRequest): Promise<Response> {
     throw new Error('实现将自动生成');
   }
 
@@ -241,6 +247,32 @@ class ComplexService {
     @header('X-Request-ID') requestId: string,
     @query() dryRun: boolean = false,
   ): Promise<Response> {
+    throw new Error('实现将自动生成');
+  }
+}
+```
+
+### 请求合并
+
+当使用 `@request()` 装饰器时，提供的 `FetcherRequest` 对象会使用复杂的合并策略与端点特定配置进行合并：
+
+- **嵌套对象**（路径、查询、头部）会被递归合并，参数值优先
+- **基本值**（方法、请求体、超时、信号）来自参数请求的值会覆盖端点值
+- **空对象**会被优雅地处理，回退到端点配置
+
+```typescript
+
+@api('/users')
+class UserService {
+  @post('/')
+  createUsers(
+    @body() user: User,
+    @request() request: FetcherRequest,
+  ): Promise<Response> {
+    // 最终请求将合并：
+    // - 端点方法（POST）
+    // - 请求体参数（user 对象）
+    // - 来自 request 参数的任何配置
     throw new Error('实现将自动生成');
   }
 }

--- a/packages/decorator/src/parameterDecorator.ts
+++ b/packages/decorator/src/parameterDecorator.ts
@@ -64,6 +64,11 @@ export enum ParameterType {
    * ```
    */
   BODY = 'body',
+
+  /**
+   * Request parameter that will be used as the request object.
+   */
+  REQUEST = 'request',
 }
 
 /**
@@ -245,4 +250,23 @@ export function header(name: string = '') {
  */
 export function body() {
   return parameter(ParameterType.BODY);
+}
+
+/**
+ * Request parameter decorator
+ *
+ * Defines a request parameter that will be used as the base request object.
+ * This allows you to pass a complete FetcherRequest object to customize
+ * the request configuration.
+ *
+ * @returns A parameter decorator function
+ *
+ * @example
+ * ```typescript
+ * @post('/users')
+ * createUsers(@request() request: FetcherRequest): Promise<Response>
+ * ```
+ */
+export function request() {
+  return parameter(ParameterType.REQUEST);
 }

--- a/packages/decorator/src/requestExecutor.ts
+++ b/packages/decorator/src/requestExecutor.ts
@@ -16,6 +16,7 @@ import {
   Fetcher,
   fetcherRegistrar,
   FetcherRequest,
+  mergeRequest,
   NamedCapable,
 } from '@ahoo-wang/fetcher';
 import { ApiMetadata } from './apiDecorator';
@@ -89,10 +90,44 @@ export class FunctionMetadata implements NamedCapable {
    *
    * This method processes the runtime arguments according to the parameter metadata
    * and constructs a FetcherRequest object with path parameters, query parameters,
-   * headers, body, and timeout.
+   * headers, body, and timeout. It handles various parameter types including:
+   * - Path parameters (@path decorator)
+   * - Query parameters (@query decorator)
+   * - Header parameters (@header decorator)
+   * - Body parameter (@body decorator)
+   * - Complete request object (@request decorator)
+   * - AbortSignal for request cancellation
+   *
+   * The method uses mergeRequest to combine the endpoint-specific configuration
+   * with the parameter-provided request object, where the parameter request
+   * takes precedence over endpoint configuration.
    *
    * @param args - The runtime arguments passed to the method
    * @returns A FetcherRequest object with all request configuration
+   *
+   * @example
+   * ```typescript
+   * // For a method decorated like:
+   * @get('/users/{id}')
+   * getUser(
+   *   @path('id') id: number,
+   *   @query('include') include: string,
+   *   @header('Authorization') auth: string
+   * ): Promise<Response>
+   *
+   * // Calling with: getUser(123, 'profile', 'Bearer token')
+   * // Would produce a request with:
+   * // {
+   * //   method: 'GET',
+   * //   path: { id: 123 },
+   * //   query: { include: 'profile' },
+   * //   headers: {
+   * //     'Authorization': 'Bearer token',
+   * //     ...apiHeaders,
+   * //     ...endpointHeaders
+   * //   }
+   * // }
+   * ```
    */
   resolveRequest(args: any[]): FetcherRequest {
     const path: Record<string, any> = {};
@@ -101,8 +136,9 @@ export class FunctionMetadata implements NamedCapable {
       ...this.api.headers,
       ...this.endpoint.headers,
     };
-    let body: any = null;
-    let signal: AbortSignal | null = null;
+    let body: any = undefined;
+    let signal: AbortSignal | null | undefined = undefined;
+    let parameterRequest: FetcherRequest = {};
     // Process parameters based on their decorators
     args.forEach((value, index) => {
       if (value instanceof AbortSignal) {
@@ -124,10 +160,13 @@ export class FunctionMetadata implements NamedCapable {
           case ParameterType.BODY:
             body = value;
             break;
+          case ParameterType.REQUEST:
+            parameterRequest = this.processRequestParam(value);
+            break;
         }
       }
     });
-    return {
+    const endpointRequest: FetcherRequest = {
       method: this.endpoint.method,
       path,
       query,
@@ -136,6 +175,7 @@ export class FunctionMetadata implements NamedCapable {
       timeout: this.resolveTimeout(),
       signal,
     };
+    return mergeRequest(endpointRequest, parameterRequest);
   }
 
   private processPathParam(
@@ -164,6 +204,34 @@ export class FunctionMetadata implements NamedCapable {
     if (param.name && value !== undefined) {
       headers[param.name] = String(value);
     }
+  }
+
+  /**
+   * Processes a request parameter value
+   *
+   * This method handles the @request() decorator parameter by casting
+   * the provided value to a FetcherRequest. The @request() decorator
+   * allows users to pass a complete FetcherRequest object to customize
+   * the request configuration.
+   *
+   * @param value - The value provided for the @request() parameter
+   * @returns The value cast to FetcherRequest type
+   *
+   * @example
+   * ```typescript
+   * @post('/users')
+   * createUsers(@request() request: FetcherRequest): Promise<Response>
+   *
+   * // Usage:
+   * const customRequest: FetcherRequest = {
+   *   headers: { 'X-Custom': 'value' },
+   *   timeout: 5000
+   * };
+   * await service.createUsers(customRequest);
+   * ```
+   */
+  private processRequestParam(value: any): FetcherRequest {
+    return value as FetcherRequest;
   }
 
   /**

--- a/packages/decorator/test/apiDecorator.test.ts
+++ b/packages/decorator/test/apiDecorator.test.ts
@@ -223,9 +223,9 @@ describe('apiDecorator', () => {
         path: { id: 1 },
         query: {},
         headers: {},
-        body: null,
+        body: undefined,
         timeout: undefined,
-        signal: null,
+        signal: undefined,
       });
       expect(response).toBe(mockResponse);
     });

--- a/packages/decorator/test/parameterDecorator.test.ts
+++ b/packages/decorator/test/parameterDecorator.test.ts
@@ -5,6 +5,7 @@ import {
   query,
   header,
   body,
+  request,
   ParameterType,
   PARAMETER_METADATA_KEY,
 } from '../src';
@@ -142,7 +143,7 @@ describe('parameterDecorator', () => {
 
   it('should handle multiple parameters', () => {
     class TestService {
-      updateUsers(id: number, force: boolean, user: any) {
+      updateUsers(_id: number, _force: boolean, _user: any) {
         // Implementation will be generated automatically
       }
     }
@@ -172,8 +173,34 @@ describe('parameterDecorator', () => {
       },
       {
         type: ParameterType.BODY,
-        name: 'user',
+        name: '_user',
         index: 2,
+      },
+    ]);
+  });
+
+  it('should define request parameter', () => {
+    class TestService {
+      createUsers(_request: any) {
+        // Implementation will be generated automatically
+      }
+    }
+
+    // Apply decorator manually for testing
+    request()(TestService.prototype, 'createUsers', 0);
+
+    const instance = new TestService();
+    const metadata = Reflect.getMetadata(
+      PARAMETER_METADATA_KEY,
+      Object.getPrototypeOf(instance),
+      'createUsers',
+    );
+
+    expect(metadata).toEqual([
+      {
+        type: ParameterType.REQUEST,
+        name: '_request',
+        index: 0,
       },
     ]);
   });

--- a/packages/decorator/test/requestExecutor.resolveRequest.test.ts
+++ b/packages/decorator/test/requestExecutor.resolveRequest.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { FunctionMetadata } from '../src';
+import { ParameterType } from '../src';
+import { HttpMethod } from '@ahoo-wang/fetcher';
+
+describe('FunctionMetadata.resolveRequest', () => {
+  it('should resolve request with request parameter', () => {
+    const metadata = new FunctionMetadata(
+      'testFunc',
+      {},
+      { method: HttpMethod.POST },
+      [
+        {
+          type: ParameterType.REQUEST,
+          index: 0,
+        },
+      ],
+    );
+
+    const requestObject = {
+      headers: { 'X-Custom': 'value' },
+      query: { filter: 'active' },
+      timeout: 5000,
+    };
+    const request = metadata.resolveRequest([requestObject]);
+    expect(request.headers).toEqual({
+      'X-Custom': 'value',
+    });
+    expect(request.query).toEqual({ filter: 'active' });
+    expect(request.timeout).toBe(5000);
+  });
+
+  it('should merge endpoint request with parameter request', () => {
+    const metadata = new FunctionMetadata(
+      'testFunc',
+      {},
+      { method: HttpMethod.POST },
+      [
+        {
+          type: ParameterType.PATH,
+          name: 'id',
+          index: 0,
+        },
+        {
+          type: ParameterType.REQUEST,
+          index: 1,
+        },
+      ],
+    );
+
+    const requestObject = {
+      headers: { 'X-Custom': 'value' },
+      query: { filter: 'active' },
+      timeout: 5000,
+    };
+    const request = metadata.resolveRequest([123, requestObject]);
+
+    // Path parameter should be merged
+    expect(request.path).toEqual({ id: 123 });
+
+    // Parameter request should take precedence
+    expect(request.headers).toEqual({
+      'X-Custom': 'value',
+    });
+    expect(request.query).toEqual({ filter: 'active' });
+    expect(request.timeout).toBe(5000);
+  });
+
+  it('should give parameter request precedence over endpoint configuration', () => {
+    const metadata = new FunctionMetadata(
+      'testFunc',
+      {},
+      { method: HttpMethod.GET },
+      [
+        {
+          type: ParameterType.REQUEST,
+          index: 0,
+        },
+      ],
+    );
+
+    const requestObject = {
+      method: HttpMethod.POST,
+      headers: { 'Content-Type': 'application/json' },
+      body: { name: 'John' },
+    };
+    const request = metadata.resolveRequest([requestObject]);
+
+    // Parameter request should take precedence
+    expect(request.method).toBe(HttpMethod.POST);
+    expect(request.headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(request.body).toEqual({ name: 'John' });
+  });
+
+  it('should handle empty parameter request', () => {
+    const metadata = new FunctionMetadata(
+      'testFunc',
+      {},
+      { method: HttpMethod.GET },
+      [
+        {
+          type: ParameterType.REQUEST,
+          index: 0,
+        },
+        {
+          type: ParameterType.PATH,
+          name: 'id',
+          index: 1,
+        },
+      ],
+    );
+
+    const requestObject = {};
+    const request = metadata.resolveRequest([requestObject, 456]);
+
+    // Should fall back to endpoint configuration
+    expect(request.method).toBe(HttpMethod.GET);
+    // Path parameter should still be processed
+    expect(request.path).toEqual({ id: 456 });
+  });
+
+  it('should merge nested objects correctly', () => {
+    const metadata = new FunctionMetadata(
+      'testFunc',
+      {},
+      { method: HttpMethod.POST },
+      [
+        {
+          type: ParameterType.REQUEST,
+          index: 0,
+        },
+        {
+          type: ParameterType.PATH,
+          name: 'userId',
+          index: 1,
+        },
+        {
+          type: ParameterType.QUERY,
+          name: 'page',
+          index: 2,
+        },
+      ],
+    );
+
+    const requestObject = {
+      path: { postId: 123 },
+      query: { filter: 'active' },
+      headers: { Authorization: 'Bearer token' },
+    };
+    const request = metadata.resolveRequest([requestObject, 789, 2]);
+
+    // Should merge nested objects
+    expect(request.path).toEqual({
+      postId: 123,
+      userId: 789,
+    });
+    expect(request.query).toEqual({
+      filter: 'active',
+      page: 2,
+    });
+    expect(request.headers).toEqual({
+      Authorization: 'Bearer token',
+    });
+  });
+});

--- a/packages/decorator/test/requestExecutor.test.ts
+++ b/packages/decorator/test/requestExecutor.test.ts
@@ -122,7 +122,7 @@ describe('FunctionMetadata', () => {
 
     const request = metadata.resolveRequest([123]);
     expect(request.path).toEqual({ id: 123 });
-    expect(request.signal).toBeNull();
+    expect(request.signal).toBeUndefined();
   });
 
   it('should get fetcher correctly', () => {

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -14,6 +14,7 @@
 export * from './fetcher';
 export * from './fetcherRegistrar';
 export * from './interceptor';
+export * from './mergeRequest';
 export * from './namedFetcher';
 export * from './orderedCapable';
 export * from './requestBodyInterceptor';

--- a/packages/fetcher/src/mergeRequest.ts
+++ b/packages/fetcher/src/mergeRequest.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FetcherRequest } from './fetcher';
+
+/**
+ * Merges two FetcherRequest objects into one.
+ *
+ * This function combines two FetcherRequest objects, with the second object's properties
+ * taking precedence over the first object's properties. Special handling is applied
+ * to nested objects like path, query, and headers which are merged recursively.
+ * For primitive values, the second object's values override the first's.
+ *
+ * @param first - The first request object (lower priority)
+ * @param second - The second request object (higher priority)
+ * @returns A new FetcherRequest object with merged properties
+ *
+ * @example
+ * ```typescript
+ * const request1 = {
+ *   method: 'GET',
+ *   path: { id: 1 },
+ *   headers: { 'Content-Type': 'application/json' }
+ * };
+ *
+ * const request2 = {
+ *   method: 'POST',
+ *   query: { filter: 'active' },
+ *   headers: { 'Authorization': 'Bearer token' }
+ * };
+ *
+ * const merged = mergeRequest(request1, request2);
+ * // Result: {
+ * //   method: 'POST',
+ * //   path: { id: 1 },
+ * //   query: { filter: 'active' },
+ * //   headers: {
+ * //     'Content-Type': 'application/json',
+ * //     'Authorization': 'Bearer token'
+ * //   }
+ * // }
+ * ```
+ */
+export function mergeRequest(
+  first: FetcherRequest,
+  second: FetcherRequest,
+): FetcherRequest {
+  // If first request is empty, return second request
+  if (Object.keys(first).length === 0) {
+    return second;
+  }
+
+  // If second request is empty, return first request
+  if (Object.keys(second).length === 0) {
+    return first;
+  }
+
+  // Merge nested objects
+  const path = {
+    ...first.path,
+    ...second.path,
+  };
+
+  const query = {
+    ...first.query,
+    ...second.query,
+  };
+
+  const headers = {
+    ...first.headers,
+    ...second.headers,
+  };
+
+  // For primitive values, second takes precedence
+  const method = second.method ?? first.method;
+  const body = second.body ?? first.body;
+  const timeout = second.timeout ?? first.timeout;
+  const signal = second.signal ?? first.signal;
+
+  // Return merged request with second object's top-level properties taking precedence
+  return {
+    ...first,
+    ...second,
+    method,
+    path,
+    query,
+    headers,
+    body,
+    timeout,
+    signal,
+  };
+}

--- a/packages/fetcher/test/mergeRequest.test.ts
+++ b/packages/fetcher/test/mergeRequest.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import { mergeRequest } from '../src';
+import { HttpMethod } from '../src';
+
+describe('mergeRequest', () => {
+  it('should return second request when first request is empty', () => {
+    const first = {};
+    const second = {
+      method: HttpMethod.POST,
+      path: { id: 1 },
+      query: { filter: 'active' },
+      headers: { 'Content-Type': 'application/json' },
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result).toEqual(second);
+  });
+
+  it('should return first request when second request is empty', () => {
+    const first = {
+      method: HttpMethod.GET,
+      path: { userId: 123 },
+      headers: { Authorization: 'Bearer token' },
+    };
+    const second = {};
+
+    const result = mergeRequest(first, second);
+    expect(result).toEqual(first);
+  });
+
+  it('should merge path parameters', () => {
+    const first = {
+      path: { id: 1 },
+    };
+    const second = {
+      path: { action: 'edit' },
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result.path).toEqual({ id: 1, action: 'edit' });
+  });
+
+  it('should merge query parameters', () => {
+    const first = {
+      query: { page: 1, limit: 10 },
+    };
+    const second = {
+      query: { filter: 'active', sort: 'name' },
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result.query).toEqual({
+      page: 1,
+      limit: 10,
+      filter: 'active',
+      sort: 'name',
+    });
+  });
+
+  it('should merge headers', () => {
+    const first = {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    };
+    const second = {
+      headers: { Authorization: 'Bearer token', 'X-Custom': 'value' },
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result.headers).toEqual({
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: 'Bearer token',
+      'X-Custom': 'value',
+    });
+  });
+
+  it('should give second request precedence for primitive values', () => {
+    const first = {
+      method: HttpMethod.GET,
+      body: { name: 'John' },
+      timeout: 5000,
+    };
+    const second = {
+      method: HttpMethod.POST,
+      body: { name: 'Jane' },
+      timeout: 3000,
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result.method).toBe(HttpMethod.POST);
+    expect(result.body).toEqual({ name: 'Jane' });
+    expect(result.timeout).toBe(3000);
+  });
+
+  it('should handle undefined values correctly', () => {
+    const first = {
+      method: HttpMethod.GET,
+      body: undefined,
+      timeout: undefined,
+    };
+    const second = {
+      method: undefined,
+      body: { name: 'John' },
+      timeout: 5000,
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result.method).toBe(HttpMethod.GET);
+    expect(result.body).toEqual({ name: 'John' });
+    expect(result.timeout).toBe(5000);
+  });
+
+  it('should handle null body values correctly', () => {
+    const first = {
+      body: null,
+      timeout: 1000,
+    };
+    const second = {
+      body: { name: 'John' },
+      timeout: undefined,
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result.body).toEqual({ name: 'John' });
+    expect(result.timeout).toBe(1000);
+  });
+
+  it('should merge complex requests correctly', () => {
+    const first = {
+      method: HttpMethod.GET,
+      path: { userId: 123 },
+      query: { page: 1 },
+      headers: { Authorization: 'Bearer old-token' },
+      timeout: 5000,
+    };
+
+    const second = {
+      method: HttpMethod.POST,
+      path: { postId: 456 },
+      query: { filter: 'active' },
+      headers: { 'Content-Type': 'application/json' },
+      body: { title: 'New Post' },
+      timeout: 3000,
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result).toEqual({
+      method: HttpMethod.POST,
+      path: { userId: 123, postId: 456 },
+      query: { page: 1, filter: 'active' },
+      headers: {
+        Authorization: 'Bearer old-token',
+        'Content-Type': 'application/json',
+      },
+      body: { title: 'New Post' },
+      timeout: 3000,
+    });
+  });
+
+  it('should preserve signal from second request', () => {
+    const abortController = new AbortController();
+    const first = {
+      signal: null,
+    };
+    const second = {
+      signal: abortController.signal,
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result.signal).toBe(abortController.signal);
+  });
+
+  it('should handle empty objects correctly', () => {
+    const first = {
+      path: {},
+      query: {},
+      headers: {},
+    };
+    const second = {
+      path: { id: 1 },
+      query: { filter: 'active' },
+      headers: { 'Content-Type': 'application/json' },
+    };
+
+    const result = mergeRequest(first, second);
+    expect(result.path).toEqual({ id: 1 });
+    expect(result.query).toEqual({ filter: 'active' });
+    expect(result.headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+});


### PR DESCRIPTION
- Add @request() decorator to pass a complete FetcherRequest object
- Implement advanced request merging strategy:
  - Recursive merge of nested objects (path, query, headers)
  - Override of primitive values (method, body, timeout, signal)
  - Graceful handling of empty objects
- Update documentation and add new test cases