### PR TITLE
feat(wow): add command header constants for interoperability 

### DIFF
--- a/packages/wow/src/command/commandHeaders.ts
+++ b/packages/wow/src/command/commandHeaders.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Command Header Constants
+ *
+ * Defines standard HTTP header constants used in command processing within the Wow framework.
+ * These headers are used to pass metadata and control information between services.
+ *
+ * @example
+ * ```typescript
+ * // Using header constants in a request
+ * const request = {
+ *   method: 'POST',
+ *   headers: {
+ *     [CommandHeaders.TENANT_ID]: 'tenant-123',
+ *     [CommandHeaders.AGGREGATE_ID]: 'aggregate-456',
+ *     [CommandHeaders.REQUEST_ID]: 'request-789'
+ *   },
+ *   body: JSON.stringify(command)
+ * };
+ * ```
+ */
+export class CommandHeaders {
+  /**
+   * Prefix for all command-related headers
+   */
+  static readonly COMMAND_HEADERS_PREFIX = 'Command-';
+
+  /**
+   * Tenant identifier header
+   * Used to identify the tenant context for the command
+   */
+  static readonly TENANT_ID = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Tenant-Id`;
+
+  /**
+   * Owner identifier header
+   * Used to identify the owner context for the command
+   */
+  static readonly OWNER_ID = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Owner-Id`;
+
+  /**
+   * Aggregate identifier header
+   * Used to identify the aggregate root for the command
+   */
+  static readonly AGGREGATE_ID = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Aggregate-Id`;
+
+  /**
+   * Aggregate version header
+   * Used to specify the expected version of the aggregate root
+   */
+  static readonly AGGREGATE_VERSION = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Aggregate-Version`;
+
+  /**
+   * Wait prefix for wait-related headers
+   */
+  static readonly WAIT_PREFIX = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Wait-`;
+
+  /**
+   * Wait timeout header
+   * Specifies the maximum time to wait for command processing
+   */
+  static readonly WAIT_TIME_OUT = `${CommandHeaders.WAIT_PREFIX}Timeout`;
+
+  // region Wait Stage
+  /**
+   * Wait stage header
+   * Specifies the processing stage to wait for
+   */
+  static readonly WAIT_STAGE = `${CommandHeaders.WAIT_PREFIX}Stage`;
+
+  /**
+   * Wait context header
+   * Specifies the bounded context to wait for
+   */
+  static readonly WAIT_CONTEXT = `${CommandHeaders.WAIT_PREFIX}Context`;
+
+  /**
+   * Wait processor header
+   * Specifies the processor to wait for
+   */
+  static readonly WAIT_PROCESSOR = `${CommandHeaders.WAIT_PREFIX}Processor`;
+
+  /**
+   * Wait function header
+   * Specifies the function to wait for
+   */
+  static readonly WAIT_FUNCTION = `${CommandHeaders.WAIT_PREFIX}Function`;
+  // endregion
+
+  // region Wait Chain Tail
+  /**
+   * Wait tail prefix for wait chain tail-related headers
+   */
+  static readonly WAIT_TAIL_PREFIX = `${CommandHeaders.WAIT_PREFIX}Tail-`;
+
+  /**
+   * Wait tail stage header
+   * Specifies the tail processing stage to wait for
+   */
+  static readonly WAIT_TAIL_STAGE = `${CommandHeaders.WAIT_TAIL_PREFIX}Stage`;
+
+  /**
+   * Wait tail context header
+   * Specifies the tail bounded context to wait for
+   */
+  static readonly WAIT_TAIL_CONTEXT = `${CommandHeaders.WAIT_TAIL_PREFIX}Context`;
+
+  /**
+   * Wait tail processor header
+   * Specifies the tail processor to wait for
+   */
+  static readonly WAIT_TAIL_PROCESSOR = `${CommandHeaders.WAIT_TAIL_PREFIX}Processor`;
+
+  /**
+   * Wait tail function header
+   * Specifies the tail function to wait for
+   */
+  static readonly WAIT_TAIL_FUNCTION = `${CommandHeaders.WAIT_TAIL_PREFIX}Function`;
+  // endregion
+
+  /**
+   * Request identifier header
+   * Used to track the request ID for correlation
+   */
+  static readonly REQUEST_ID = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Request-Id`;
+
+  /**
+   * Local first header
+   * Indicates whether to prefer local processing
+   */
+  static readonly LOCAL_FIRST = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Local-First`;
+
+  /**
+   * Command aggregate context header
+   * Specifies the bounded context of the aggregate
+   */
+  static readonly COMMAND_AGGREGATE_CONTEXT = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Aggregate-Context`;
+
+  /**
+   * Command aggregate name header
+   * Specifies the name of the aggregate
+   */
+  static readonly COMMAND_AGGREGATE_NAME = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Aggregate-Name`;
+
+  /**
+   * Command type header
+   * Specifies the type of the command
+   */
+  static readonly COMMAND_TYPE = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Type`;
+
+  /**
+   * Command header prefix for custom headers
+   * Used to prefix custom command headers
+   */
+  static readonly COMMAND_HEADER_X_PREFIX = `${CommandHeaders.COMMAND_HEADERS_PREFIX}Header-`;
+}

