### PR TITLE
refactor(fetched): rename FetcherRequest to FetchRequestInit

### DIFF
--- a/packages/cosec/src/cosecRequestInterceptor.ts
+++ b/packages/cosec/src/cosecRequestInterceptor.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { FetcherRequest, FetchExchange, Interceptor } from '@ahoo-wang/fetcher';
+import { FetchExchange, FetchRequestInit, Interceptor } from '@ahoo-wang/fetcher';
 import { CoSecHeaders, CoSecOptions } from './types';
 import { idGenerator } from './idGenerator';
 
@@ -57,7 +57,7 @@ export class CoSecRequestInterceptor implements Interceptor {
     const token = this.options.tokenStorage.get();
 
     // Clone the request to avoid modifying the original
-    const newRequest: FetcherRequest = {
+    const newRequest: FetchRequestInit = {
       ...exchange.request,
       headers: {
         ...exchange.request.headers,

--- a/packages/decorator/src/requestExecutor.ts
+++ b/packages/decorator/src/requestExecutor.ts
@@ -15,7 +15,7 @@ import {
   DEFAULT_FETCHER_NAME,
   Fetcher,
   fetcherRegistrar,
-  FetcherRequest,
+  FetchRequestInit,
   mergeRequest,
   NamedCapable,
 } from '@ahoo-wang/fetcher';
@@ -129,7 +129,7 @@ export class FunctionMetadata implements NamedCapable {
    * // }
    * ```
    */
-  resolveRequest(args: any[]): FetcherRequest {
+  resolveRequest(args: any[]): FetchRequestInit {
     const path: Record<string, any> = {};
     const query: Record<string, any> = {};
     const headers: Record<string, string> = {
@@ -138,7 +138,7 @@ export class FunctionMetadata implements NamedCapable {
     };
     let body: any = undefined;
     let signal: AbortSignal | null | undefined = undefined;
-    let parameterRequest: FetcherRequest = {};
+    let parameterRequest: FetchRequestInit = {};
     // Process parameters based on their decorators
     args.forEach((value, index) => {
       if (value instanceof AbortSignal) {
@@ -166,7 +166,7 @@ export class FunctionMetadata implements NamedCapable {
         }
       }
     });
-    const endpointRequest: FetcherRequest = {
+    const endpointRequest: FetchRequestInit = {
       method: this.endpoint.method,
       path,
       query,
@@ -230,8 +230,8 @@ export class FunctionMetadata implements NamedCapable {
    * await service.createUsers(customRequest);
    * ```
    */
-  private processRequestParam(value: any): FetcherRequest {
-    return value as FetcherRequest;
+  private processRequestParam(value: any): FetchRequestInit {
+    return value as FetchRequestInit;
   }
 
   /**

--- a/packages/fetcher/src/fetchExchange.ts
+++ b/packages/fetcher/src/fetchExchange.ts
@@ -12,103 +12,7 @@
  */
 
 import { Fetcher } from './fetcher';
-import { HeadersCapable } from './types';
-import { TimeoutCapable } from './timeout';
-
-export enum RequestField {
-  METHOD = 'method',
-  BODY = 'body',
-}
-
-/**
- * Fetcher request configuration interface
- *
- * This interface defines all the configuration options available for making HTTP requests
- * with the Fetcher client. It extends the standard RequestInit interface while adding
- * Fetcher-specific features like path parameters, query parameters, and timeout control.
- *
- * @example
- * ```typescript
- * const request: FetcherRequest = {
- *   method: 'GET',
- *   path: { id: 123 },
- *   query: { include: 'profile' },
- *   headers: { 'Authorization': 'Bearer token' },
- *   timeout: 5000
- * };
- *
- * const response = await fetcher.fetch('/users/{id}', request);
- * ```
- */
-export interface FetcherRequest
-  extends TimeoutCapable,
-    HeadersCapable,
-    Omit<RequestInit, 'body' | 'headers'> {
-  /**
-   * Path parameters for URL templating
-   *
-   * An object containing key-value pairs that will be used to replace placeholders
-   * in the URL path. Placeholders are specified using curly braces, e.g., '/users/{id}'.
-   *
-   * @example
-   * ```typescript
-   * // With URL '/users/{id}/posts/{postId}'
-   * const request = {
-   *   path: { id: 123, postId: 456 }
-   * };
-   * // Results in URL: '/users/123/posts/456'
-   * ```
-   */
-  path?: Record<string, any>;
-
-  /**
-   * Query parameters for URL query string
-   *
-   * An object containing key-value pairs that will be serialized and appended
-   * to the URL as query parameters. Arrays are serialized as multiple parameters
-   * with the same name, and objects are JSON-stringified.
-   *
-   * @example
-   * ```typescript
-   * const request = {
-   *   query: {
-   *     limit: 10,
-   *     filter: 'active',
-   *     tags: ['important', 'urgent']
-   *   }
-   * };
-   * // Results in query string: '?limit=10&filter=active&tags=important&tags=urgent'
-   * ```
-   */
-  query?: Record<string, any>;
-
-  /**
-   * Request body
-   *
-   * The body of the request. Can be a string, Blob, ArrayBuffer, FormData,
-   * URLSearchParams, or a plain object. Plain objects are automatically
-   * converted to JSON and the appropriate Content-Type header is set.
-   *
-   * @example
-   * ```typescript
-   * // Plain object (automatically converted to JSON)
-   * const request = {
-   *   method: 'POST',
-   *   body: { name: 'John', email: 'john@example.com' }
-   * };
-   *
-   * // FormData
-   * const formData = new FormData();
-   * formData.append('name', 'John');
-   * const request = {
-   *   method: 'POST',
-   *   body: formData
-   * };
-   * ```
-   */
-  body?: BodyInit | Record<string, any> | string | null;
-}
-
+import { FetchRequestInit } from './fetchRequest';
 
 /**
  * FetchExchange Interface
@@ -163,7 +67,7 @@ export interface FetchExchange {
   /**
    * The request configuration including method, headers, body, etc.
    */
-  request: FetcherRequest;
+  request: FetchRequestInit;
 
   /**
    * The response object, undefined until the request completes successfully

--- a/packages/fetcher/src/fetchRequest.ts
+++ b/packages/fetcher/src/fetchRequest.ts
@@ -23,7 +23,7 @@ import { HeadersCapable } from './types';
  *
  * @example
  * ```typescript
- * const request: FetchRequest = {
+ * const request: FetchRequestInit = {
  *   method: 'GET',
  *   path: { id: 123 },
  *   query: { include: 'profile' },

--- a/packages/fetcher/src/fetchRequest.ts
+++ b/packages/fetcher/src/fetchRequest.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TimeoutCapable } from './timeout';
+import { HeadersCapable } from './types';
+
+/**
+ * Fetcher request configuration interface
+ *
+ * This interface defines all the configuration options available for making HTTP requests
+ * with the Fetcher client. It extends the standard RequestInit interface while adding
+ * Fetcher-specific features like path parameters, query parameters, and timeout control.
+ *
+ * @example
+ * ```typescript
+ * const request: FetchRequest = {
+ *   method: 'GET',
+ *   path: { id: 123 },
+ *   query: { include: 'profile' },
+ *   headers: { 'Authorization': 'Bearer token' },
+ *   timeout: 5000
+ * };
+ *
+ * const response = await fetcher.fetch('/users/{id}', request);
+ * ```
+ */
+export interface FetchRequestInit
+  extends TimeoutCapable,
+    HeadersCapable,
+    Omit<RequestInit, 'body' | 'headers'> {
+  /**
+   * Path parameters for URL templating
+   *
+   * An object containing key-value pairs that will be used to replace placeholders
+   * in the URL path. Placeholders are specified using curly braces, e.g., '/users/{id}'.
+   *
+   * @example
+   * ```typescript
+   * // With URL '/users/{id}/posts/{postId}'
+   * const request = {
+   *   path: { id: 123, postId: 456 }
+   * };
+   * // Results in URL: '/users/123/posts/456'
+   * ```
+   */
+  path?: Record<string, any>;
+
+  /**
+   * Query parameters for URL query string
+   *
+   * An object containing key-value pairs that will be serialized and appended
+   * to the URL as query parameters. Arrays are serialized as multiple parameters
+   * with the same name, and objects are JSON-stringified.
+   *
+   * @example
+   * ```typescript
+   * const request = {
+   *   query: {
+   *     limit: 10,
+   *     filter: 'active',
+   *     tags: ['important', 'urgent']
+   *   }
+   * };
+   * // Results in query string: '?limit=10&filter=active&tags=important&tags=urgent'
+   * ```
+   */
+  query?: Record<string, any>;
+
+  /**
+   * Request body
+   *
+   * The body of the request. Can be a string, Blob, ArrayBuffer, FormData,
+   * URLSearchParams, or a plain object. Plain objects are automatically
+   * converted to JSON and the appropriate Content-Type header is set.
+   *
+   * @example
+   * ```typescript
+   * // Plain object (automatically converted to JSON)
+   * const request = {
+   *   method: 'POST',
+   *   body: { name: 'John', email: 'john@example.com' }
+   * };
+   *
+   * // FormData
+   * const formData = new FormData();
+   * formData.append('name', 'John');
+   * const request = {
+   *   method: 'POST',
+   *   body: formData
+   * };
+   * ```
+   */
+  body?: BodyInit | Record<string, any> | string | null;
+}

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -15,7 +15,8 @@ import { UrlBuilder, UrlBuilderCapable } from './urlBuilder';
 import { resolveTimeout, TimeoutCapable } from './timeout';
 import { BaseURLCapable, ContentTypeHeader, ContentTypeValues, HeadersCapable, HttpMethod } from './types';
 import { FetcherInterceptors } from './interceptor';
-import { FetcherRequest, FetchExchange, RequestField } from './fetchExchange';
+import { FetchExchange } from './fetchExchange';
+import { FetchRequestInit } from './fetchRequest';
 
 /**
  * Fetcher configuration options interface
@@ -72,7 +73,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    * @param request - Request options, including path parameters, query parameters, etc.
    * @returns Promise<Response> HTTP response
    */
-  async fetch(url: string, request: FetcherRequest = {}): Promise<Response> {
+  async fetch(url: string, request: FetchRequestInit = {}): Promise<Response> {
     const exchange = await this.request(url, request);
     if (!exchange.response) {
       throw new Error(`Request to ${exchange.url} failed with no response`);
@@ -91,7 +92,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    */
   async request(
     url: string,
-    request: FetcherRequest = {},
+    request: FetchRequestInit = {},
   ): Promise<FetchExchange> {
     // Merge default headers and request-level headers
     const mergedHeaders = {
@@ -99,7 +100,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
       ...(request.headers || {}),
     };
     // Merge request options
-    const fetchRequest: FetcherRequest = {
+    const fetchRequest: FetchRequestInit = {
       ...request,
       headers:
         Object.keys(mergedHeaders).length > 0 ? mergedHeaders : undefined,
@@ -161,7 +162,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
   private async methodFetch(
     method: HttpMethod,
     url: string,
-    request: FetcherRequest = {},
+    request: FetchRequestInit = {},
   ): Promise<Response> {
     return this.fetch(url, {
       ...request,
@@ -178,7 +179,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    */
   async get(
     url: string,
-    request: Omit<FetcherRequest, RequestField.METHOD | RequestField.BODY> = {},
+    request: Omit<FetchRequestInit, 'method' | 'body'> = {},
   ): Promise<Response> {
     return this.methodFetch(HttpMethod.GET, url, request);
   }
@@ -192,7 +193,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    */
   async post(
     url: string,
-    request: Omit<FetcherRequest, RequestField.METHOD> = {},
+    request: Omit<FetchRequestInit, 'method'> = {},
   ): Promise<Response> {
     return this.methodFetch(HttpMethod.POST, url, request);
   }
@@ -206,7 +207,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    */
   async put(
     url: string,
-    request: Omit<FetcherRequest, RequestField.METHOD> = {},
+    request: Omit<FetchRequestInit, 'method'> = {},
   ): Promise<Response> {
     return this.methodFetch(HttpMethod.PUT, url, request);
   }
@@ -220,7 +221,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    */
   async delete(
     url: string,
-    request: Omit<FetcherRequest, RequestField.METHOD> = {},
+    request: Omit<FetchRequestInit, 'method'> = {},
   ): Promise<Response> {
     return this.methodFetch(HttpMethod.DELETE, url, request);
   }
@@ -234,7 +235,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    */
   async patch(
     url: string,
-    request: Omit<FetcherRequest, RequestField.METHOD> = {},
+    request: Omit<FetchRequestInit, 'method'> = {},
   ): Promise<Response> {
     return this.methodFetch(HttpMethod.PATCH, url, request);
   }
@@ -248,7 +249,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    */
   async head(
     url: string,
-    request: Omit<FetcherRequest, RequestField.METHOD | RequestField.BODY> = {},
+    request: Omit<FetchRequestInit, 'method' | 'body'> = {},
   ): Promise<Response> {
     return this.methodFetch(HttpMethod.HEAD, url, request);
   }
@@ -262,7 +263,7 @@ export class Fetcher implements UrlBuilderCapable, HeadersCapable, TimeoutCapabl
    */
   async options(
     url: string,
-    request: Omit<FetcherRequest, RequestField.METHOD | RequestField.BODY> = {},
+    request: Omit<FetchRequestInit, 'method' | 'body'> = {},
   ): Promise<Response> {
     return this.methodFetch(HttpMethod.OPTIONS, url, request);
   }

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -15,6 +15,7 @@ export * from './fetcher';
 export * from './fetcherRegistrar';
 export * from './fetchExchange';
 export * from './fetchInterceptor';
+export * from './fetchRequest';
 export * from './interceptor';
 export * from './mergeRequest';
 export * from './namedFetcher';

--- a/packages/fetcher/src/mergeRequest.ts
+++ b/packages/fetcher/src/mergeRequest.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { FetcherRequest } from './fetchExchange';
+import { FetchRequestInit } from './fetchRequest';
 
 /**
  * Merges two FetcherRequest objects into one.
@@ -52,9 +52,9 @@ import { FetcherRequest } from './fetchExchange';
  * ```
  */
 export function mergeRequest(
-  first: FetcherRequest,
-  second: FetcherRequest,
-): FetcherRequest {
+  first: FetchRequestInit,
+  second: FetchRequestInit,
+): FetchRequestInit {
   // If first request is empty, return second request
   if (Object.keys(first).length === 0) {
     return second;


### PR DESCRIPTION
- Rename FetcherRequest to FetchRequestInit in multiple files
- Update related imports and usages accordingly
- Move FetchRequestInit definition to a separate file