### PR TITLE
test(decorator): add robustness tests for function parameter parsing

### DIFF
--- a/packages/decorator/test/reflection.branch.test.ts
+++ b/packages/decorator/test/reflection.branch.test.ts
@@ -101,6 +101,28 @@ describe('reflection - branch coverage', () => {
     expect(getParameterNames(malformedFunc)).toEqual([]);
   });
 
+  it('should handle arrow function with unmatched parentheses', () => {
+    // Create an arrow function that starts with ( but has no closing parenthesis
+    const unmatchedArrowFunc = function() {
+    };
+    // Override toString to return arrow function with unmatched parentheses
+    unmatchedArrowFunc.toString = () => '(a: string, b: number';
+
+    // Should return empty array instead of throwing
+    expect(getParameterNames(unmatchedArrowFunc)).toEqual([]);
+  });
+
+  it('should handle regular function with no opening parenthesis', () => {
+    // Create a function with no opening parenthesis
+    const noParenFunc = function() {
+    };
+    // Override toString to return function with no opening parenthesis
+    noParenFunc.toString = () => 'function test';
+
+    // Should return empty array instead of throwing
+    expect(getParameterNames(noParenFunc)).toEqual([]);
+  });
+
   it('should handle function with unmatched parentheses', () => {
     // Create a function that would cause unmatched parentheses
     const unmatchedFunc = function () {};


### PR DESCRIPTION
- Add test cases for arrow function with unmatched parentheses and regular function with no opening parenthesis
- Ensure that the `getParameterNames` function can handle these edge cases without throwing errors