--- a/packages/wow/src/command/index.ts
+++ b/packages/wow/src/command/index.ts
@@ -12,4 +12,5 @@
  */
 
 export * from './commandGateway';
+export * from './commandHeaders';
 export * from './types';

--- a/packages/wow/src/types/error.ts
+++ b/packages/wow/src/types/error.ts
@@ -42,7 +42,7 @@ export enum RecoverableType {
    * Represents an unknown type of recoverability for an error or operation.
    * This is used when the recoverability of an error cannot be determined or is not specified.
    */
-  UNRECOVERABLE = 'UNRECOVERABLE'
+  UNRECOVERABLE = 'UNRECOVERABLE',
 }
 
 /**
@@ -82,8 +82,99 @@ export interface ErrorInfo {
   bindingErrors?: BindingError[];
 }
 
-/**
- * A constant representing a successful operation or status.
- * This value is typically used in the context of error handling and response descriptions to indicate that an operation has been completed successfully.
- */
-export const SUCCEEDED_ERROR_CODE = 'Ok';
+export class ErrorCodes {
+  /**
+   * A constant representing a successful operation or status.
+   * This value is typically used in the context of error handling and response descriptions to indicate that an operation has been completed successfully.
+   */
+  static readonly SUCCEEDED = 'Ok';
+  static readonly SUCCEEDED_MESSAGE = '';
+
+  /**
+   * Error code for when a requested resource is not found.
+   */
+  static readonly NOT_FOUND = 'NotFound';
+
+  /**
+   * Default message for NOT_FOUND error code.
+   */
+  static readonly NOT_FOUND_MESSAGE = 'Not found resource!';
+
+  /**
+   * Error code for bad request errors.
+   */
+  static readonly BAD_REQUEST = 'BadRequest';
+
+  /**
+   * Error code for illegal argument errors.
+   */
+  static readonly ILLEGAL_ARGUMENT = 'IllegalArgument';
+
+  /**
+   * Error code for illegal state errors.
+   */
+  static readonly ILLEGAL_STATE = 'IllegalState';
+
+  /**
+   * Error code for request timeout errors.
+   */
+  static readonly REQUEST_TIMEOUT = 'RequestTimeout';
+
+  /**
+   * Error code for too many requests errors (rate limiting).
+   */
+  static readonly TOO_MANY_REQUESTS = 'TooManyRequests';
+
+  /**
+   * Error code for duplicate request ID errors.
+   */
+  static readonly DUPLICATE_REQUEST_ID = 'DuplicateRequestId';
+
+  /**
+   * Error code for command validation errors.
+   */
+  static readonly COMMAND_VALIDATION = 'CommandValidation';
+
+  /**
+   * Error code for when no command is found to rewrite.
+   */
+  static readonly REWRITE_NO_COMMAND = 'RewriteNoCommand';
+
+  /**
+   * Error code for event version conflicts.
+   */
+  static readonly EVENT_VERSION_CONFLICT = 'EventVersionConflict';
+
+  /**
+   * Error code for duplicate aggregate ID errors.
+   */
+  static readonly DUPLICATE_AGGREGATE_ID = 'DuplicateAggregateId';
+
+  /**
+   * Error code for command expected version conflicts.
+   */
+  static readonly COMMAND_EXPECT_VERSION_CONFLICT =
+    'CommandExpectVersionConflict';
+
+  /**
+   * Error code for sourcing version conflicts.
+   */
+  static readonly SOURCING_VERSION_CONFLICT = 'SourcingVersionConflict';
+
+  /**
+   * Error code for illegal access to deleted aggregate errors.
+   */
+  static readonly ILLEGAL_ACCESS_DELETED_AGGREGATE =
+    'IllegalAccessDeletedAggregate';
+
+  /**
+   * Error code for illegal access to owner aggregate errors.
+   */
+  static readonly ILLEGAL_ACCESS_OWNER_AGGREGATE =
+    'IllegalAccessOwnerAggregate';
+
+  /**
+   * Error code for internal server errors.
+   */
+  static readonly INTERNAL_SERVER_ERROR = 'InternalServerError';
+}

