### PR TITLE
refactor(fetcher): consolidate type definitions and improve type safety

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fetcher/examples",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "description": "Examples for Fetcher HTTP client library",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcher",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "A modern HTTP client library based on fetch API",
   "private": true,
   "type": "module",

--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-cosec",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "CoSec authentication integration for Fetcher HTTP client",
   "keywords": [
     "fetch",

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-decorator",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "TypeScript decorators for clean API service definitions with Fetcher HTTP client",
   "keywords": [
     "fetch",

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventstream",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Server-Sent Events (SSE) support for Fetcher HTTP client",
   "keywords": [
     "fetch",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Ultra-lightweight (1.9kB) HTTP client with built-in path parameters and Axios-like API",
   "keywords": [
     "fetch",

--- a/packages/fetcher/src/fetchRequest.ts
+++ b/packages/fetcher/src/fetchRequest.ts
@@ -12,8 +12,50 @@
  */
 
 import { TimeoutCapable } from './timeout';
-import { HeadersCapable } from './types';
 import { UrlParams } from './urlBuilder';
+
+export interface BaseURLCapable {
+  /**
+   * 请求的 baseURL
+   * 当值为空时，表示不设置 baseURL，默认值为 undefined
+   */
+  baseURL: string;
+}
+
+/**
+ * HTTP方法枚举常量
+ */
+export enum HttpMethod {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  DELETE = 'DELETE',
+  PATCH = 'PATCH',
+  HEAD = 'HEAD',
+  OPTIONS = 'OPTIONS',
+}
+
+export const ContentTypeHeader = 'Content-Type';
+
+export enum ContentTypeValues {
+  APPLICATION_JSON = 'application/json',
+  TEXT_EVENT_STREAM = 'text/event-stream',
+}
+
+export interface RequestHeaders {
+  ContentTypeHeader?: string;
+  'Accept'?: string;
+  'Authorization'?: string;
+
+  [key: string]: string | undefined;
+}
+
+export interface RequestHeadersCapable {
+  /**
+   * Request headers
+   */
+  headers?: RequestHeaders;
+}
 
 /**
  * Fetcher request configuration interface
@@ -39,7 +81,7 @@ import { UrlParams } from './urlBuilder';
  */
 export interface FetchRequestInit
   extends TimeoutCapable,
-    HeadersCapable,
+    RequestHeadersCapable,
     Omit<RequestInit, 'body' | 'headers'> {
   urlParams?: UrlParams;
 

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -13,16 +13,17 @@
 
 import { UrlBuilder, UrlBuilderCapable } from './urlBuilder';
 import { resolveTimeout, TimeoutCapable } from './timeout';
-import {
-  BaseURLCapable,
-  ContentTypeHeader,
-  ContentTypeValues,
-  HeadersCapable,
-  HttpMethod,
-} from './types';
 import { FetcherInterceptors } from './interceptor';
 import { FetchExchange } from './fetchExchange';
-import { FetchRequest, FetchRequestInit } from './fetchRequest';
+import {
+  BaseURLCapable,
+  ContentTypeValues,
+  FetchRequest,
+  FetchRequestInit,
+  HttpMethod,
+  RequestHeaders,
+  RequestHeadersCapable,
+} from './fetchRequest';
 import { mergeRecords } from './utils';
 
 /**
@@ -40,13 +41,13 @@ import { mergeRecords } from './utils';
  */
 export interface FetcherOptions
   extends BaseURLCapable,
-    HeadersCapable,
+    RequestHeadersCapable,
     TimeoutCapable {
   interceptors?: FetcherInterceptors;
 }
 
-const DEFAULT_HEADERS: Record<string, string> = {
-  [ContentTypeHeader]: ContentTypeValues.APPLICATION_JSON,
+const DEFAULT_HEADERS: RequestHeaders = {
+  'Content-Type': ContentTypeValues.APPLICATION_JSON,
 };
 
 export const DEFAULT_OPTIONS: FetcherOptions = {
@@ -70,10 +71,10 @@ export const DEFAULT_OPTIONS: FetcherOptions = {
  * ```
  */
 export class Fetcher
-  implements UrlBuilderCapable, HeadersCapable, TimeoutCapable
+  implements UrlBuilderCapable, RequestHeadersCapable, TimeoutCapable
 {
   urlBuilder: UrlBuilder;
-  headers?: Record<string, string> = DEFAULT_HEADERS;
+  headers?: RequestHeaders = DEFAULT_HEADERS;
   timeout?: number;
   interceptors: FetcherInterceptors;
 

--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -12,8 +12,8 @@
  */
 
 import { Interceptor } from './interceptor';
-import { ContentTypeHeader, ContentTypeValues } from './types';
 import { FetchExchange } from './fetchExchange';
+import { ContentTypeValues } from './fetchRequest';
 
 /**
  * RequestBodyInterceptor Class
@@ -117,9 +117,9 @@ export class RequestBodyInterceptor implements Interceptor {
     }
 
     // Only set default Content-Type if not explicitly set
-    const headers = modifiedRequest.headers as Record<string, string>;
-    if (!headers[ContentTypeHeader]) {
-      headers[ContentTypeHeader] = ContentTypeValues.APPLICATION_JSON;
+    const headers = modifiedRequest.headers;
+    if (!headers['Content-Type']) {
+      headers['Content-Type'] = ContentTypeValues.APPLICATION_JSON;
     }
     exchange.request = modifiedRequest;
     return exchange;

--- a/packages/fetcher/src/types.ts
+++ b/packages/fetcher/src/types.ts
@@ -10,43 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export interface BaseURLCapable {
-  /**
-   * 请求的 baseURL
-   * 当值为空时，表示不设置 baseURL，默认值为 undefined
-   */
-  baseURL: string;
-}
-
-export interface HeadersCapable {
-  /**
-   * 请求头
-   */
-  headers?: Record<string, string>;
-}
-
-/**
- * HTTP方法枚举常量
- */
-export enum HttpMethod {
-  GET = 'GET',
-  POST = 'POST',
-  PUT = 'PUT',
-  DELETE = 'DELETE',
-  PATCH = 'PATCH',
-  HEAD = 'HEAD',
-  OPTIONS = 'OPTIONS',
-}
-
-
-export const ContentTypeHeader = 'Content-Type';
-
-export enum ContentTypeValues {
-  APPLICATION_JSON = 'application/json',
-  TEXT_EVENT_STREAM = 'text/event-stream',
-}
-
 /**
  * 具备名称能力的接口
  * 实现该接口的类型需要提供一个名称属性

--- a/packages/fetcher/src/urlBuilder.ts
+++ b/packages/fetcher/src/urlBuilder.ts
@@ -12,8 +12,7 @@
  */
 
 import { combineURLs } from './urls';
-import { BaseURLCapable } from './types';
-import { FetchRequest } from './fetchRequest';
+import { BaseURLCapable, FetchRequest } from './fetchRequest';
 
 /**
  * Interface for URL parameters including path and query parameters

--- a/packages/fetcher/test/fetcher-exchange.test.ts
+++ b/packages/fetcher/test/fetcher-exchange.test.ts
@@ -65,8 +65,7 @@ describe('Fetcher - exchange', () => {
 
     const exchange: FetchExchange = {
       fetcher,
-      url: '/test',
-      request: { method: 'GET' },
+      request: { url: '/test', method: 'GET' },
       response: undefined,
       error: undefined,
       attributes: {},
@@ -119,8 +118,7 @@ describe('Fetcher - exchange', () => {
 
     const exchange: FetchExchange = {
       fetcher,
-      url: '/test',
-      request: { method: 'GET' },
+      request: { url: '/test', method: 'GET' },
       response: undefined,
       error: undefined,
       attributes: {},
@@ -171,8 +169,7 @@ describe('Fetcher - exchange', () => {
 
     const exchange: FetchExchange = {
       fetcher,
-      url: '/test',
-      request: { method: 'GET' },
+      request: { url: '/test', method: 'GET' },
       response: undefined,
       error: undefined,
       attributes: {},

--- a/packages/fetcher/test/fetcherInterceptors.test.ts
+++ b/packages/fetcher/test/fetcherInterceptors.test.ts
@@ -12,10 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { FetcherInterceptors } from '../src/interceptor';
-import { UrlResolveInterceptor } from '../src/urlResolveInterceptor';
-import { RequestBodyInterceptor } from '../src/requestBodyInterceptor';
-import { FetchInterceptor } from '../src/fetchInterceptor';
+import { FetcherInterceptors, FetchInterceptor, RequestBodyInterceptor, UrlResolveInterceptor } from '../src';
 
 describe('FetcherInterceptors', () => {
   it('should create FetcherInterceptors with default interceptors', () => {

--- a/packages/fetcher/test/requestBodyInterceptor.test.ts
+++ b/packages/fetcher/test/requestBodyInterceptor.test.ts
@@ -12,8 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { RequestBodyInterceptor } from '../src/requestBodyInterceptor';
-import { ContentTypeHeader, ContentTypeValues, Fetcher, FetchExchange } from '../src';
+import { ContentTypeValues, Fetcher, FetchExchange, RequestBodyInterceptor } from '../src';
 
 describe('RequestBodyInterceptor', () => {
   const interceptor = new RequestBodyInterceptor();
@@ -273,8 +272,8 @@ describe('RequestBodyInterceptor', () => {
     expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers as Record<string, string>;
-    expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
+    const headers = result.request.headers!;
+    expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
   it('should not override existing Content-Type header', () => {
@@ -286,7 +285,7 @@ describe('RequestBodyInterceptor', () => {
         method: 'POST',
         body: requestBody as any,
         headers: {
-          [ContentTypeHeader]: 'text/plain',
+          ['Content-Type']: 'text/plain',
         },
       },
       response: undefined,
@@ -299,8 +298,8 @@ describe('RequestBodyInterceptor', () => {
     expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that existing Content-Type header is preserved
-    const headers = result.request.headers as Record<string, string>;
-    expect(headers[ContentTypeHeader]).toBe('text/plain');
+    const headers = result.request.headers!;
+    expect(headers['Content-Type']).toBe('text/plain');
   });
 
   it('should handle array body by converting to JSON', () => {
@@ -322,8 +321,8 @@ describe('RequestBodyInterceptor', () => {
     expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers as Record<string, string>;
-    expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
+    const headers = result.request.headers!;
+    expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
   it('should handle nested object body by converting to JSON', () => {
@@ -353,8 +352,8 @@ describe('RequestBodyInterceptor', () => {
     expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers as Record<string, string>;
-    expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
+    const headers = result.request.headers!;
+    expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
   it('should handle empty object body', () => {
@@ -376,8 +375,8 @@ describe('RequestBodyInterceptor', () => {
     expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers as Record<string, string>;
-    expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
+    const headers = result.request.headers!;
+    expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
   it('should handle null prototype object body', () => {
@@ -400,7 +399,7 @@ describe('RequestBodyInterceptor', () => {
     expect(result.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers as Record<string, string>;
-    expect(headers[ContentTypeHeader]).toBe(ContentTypeValues.APPLICATION_JSON);
+    const headers = result.request.headers!;
+    expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 });

--- a/packages/wow/package.json
+++ b/packages/wow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-wow",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Support for Wow(https://github.com/Ahoo-Wang/Wow) in Fetcher",
   "keywords": [
     "fetch",


### PR DESCRIPTION
- Move common types to fetchRequest.ts for better organization
- Replace Record<string, string> with more specific RequestHeaders type
- Update Fetcher and FetchRequestInit to use new RequestHeadersCapable interface
- Modify tests to align with new RequestHeaders type
- Remove redundant type imports and simplify code