### PR TITLE
refactor(fetcher): move RequestField enum to fetchExchange.ts

### DIFF
--- a/packages/fetcher/src/fetchExchange.ts
+++ b/packages/fetcher/src/fetchExchange.ts
@@ -15,6 +15,10 @@ import { Fetcher } from './fetcher';
 import { HeadersCapable } from './types';
 import { TimeoutCapable } from './timeout';
 
+export enum RequestField {
+  METHOD = 'method',
+  BODY = 'body',
+}
 
 /**
  * Fetcher request configuration interface
@@ -104,6 +108,7 @@ export interface FetcherRequest
    */
   body?: BodyInit | Record<string, any> | string | null;
 }
+
 
 /**
  * FetchExchange Interface

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -13,16 +13,9 @@
 
 import { UrlBuilder, UrlBuilderCapable } from './urlBuilder';
 import { resolveTimeout, TimeoutCapable } from './timeout';
-import {
-  BaseURLCapable,
-  ContentTypeHeader,
-  ContentTypeValues,
-  HeadersCapable,
-  HttpMethod,
-  RequestField,
-} from './types';
+import { BaseURLCapable, ContentTypeHeader, ContentTypeValues, HeadersCapable, HttpMethod } from './types';
 import { FetcherInterceptors } from './interceptor';
-import { FetcherRequest, FetchExchange } from './fetchExchange';
+import { FetcherRequest, FetchExchange, RequestField } from './fetchExchange';
 
 /**
  * Fetcher configuration options interface

--- a/packages/fetcher/src/types.ts
+++ b/packages/fetcher/src/types.ts
@@ -39,10 +39,6 @@ export enum HttpMethod {
   OPTIONS = 'OPTIONS',
 }
 
-export enum RequestField {
-  METHOD = 'method',
-  BODY = 'body',
-}
 
 export const ContentTypeHeader = 'Content-Type';
 


### PR DESCRIPTION
- Move RequestField enum from types.ts to fetchExchange.ts
- Update import in fetcher.ts to reflect the new location of RequestField
- This change organizes the code better, placing the RequestField enum where it's primarily used