--- a/packages/wow/test/command/commandHeaders.test.ts
+++ b/packages/wow/test/command/commandHeaders.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { CommandHeaders } from '../../src';
+
+describe('CommandHeaders', () => {
+  it('should have correct prefix', () => {
+    expect(CommandHeaders.COMMAND_HEADERS_PREFIX).toBe('Command-');
+  });
+
+  it('should have correct tenant id header', () => {
+    expect(CommandHeaders.TENANT_ID).toBe('Command-Tenant-Id');
+  });
+
+  it('should have correct owner id header', () => {
+    expect(CommandHeaders.OWNER_ID).toBe('Command-Owner-Id');
+  });
+
+  it('should have correct aggregate id header', () => {
+    expect(CommandHeaders.AGGREGATE_ID).toBe('Command-Aggregate-Id');
+  });
+
+  it('should have correct aggregate version header', () => {
+    expect(CommandHeaders.AGGREGATE_VERSION).toBe('Command-Aggregate-Version');
+  });
+
+  it('should have correct wait prefix', () => {
+    expect(CommandHeaders.WAIT_PREFIX).toBe('Command-Wait-');
+  });
+
+  it('should have correct wait timeout header', () => {
+    expect(CommandHeaders.WAIT_TIME_OUT).toBe('Command-Wait-Timeout');
+  });
+
+  it('should have correct wait stage header', () => {
+    expect(CommandHeaders.WAIT_STAGE).toBe('Command-Wait-Stage');
+  });
+
+  it('should have correct wait context header', () => {
+    expect(CommandHeaders.WAIT_CONTEXT).toBe('Command-Wait-Context');
+  });
+
+  it('should have correct wait processor header', () => {
+    expect(CommandHeaders.WAIT_PROCESSOR).toBe('Command-Wait-Processor');
+  });
+
+  it('should have correct wait function header', () => {
+    expect(CommandHeaders.WAIT_FUNCTION).toBe('Command-Wait-Function');
+  });
+
+  it('should have correct wait tail prefix', () => {
+    expect(CommandHeaders.WAIT_TAIL_PREFIX).toBe('Command-Wait-Tail-');
+  });
+
+  it('should have correct wait tail stage header', () => {
+    expect(CommandHeaders.WAIT_TAIL_STAGE).toBe('Command-Wait-Tail-Stage');
+  });
+
+  it('should have correct wait tail context header', () => {
+    expect(CommandHeaders.WAIT_TAIL_CONTEXT).toBe('Command-Wait-Tail-Context');
+  });
+
+  it('should have correct wait tail processor header', () => {
+    expect(CommandHeaders.WAIT_TAIL_PROCESSOR).toBe(
+      'Command-Wait-Tail-Processor',
+    );
+  });
+
+  it('should have correct wait tail function header', () => {
+    expect(CommandHeaders.WAIT_TAIL_FUNCTION).toBe(
+      'Command-Wait-Tail-Function',
+    );
+  });
+
+  it('should have correct request id header', () => {
+    expect(CommandHeaders.REQUEST_ID).toBe('Command-Request-Id');
+  });
+
+  it('should have correct local first header', () => {
+    expect(CommandHeaders.LOCAL_FIRST).toBe('Command-Local-First');
+  });
+
+  it('should have correct command aggregate context header', () => {
+    expect(CommandHeaders.COMMAND_AGGREGATE_CONTEXT).toBe(
+      'Command-Aggregate-Context',
+    );
+  });
+
+  it('should have correct command aggregate name header', () => {
+    expect(CommandHeaders.COMMAND_AGGREGATE_NAME).toBe(
+      'Command-Aggregate-Name',
+    );
+  });
+
+  it('should have correct command type header', () => {
+    expect(CommandHeaders.COMMAND_TYPE).toBe('Command-Type');
+  });
+
+  it('should have correct command header x prefix', () => {
+    expect(CommandHeaders.COMMAND_HEADER_X_PREFIX).toBe('Command-Header-');
+  });
+});

