### PR TITLE
refactor(fetcher): adjust interceptor orders for better extensibility

### DIFF
--- a/packages/cosec/src/cosecRequestInterceptor.ts
+++ b/packages/cosec/src/cosecRequestInterceptor.ts
@@ -24,9 +24,24 @@ import { idGenerator } from './idGenerator';
  * - Authorization: Bearer token
  * - CoSec-Request-Id: Unique request identifier for each request
  */
+/**
+ * CoSec Request Interceptor
+ *
+ * Automatically adds CoSec authentication headers to requests:
+ * - CoSec-Device-Id: Device identifier (stored in localStorage or generated)
+ * - CoSec-App-Id: Application identifier
+ * - Authorization: Bearer token
+ * - CoSec-Request-Id: Unique request identifier for each request
+ *
+ * @remarks
+ * This interceptor runs after the basic request processing interceptors but before
+ * the actual HTTP request is made. The order is set to Number.MIN_SAFE_INTEGER + 1000
+ * to allow for other authentication or preprocessing interceptors to run earlier
+ * while ensuring it runs before FetchInterceptor.
+ */
 export class CoSecRequestInterceptor implements Interceptor {
   name = 'CoSecRequestInterceptor';
-  order = Number.MIN_SAFE_INTEGER;
+  order = Number.MIN_SAFE_INTEGER + 1000;
   private options: CoSecOptions;
 
   constructor(options: CoSecOptions) {

--- a/packages/cosec/src/cosecResponseInterceptor.ts
+++ b/packages/cosec/src/cosecResponseInterceptor.ts
@@ -19,9 +19,21 @@ import { FetchExchange, Interceptor } from '@ahoo-wang/fetcher';
  *
  * Handles automatic token refresh based on response codes
  */
+/**
+ * CoSec Response Interceptor
+ *
+ * Handles automatic token refresh based on response codes
+ *
+ * @remarks
+ * This interceptor runs near the end of the response processing chain, just before
+ * the final response is returned. The order is set to Number.MAX_SAFE_INTEGER - 100
+ * to ensure it runs after most other response interceptors but still allows for
+ * final processing interceptors to run afterward. This order aligns with other
+ * response enhancement interceptors like EventStreamInterceptor.
+ */
 export class CoSecResponseInterceptor implements Interceptor {
   name = 'CoSecResponseInterceptor';
-  order = Number.MAX_SAFE_INTEGER;
+  order = Number.MAX_SAFE_INTEGER - 100;
   private options: CoSecOptions;
 
   constructor(options: CoSecOptions) {

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-decorator",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "TypeScript decorators for clean API service definitions with Fetcher HTTP client",
   "keywords": [
     "fetch",

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventstream",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Server-Sent Events (SSE) support for Fetcher HTTP client",
   "keywords": [
     "fetch",

--- a/packages/eventstream/src/eventStreamInterceptor.ts
+++ b/packages/eventstream/src/eventStreamInterceptor.ts
@@ -12,16 +12,24 @@
  */
 
 import { toServerSentEventStream } from './eventStreamConverter';
-import {
-  ContentTypeHeader,
-  ContentTypeValues,
-  FetchExchange,
-  Interceptor,
-} from '@ahoo-wang/fetcher';
+import { ContentTypeHeader, ContentTypeValues, FetchExchange, Interceptor } from '@ahoo-wang/fetcher';
 
+/**
+ * EventStreamInterceptor Class
+ *
+ * Interceptor responsible for enhancing Response objects with event stream capabilities
+ * when the response content type indicates a server-sent event stream.
+ *
+ * @remarks
+ * This interceptor runs after the HTTP response is received but before the response
+ * is returned to the caller. The order is set to Number.MAX_SAFE_INTEGER - 100 to
+ * ensure it runs after all standard response processing is complete, as it adds
+ * specialized functionality to the response object. This order allows other
+ * response interceptors to run after it if needed.
+ */
 export class EventStreamInterceptor implements Interceptor {
   name = 'EventStreamInterceptor';
-  order = Number.MAX_SAFE_INTEGER;
+  order = Number.MAX_SAFE_INTEGER - 100;
 
   intercept(exchange: FetchExchange): FetchExchange {
     // Check if the response is an event stream

--- a/packages/fetcher/README.md
+++ b/packages/fetcher/README.md
@@ -121,9 +121,9 @@ responses, and errors at different stages of the HTTP request lifecycle.
 
 Fetcher comes with several built-in interceptors that are automatically registered:
 
-1. **UrlResolveInterceptor**: Resolves URLs with path and query parameters (order: Number.MIN_SAFE_INTEGER)
-2. **RequestBodyInterceptor**: Converts object bodies to JSON strings (order: Number.MIN_SAFE_INTEGER + 100)
-3. **FetchInterceptor**: Executes the actual HTTP request (order: Number.MAX_SAFE_INTEGER)
+1. **UrlResolveInterceptor**: Resolves URLs with path and query parameters (order: Number.MIN_SAFE_INTEGER + 100)
+2. **RequestBodyInterceptor**: Converts object bodies to JSON strings (order: Number.MIN_SAFE_INTEGER + 200)
+3. **FetchInterceptor**: Executes the actual HTTP request (order: Number.MAX_SAFE_INTEGER - 100)
 
 ### Using Interceptors
 

--- a/packages/fetcher/README.zh-CN.md
+++ b/packages/fetcher/README.zh-CN.md
@@ -119,9 +119,9 @@ Fetcher 中的拦截器系统遵循中间件模式，允许您在 HTTP 请求生
 
 Fetcher 自带几个内置拦截器，它们会自动注册：
 
-1. **UrlResolveInterceptor**：解析带路径和查询参数的 URL（顺序：Number.MIN_SAFE_INTEGER）
-2. **RequestBodyInterceptor**：将对象体转换为 JSON 字符串（顺序：Number.MIN_SAFE_INTEGER + 100）
-3. **FetchInterceptor**：执行实际的 HTTP 请求（顺序：Number.MAX_SAFE_INTEGER）
+1. **UrlResolveInterceptor**：解析带路径和查询参数的 URL（顺序：Number.MIN_SAFE_INTEGER + 100）
+2. **RequestBodyInterceptor**：将对象体转换为 JSON 字符串（顺序：Number.MIN_SAFE_INTEGER + 200）
+3. **FetchInterceptor**：执行实际的 HTTP 请求（顺序：Number.MAX_SAFE_INTEGER - 100）
 
 ### 使用拦截器
 

--- a/packages/fetcher/src/fetchInterceptor.ts
+++ b/packages/fetcher/src/fetchInterceptor.ts
@@ -39,14 +39,16 @@ export class FetchInterceptor implements Interceptor {
   name = 'FetchInterceptor';
 
   /**
-   * Interceptor execution order, set to maximum safe integer to ensure last execution
+   * Interceptor execution order, set to near maximum safe integer to ensure last execution
    *
    * @remarks
    * Since this is the interceptor that actually executes HTTP requests, it should
    * execute after all other request interceptors, so its order is set to
-   * Number.MAX_SAFE_INTEGER
+   * Number.MAX_SAFE_INTEGER - 100. This ensures that all request preprocessing is
+   * completed before the actual network request is made, while still allowing
+   * other interceptors to run after it if needed.
    */
-  order = Number.MAX_SAFE_INTEGER;
+  order = Number.MAX_SAFE_INTEGER - 100;
 
   /**
    * Intercept and process HTTP requests

--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -39,10 +39,11 @@ export class RequestBodyInterceptor implements Interceptor {
    * @remarks
    * This interceptor should run after URL resolution (UrlResolveInterceptor) but before
    * the actual HTTP request is made (FetchInterceptor). The order is set to
-   * Number.MIN_SAFE_INTEGER + 100 to ensure it executes in the correct position
-   * in the interceptor chain.
+   * Number.MIN_SAFE_INTEGER + 200 to ensure it executes in the correct position
+   * in the interceptor chain, allowing for other interceptors to run between URL resolution
+   * and request body processing.
    */
-  order = Number.MIN_SAFE_INTEGER + 100;
+  order = Number.MIN_SAFE_INTEGER + 200;
 
   /**
    * Attempts to convert request body to a valid fetch API body type

--- a/packages/fetcher/src/urlResolveInterceptor.ts
+++ b/packages/fetcher/src/urlResolveInterceptor.ts
@@ -41,6 +41,12 @@ export class UrlResolveInterceptor implements Interceptor {
 
   /**
    * The order of this interceptor (executed first)
+   *
+   * @remarks
+   * This interceptor should run first in the request interceptor chain to ensure
+   * URL resolution happens before any other request processing. The order is set to
+   * Number.MIN_SAFE_INTEGER + 100 to allow for other interceptors that need to run
+   * even earlier while still maintaining a high priority.
    */
   order = Number.MIN_SAFE_INTEGER + 100;
 

--- a/packages/fetcher/test/fetcherInterceptors.test.ts
+++ b/packages/fetcher/test/fetcherInterceptors.test.ts
@@ -77,13 +77,13 @@ describe('FetcherInterceptors', () => {
 
     // Check the order of interceptors
     expect(requestInterceptors[0].name).toBe('UrlResolveInterceptor');
-    expect(requestInterceptors[0].order).toBe(Number.MIN_SAFE_INTEGER);
+    expect(requestInterceptors[0].order).toBe(Number.MIN_SAFE_INTEGER + 100);
 
     expect(requestInterceptors[1].name).toBe('RequestBodyInterceptor');
-    expect(requestInterceptors[1].order).toBe(Number.MIN_SAFE_INTEGER + 100);
+    expect(requestInterceptors[1].order).toBe(Number.MIN_SAFE_INTEGER + 200);
 
     expect(requestInterceptors[2].name).toBe('FetchInterceptor');
-    expect(requestInterceptors[2].order).toBe(Number.MAX_SAFE_INTEGER);
+    expect(requestInterceptors[2].order).toBe(Number.MAX_SAFE_INTEGER - 100);
   });
 
   it('should start with empty response and error interceptors', () => {

--- a/packages/fetcher/test/requestBodyInterceptor.test.ts
+++ b/packages/fetcher/test/requestBodyInterceptor.test.ts
@@ -21,7 +21,7 @@ describe('RequestBodyInterceptor', () => {
 
   it('should have correct name and order', () => {
     expect(interceptor.name).toBe('RequestBodyInterceptor');
-    expect(interceptor.order).toBe(Number.MIN_SAFE_INTEGER + 100);
+    expect(interceptor.order).toBe(Number.MIN_SAFE_INTEGER + 200);
   });
 
   it('should not modify request without body', () => {

--- a/packages/fetcher/test/urlResolveInterceptor.test.ts
+++ b/packages/fetcher/test/urlResolveInterceptor.test.ts
@@ -18,7 +18,7 @@ describe('UrlResolveInterceptor', () => {
   it('should have correct name and order', () => {
     const interceptor = new UrlResolveInterceptor();
     expect(interceptor.name).toBe('UrlResolveInterceptor');
-    expect(interceptor.order).toBe(Number.MIN_SAFE_INTEGER);
+    expect(interceptor.order).toBe(Number.MIN_SAFE_INTEGER + 100);
   });
 
   it('should resolve URL with path and query parameters', () => {


### PR DESCRIPTION
- Update interceptor orders to allow more flexibility for custom interceptors
- CoSecRequestInterceptor: Number.MIN_SAFE_INTEGER + 1000
- CoSecResponseInterceptor: Number.MAX_SAFE_INTEGER -100
- EventStreamInterceptor: Number.MAX_SAFE_INTEGER - 100
- FetchInterceptor: Number.MAX_SAFE_INTEGER - 100
- RequestBodyInterceptor: Number.MIN_SAFE_INTEGER + 200
- UrlResolveInterceptor: Number.MIN_SAFE_INTEGER + 100