### PR TITLE
refactor(fetcher): merge request parameters and simplify error handling 

### DIFF
--- a/packages/cosec/src/cosecRequestInterceptor.ts
+++ b/packages/cosec/src/cosecRequestInterceptor.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { FetchExchange, FetchRequestInit, Interceptor } from '@ahoo-wang/fetcher';
+import { FetchExchange, FetchRequest, Interceptor } from '@ahoo-wang/fetcher';
 import { CoSecHeaders, CoSecOptions } from './types';
 import { idGenerator } from './idGenerator';
 
@@ -57,7 +57,7 @@ export class CoSecRequestInterceptor implements Interceptor {
     const token = this.options.tokenStorage.get();
 
     // Clone the request to avoid modifying the original
-    const newRequest: FetchRequestInit = {
+    const newRequest: FetchRequest = {
       ...exchange.request,
       headers: {
         ...exchange.request.headers,

--- a/packages/cosec/src/cosecResponseInterceptor.ts
+++ b/packages/cosec/src/cosecResponseInterceptor.ts
@@ -62,7 +62,7 @@ export class CoSecResponseInterceptor implements Interceptor {
     try {
       const newToken = await this.options.tokenRefresher.refresh(currentToken);
       this.options.tokenStorage.set(newToken);
-      return exchange.fetcher.request(exchange.url, exchange.request);
+      return exchange.fetcher.request(exchange.request);
     } catch (error) {
       // If token refresh fails, clear stored tokens and re-throw the error
       this.options.tokenStorage.clear();

--- a/packages/cosec/test/cosecRequestInterceptor.test.ts
+++ b/packages/cosec/test/cosecRequestInterceptor.test.ts
@@ -11,12 +11,8 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { CoSecRequestInterceptor } from '../src';
-import { DeviceIdStorage } from '../src';
-import { TokenStorage } from '../src';
-import { InMemoryStorage } from '../src';
-import { CoSecHeaders } from '../src';
+import { describe, expect, it, vi } from 'vitest';
+import { CoSecHeaders, CoSecRequestInterceptor, DeviceIdStorage, InMemoryStorage, TokenStorage } from '../src';
 import { Fetcher, FetchExchange } from '@ahoo-wang/fetcher';
 
 describe('CoSecRequestInterceptor', () => {
@@ -44,8 +40,8 @@ describe('CoSecRequestInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: undefined,
@@ -81,8 +77,8 @@ describe('CoSecRequestInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: undefined,
@@ -119,8 +115,8 @@ describe('CoSecRequestInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: undefined,
@@ -160,8 +156,8 @@ describe('CoSecRequestInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/cosec/test/cosecResponseInterceptor.test.ts
+++ b/packages/cosec/test/cosecResponseInterceptor.test.ts
@@ -11,11 +11,8 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { CoSecResponseInterceptor } from '../src';
-import { DeviceIdStorage } from '../src';
-import { TokenStorage } from '../src';
-import { InMemoryStorage } from '../src';
+import { describe, expect, it, vi } from 'vitest';
+import { CoSecResponseInterceptor, DeviceIdStorage, InMemoryStorage, TokenStorage } from '../src';
 import { Fetcher, FetchExchange } from '@ahoo-wang/fetcher';
 
 describe('CoSecResponseInterceptor', () => {
@@ -38,8 +35,8 @@ describe('CoSecResponseInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: undefined,
@@ -71,8 +68,8 @@ describe('CoSecResponseInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: new Response('Forbidden', { status: 403 }),
@@ -106,8 +103,8 @@ describe('CoSecResponseInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: new Response('Unauthorized', { status: 401 }),
@@ -150,8 +147,8 @@ describe('CoSecResponseInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: new Response('Unauthorized', { status: 401 }),
@@ -161,8 +158,8 @@ describe('CoSecResponseInterceptor', () => {
     // Mock the fetcher's request method to avoid actual network calls
     const requestMock = vi.fn().mockResolvedValue({
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: new Response('OK', { status: 200 }),
@@ -177,7 +174,8 @@ describe('CoSecResponseInterceptor', () => {
       refreshToken: 'old-refresh-token',
     });
     expect(tokenStorage.get()).toEqual(newToken);
-    expect(requestMock).toHaveBeenCalledWith('https://api.example.com/test', {
+    expect(requestMock).toHaveBeenCalledWith({
+      url: 'https://api.example.com/test',
       method: 'GET',
     });
   });
@@ -207,8 +205,8 @@ describe('CoSecResponseInterceptor', () => {
     const fetcher = new Fetcher();
     const exchange: FetchExchange = {
       fetcher,
-      url: 'https://api.example.com/test',
       request: {
+        url: 'https://api.example.com/test',
         method: 'GET',
       },
       response: new Response('Unauthorized', { status: 401 }),

--- a/packages/fetcher/src/fetchExchange.ts
+++ b/packages/fetcher/src/fetchExchange.ts
@@ -12,7 +12,7 @@
  */
 
 import { Fetcher } from './fetcher';
-import { FetchRequestInit } from './fetchRequest';
+import { FetchRequest } from './fetchRequest';
 
 /**
  * FetchExchange Interface
@@ -60,14 +60,9 @@ export interface FetchExchange {
   fetcher: Fetcher;
 
   /**
-   * The URL for this request
+   * The request configuration including url, method, headers, body, etc.
    */
-  url: string;
-
-  /**
-   * The request configuration including method, headers, body, etc.
-   */
-  request: FetchRequestInit;
+  request: FetchRequest;
 
   /**
    * The response object, undefined until the request completes successfully

--- a/packages/fetcher/src/fetchInterceptor.ts
+++ b/packages/fetcher/src/fetchInterceptor.ts
@@ -75,11 +75,7 @@ export class FetchInterceptor implements Interceptor {
    * console.log(result.response); // HTTP response object
    */
   async intercept(exchange: FetchExchange): Promise<FetchExchange> {
-    exchange.response = await timeoutFetch(
-      exchange.url,
-      exchange.request as RequestInit,
-      exchange.request.timeout,
-    );
+    exchange.response = await timeoutFetch(exchange.request);
     return exchange;
   }
 }

--- a/packages/fetcher/src/fetchRequest.ts
+++ b/packages/fetcher/src/fetchRequest.ts
@@ -102,3 +102,10 @@ export interface FetchRequestInit
    */
   body?: BodyInit | Record<string, any> | string | null;
 }
+
+export interface FetchRequest extends FetchRequestInit {
+  /**
+   * The URL for this request
+   */
+  url: string;
+}

--- a/packages/fetcher/src/timeout.ts
+++ b/packages/fetcher/src/timeout.ts
@@ -116,9 +116,7 @@ export class FetchTimeoutError extends Error {
  * const response = await timeoutFetch('https://api.example.com/users', { method: 'GET' });
  * ```
  */
-export async function timeoutFetch(
-  request: FetchRequest,
-): Promise<Response> {
+export async function timeoutFetch(request: FetchRequest): Promise<Response> {
   const url = request.url;
   const timeout = request.timeout;
   const requestInit = request as RequestInit;
@@ -130,8 +128,8 @@ export async function timeoutFetch(
   // Create AbortController for fetch request cancellation
   const controller = new AbortController();
   // Create a new request object to avoid modifying the original request object
-  const fetchRequest = {
-    ...request,
+  const fetchRequest: RequestInit = {
+    ...requestInit,
     signal: controller.signal,
   };
 
@@ -152,10 +150,7 @@ export async function timeoutFetch(
 
   try {
     // Race between fetch request and timeout Promise
-    return await Promise.race([
-      fetch(url, requestInit),
-      timeoutPromise,
-    ]);
+    return await Promise.race([fetch(url, fetchRequest), timeoutPromise]);
   } finally {
     // Clean up timer resources
     if (timerId) {

--- a/packages/fetcher/src/urlBuilder.ts
+++ b/packages/fetcher/src/urlBuilder.ts
@@ -13,6 +13,7 @@
 
 import { combineURLs } from './urls';
 import { BaseURLCapable } from './types';
+import { FetchRequest } from './fetchRequest';
 
 /**
  * UrlBuilder Class
@@ -75,6 +76,10 @@ export class UrlBuilder implements BaseURLCapable {
       }
     }
     return finalUrl;
+  }
+
+  resolveRequestUrl(request: FetchRequest) {
+    return this.build(request.url, request.path, request.query);
   }
 
   /**

--- a/packages/fetcher/src/urlResolveInterceptor.ts
+++ b/packages/fetcher/src/urlResolveInterceptor.ts
@@ -57,11 +57,8 @@ export class UrlResolveInterceptor implements Interceptor {
    * @returns The modified exchange with the resolved URL
    */
   intercept(exchange: FetchExchange): FetchExchange {
-    exchange.url = exchange.fetcher.urlBuilder.build(
-      exchange.url,
-      exchange.request.path,
-      exchange.request.query,
-    );
+    const request = exchange.request;
+    request.url = exchange.fetcher.urlBuilder.resolveRequestUrl(request);
     return exchange;
   }
 }

--- a/packages/fetcher/test/fetcher-edge-case.test.ts
+++ b/packages/fetcher/test/fetcher-edge-case.test.ts
@@ -11,9 +11,8 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { Fetcher } from '../src';
-import { FetchExchange } from '../src';
+import { describe, expect, it, vi } from 'vitest';
+import { Fetcher, FetchExchange } from '../src';
 
 describe('Fetcher Edge Cases', () => {
   it('should handle case where exchange has no response (covers lines 84-85)', async () => {
@@ -22,14 +21,16 @@ describe('Fetcher Edge Cases', () => {
     // Mock the request method to return an exchange without response
     const mockRequest = vi.spyOn(fetcher as any, 'request').mockResolvedValue({
       fetcher,
-      url: 'https://api.example.com/test',
-      request: {},
+      request: {
+        url: '/test',
+      },
       response: undefined, // No response
       error: undefined,
+      attributes: {},
     } as FetchExchange);
 
     await expect(fetcher.fetch('/test')).rejects.toThrow(
-      'Request to https://api.example.com/test failed with no response',
+      'Request to /test failed with no response',
     );
 
     mockRequest.mockRestore();

--- a/packages/fetcher/test/timeout.test.ts
+++ b/packages/fetcher/test/timeout.test.ts
@@ -123,7 +123,9 @@ describe('timeout.ts', () => {
       });
 
       // Mock global fetch
-      const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse);
+      const mockFetch = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(mockResponse);
 
       const url = 'https://api.example.com/users';
       const request = { url, method: HttpMethod.GET };
@@ -144,7 +146,9 @@ describe('timeout.ts', () => {
       });
 
       // Mock global fetch
-      const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse);
+      const mockFetch = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(mockResponse);
 
       const url = 'https://api.example.com/users';
       const timeout = 1000;
@@ -152,9 +156,12 @@ describe('timeout.ts', () => {
 
       const response = await timeoutFetch(request);
 
-      expect(mockFetch).toHaveBeenCalledWith(url, expect.objectContaining({
-        signal: expect.any(AbortSignal),
-      }));
+      expect(mockFetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
+      );
       expect(response).toBe(mockResponse);
 
       // Clean up
@@ -173,8 +180,14 @@ describe('timeout.ts', () => {
       const request = { url, method: HttpMethod.GET, timeout };
 
       await expect(timeoutFetch(request)).rejects.toThrow(FetchTimeoutError);
-      await expect(timeoutFetch(request)).rejects.toHaveProperty('url', url);
-      await expect(timeoutFetch(request)).rejects.toHaveProperty('timeout', timeout);
+      await expect(timeoutFetch(request)).rejects.toHaveProperty(
+        'request.url',
+        url,
+      );
+      await expect(timeoutFetch(request)).rejects.toHaveProperty(
+        'request.timeout',
+        timeout,
+      );
 
       // Clean up
       mockFetch.mockRestore();
@@ -187,7 +200,9 @@ describe('timeout.ts', () => {
       });
 
       // Mock global fetch
-      const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse);
+      const mockFetch = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(mockResponse);
 
       // Mock clearTimeout to verify it's called
       const mockClearTimeout = vi.spyOn(globalThis, 'clearTimeout');

--- a/packages/fetcher/test/urlResolveInterceptor.test.ts
+++ b/packages/fetcher/test/urlResolveInterceptor.test.ts
@@ -27,8 +27,8 @@ describe('UrlResolveInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher,
-      url: '/users/{id}',
       request: {
+        url: '/users/{id}',
         method: 'GET',
         path: { id: 123 },
         query: { filter: 'active' },
@@ -40,7 +40,9 @@ describe('UrlResolveInterceptor', () => {
 
     const result = interceptor.intercept(exchange);
 
-    expect(result.url).toBe('https://api.example.com/users/123?filter=active');
+    expect(result.request.url).toBe(
+      'https://api.example.com/users/123?filter=active',
+    );
   });
 
   it('should resolve URL without path and query parameters', () => {
@@ -49,8 +51,8 @@ describe('UrlResolveInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher,
-      url: '/users',
       request: {
+        url: '/users',
         method: 'GET',
       },
       response: undefined,
@@ -60,7 +62,7 @@ describe('UrlResolveInterceptor', () => {
 
     const result = interceptor.intercept(exchange);
 
-    expect(result.url).toBe('https://api.example.com/users');
+    expect(result.request.url).toBe('https://api.example.com/users');
   });
 
   it('should resolve URL with only path parameters', () => {
@@ -69,8 +71,8 @@ describe('UrlResolveInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher,
-      url: '/users/{id}/posts/{postId}',
       request: {
+        url: '/users/{id}/posts/{postId}',
         method: 'GET',
         path: { id: 123, postId: 456 },
       },
@@ -81,7 +83,9 @@ describe('UrlResolveInterceptor', () => {
 
     const result = interceptor.intercept(exchange);
 
-    expect(result.url).toBe('https://api.example.com/users/123/posts/456');
+    expect(result.request.url).toBe(
+      'https://api.example.com/users/123/posts/456',
+    );
   });
 
   it('should resolve URL with only query parameters', () => {
@@ -90,8 +94,8 @@ describe('UrlResolveInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher,
-      url: '/users',
       request: {
+        url: '/users',
         method: 'GET',
         query: {
           filter: 'active',
@@ -105,7 +109,7 @@ describe('UrlResolveInterceptor', () => {
 
     const result = interceptor.intercept(exchange);
 
-    expect(result.url).toBe(
+    expect(result.request.url).toBe(
       'https://api.example.com/users?filter=active&limit=10',
     );
   });
@@ -116,8 +120,8 @@ describe('UrlResolveInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher,
-      url: '/users',
       request: {
+        url: '/users',
         method: 'GET',
         query: {
           tags: ['important', 'urgent'],
@@ -132,8 +136,8 @@ describe('UrlResolveInterceptor', () => {
     const result = interceptor.intercept(exchange);
 
     // Check that the URL contains the expected parameters
-    expect(result.url).toContain('https://api.example.com/users');
-    expect(result.url).toContain('tags=important');
-    expect(result.url).toContain('status=active');
+    expect(result.request.url).toContain('https://api.example.com/users');
+    expect(result.request.url).toContain('tags=important');
+    expect(result.request.url).toContain('status=active');
   });
 });


### PR DESCRIPTION
- Merge URL and request parameters into a single FetchRequest object
- Update FetchExchange to use FetchRequest instead of separate URL and request
- Modify FetchTimeoutError to use FetchRequest instead of individual parameters
- Adjust timeoutFetch to accept FetchRequest instead of separate URL and request
- Update URLResolveInterceptor to use new FetchRequest structure
- Modify tests to accommodate new FetchRequest format