--- a/packages/wow/test/query/snapshot.test.ts
+++ b/packages/wow/test/query/snapshot.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { MaterializedSnapshot, SmallMaterializedSnapshot } from '../../src/query/snapshot';
+
+interface TestState {
+  name: string;
+  value: number;
+}
+
+describe('MaterializedSnapshot', () => {
+  it('should create a materialized snapshot with all required properties', () => {
+    const snapshot: MaterializedSnapshot<TestState> = {
+      contextName: 'test-context',
+      aggregateName: 'test-aggregate',
+      tenantId: 'tenant-1',
+      ownerId: 'owner-1',
+      version: 1,
+      eventId: 'event-1',
+      firstOperator: 'operator-1',
+      operator: 'operator-2',
+      firstEventTime: Date.now(),
+      eventTime: Date.now(),
+      snapshotTime: Date.now(),
+      deleted: false,
+      state: {
+        name: 'test',
+        value: 42,
+      },
+    };
+
+    expect(snapshot).toBeDefined();
+    expect(snapshot.contextName).toBe('test-context');
+    expect(snapshot.aggregateName).toBe('test-aggregate');
+    expect(snapshot.tenantId).toBe('tenant-1');
+    expect(snapshot.ownerId).toBe('owner-1');
+    expect(snapshot.version).toBe(1);
+    expect(snapshot.eventId).toBe('event-1');
+    expect(snapshot.firstOperator).toBe('operator-1');
+    expect(snapshot.operator).toBe('operator-2');
+    expect(snapshot.state.name).toBe('test');
+    expect(snapshot.state.value).toBe(42);
+  });
+});
+
+describe('SmallMaterializedSnapshot', () => {
+  it('should create a small materialized snapshot with required properties', () => {
+    const smallSnapshot: SmallMaterializedSnapshot<TestState> = {
+      contextName: 'test-context',
+      aggregateName: 'test-aggregate',
+      version: 1,
+      firstEventTime: Date.now(),
+      state: {
+        name: 'test',
+        value: 42,
+      },
+    };
+
+    expect(smallSnapshot).toBeDefined();
+    expect(smallSnapshot.contextName).toBe('test-context');
+    expect(smallSnapshot.aggregateName).toBe('test-aggregate');
+    expect(smallSnapshot.version).toBe(1);
+    expect(smallSnapshot.state.name).toBe('test');
+    expect(smallSnapshot.state.value).toBe(42);
+  });
+});

--- a/packages/wow/test/types/common.test.ts
+++ b/packages/wow/test/types/common.test.ts
@@ -12,10 +12,24 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { Identifier, Version } from '../../src/types';
 
-describe('Common Types', () => {
-  it('should compile without errors', () => {
-    // This test ensures that the common types can be imported without compilation errors
-    expect(true).toBe(true);
+describe('Identifier', () => {
+  it('should have an id property', () => {
+    const identifier: Identifier = {
+      id: 'test-id',
+    };
+
+    expect(identifier.id).toBe('test-id');
+  });
+});
+
+describe('Version', () => {
+  it('should have a version property', () => {
+    const version: Version = {
+      version: 1,
+    };
+
+    expect(version.version).toBe(1);
   });
 });

--- a/packages/wow/test/types/error.test.ts
+++ b/packages/wow/test/types/error.test.ts
@@ -12,25 +12,98 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { RecoverableType } from '../../src';
+import { ErrorCodes, RecoverableType } from '../../src/types/error';
 
-describe('Error Types', () => {
-  describe('RecoverableType', () => {
-    it('should have all recoverable types', () => {
-      expect(RecoverableType.RECOVERABLE).toBe('RECOVERABLE');
-      expect(RecoverableType.UNKNOWN).toBe('UNKNOWN');
-      expect(RecoverableType.UNRECOVERABLE).toBe('UNRECOVERABLE');
-    });
-
-    it('should have unique values for all types', () => {
-      const typeValues = Object.values(RecoverableType);
-      const uniqueValues = [...new Set(typeValues)];
-      expect(typeValues.length).toBe(uniqueValues.length);
-    });
+describe('ErrorCodes', () => {
+  it('should have correct SUCCEEDED code and message', () => {
+    expect(ErrorCodes.SUCCEEDED).toBe('Ok');
+    expect(ErrorCodes.SUCCEEDED_MESSAGE).toBe('');
   });
 
-  it('should compile without errors', () => {
-    // This test ensures that the error types can be imported without compilation errors
-    expect(true).toBe(true);
+  it('should have correct NOT_FOUND code and message', () => {
+    expect(ErrorCodes.NOT_FOUND).toBe('NotFound');
+    expect(ErrorCodes.NOT_FOUND_MESSAGE).toBe('Not found resource!');
+  });
+
+  it('should have correct BAD_REQUEST code', () => {
+    expect(ErrorCodes.BAD_REQUEST).toBe('BadRequest');
+  });
+
+  it('should have correct ILLEGAL_ARGUMENT code', () => {
+    expect(ErrorCodes.ILLEGAL_ARGUMENT).toBe('IllegalArgument');
+  });
+
+  it('should have correct ILLEGAL_STATE code', () => {
+    expect(ErrorCodes.ILLEGAL_STATE).toBe('IllegalState');
+  });
+
+  it('should have correct REQUEST_TIMEOUT code', () => {
+    expect(ErrorCodes.REQUEST_TIMEOUT).toBe('RequestTimeout');
+  });
+
+  it('should have correct TOO_MANY_REQUESTS code', () => {
+    expect(ErrorCodes.TOO_MANY_REQUESTS).toBe('TooManyRequests');
+  });
+
+  it('should have correct DUPLICATE_REQUEST_ID code', () => {
+    expect(ErrorCodes.DUPLICATE_REQUEST_ID).toBe('DuplicateRequestId');
+  });
+
+  it('should have correct COMMAND_VALIDATION code', () => {
+    expect(ErrorCodes.COMMAND_VALIDATION).toBe('CommandValidation');
+  });
+
+  it('should have correct REWRITE_NO_COMMAND code', () => {
+    expect(ErrorCodes.REWRITE_NO_COMMAND).toBe('RewriteNoCommand');
+  });
+
+  it('should have correct EVENT_VERSION_CONFLICT code', () => {
+    expect(ErrorCodes.EVENT_VERSION_CONFLICT).toBe('EventVersionConflict');
+  });
+
+  it('should have correct DUPLICATE_AGGREGATE_ID code', () => {
+    expect(ErrorCodes.DUPLICATE_AGGREGATE_ID).toBe('DuplicateAggregateId');
+  });
+
+  it('should have correct COMMAND_EXPECT_VERSION_CONFLICT code', () => {
+    expect(ErrorCodes.COMMAND_EXPECT_VERSION_CONFLICT).toBe(
+      'CommandExpectVersionConflict',
+    );
+  });
+
+  it('should have correct SOURCING_VERSION_CONFLICT code', () => {
+    expect(ErrorCodes.SOURCING_VERSION_CONFLICT).toBe(
+      'SourcingVersionConflict',
+    );
+  });
+
+  it('should have correct ILLEGAL_ACCESS_DELETED_AGGREGATE code', () => {
+    expect(ErrorCodes.ILLEGAL_ACCESS_DELETED_AGGREGATE).toBe(
+      'IllegalAccessDeletedAggregate',
+    );
+  });
+
+  it('should have correct ILLEGAL_ACCESS_OWNER_AGGREGATE code', () => {
+    expect(ErrorCodes.ILLEGAL_ACCESS_OWNER_AGGREGATE).toBe(
+      'IllegalAccessOwnerAggregate',
+    );
+  });
+
+  it('should have correct INTERNAL_SERVER_ERROR code', () => {
+    expect(ErrorCodes.INTERNAL_SERVER_ERROR).toBe('InternalServerError');
+  });
+});
+
+describe('RecoverableType', () => {
+  it('should have correct RECOVERABLE value', () => {
+    expect(RecoverableType.RECOVERABLE).toBe('RECOVERABLE');
+  });
+
+  it('should have correct UNKNOWN value', () => {
+    expect(RecoverableType.UNKNOWN).toBe('UNKNOWN');
+  });
+
+  it('should have correct UNRECOVERABLE value', () => {
+    expect(RecoverableType.UNRECOVERABLE).toBe('UNRECOVERABLE');
   });
 });

--- a/packages/wow/test/types/naming.test.ts
+++ b/packages/wow/test/types/naming.test.ts
@@ -12,10 +12,24 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { Named, NamedBoundedContext } from '../../src/types';
 
-describe('Naming Types', () => {
-  it('should compile without errors', () => {
-    // This test ensures that the naming types can be imported without compilation errors
-    expect(true).toBe(true);
+describe('NamedBoundedContext', () => {
+  it('should have a contextName property', () => {
+    const namedContext: NamedBoundedContext = {
+      contextName: 'test-context',
+    };
+
+    expect(namedContext.contextName).toBe('test-context');
+  });
+});
+
+describe('Named', () => {
+  it('should have a name property', () => {
+    const named: Named = {
+      name: 'test-name',
+    };
+
+    expect(named.name).toBe('test-name');
   });
 });


### PR DESCRIPTION
- Introduce CommandHeaders class with standard HTTP header constants
- Cover tenant, owner, aggregate IDs and versions
- Include wait-related headers for command processing stages
- Add request ID and local processing preference headers
- Specify aggregate context, name, and command type headers
- Provide prefix for custom command headers