### PR TITLE
test(decorator): remove unused imports and delete redundant tests

### DIFF
--- a/packages/decorator/test/apiDecorator.edge-case.test.ts
+++ b/packages/decorator/test/apiDecorator.edge-case.test.ts
@@ -1,13 +1,18 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  api,
-  API_METADATA_KEY,
-  ENDPOINT_METADATA_KEY,
-  get,
-  PARAMETER_METADATA_KEY,
-  ParameterType,
-  path,
-} from '../src';
+import { api, API_METADATA_KEY, get, PARAMETER_METADATA_KEY } from '../src';
 import { fetcherRegistrar } from '@ahoo-wang/fetcher';
 import 'reflect-metadata';
 
@@ -41,55 +46,6 @@ describe('apiDecorator - edge cases', () => {
     const metadata = Reflect.getMetadata(API_METADATA_KEY, TestService);
     expect(metadata).toBeDefined();
     expect(metadata.basePath).toBe('/test');
-  });
-
-  it('should handle class with only constructor', () => {
-    @api('/test')
-    class TestService {
-      constructor() {
-        // Empty constructor
-      }
-    }
-
-    const metadata = Reflect.getMetadata(API_METADATA_KEY, TestService);
-    expect(metadata).toBeDefined();
-    expect(metadata.basePath).toBe('/test');
-
-    // Constructor should not be modified
-    const instance = new TestService();
-    expect(typeof instance.constructor).toBe('function');
-  });
-
-  it('should handle class with non-function properties', () => {
-    @api('/test')
-    class TestService {
-      static staticProperty = 'static';
-      instanceProperty = 'instance';
-
-      static staticMethod() {
-        return 'static method';
-      }
-
-      @get('/users')
-      getUsers() {
-        return Promise.resolve(new Response('{"users": []}'));
-      }
-    }
-
-    const metadata = Reflect.getMetadata(API_METADATA_KEY, TestService);
-    expect(metadata).toBeDefined();
-    expect(metadata.basePath).toBe('/test');
-
-    // Static properties should be preserved
-    expect(TestService.staticProperty).toBe('static');
-    expect(TestService.staticMethod()).toBe('static method');
-
-    // Instance properties should be preserved
-    const instance = new TestService();
-    expect(instance.instanceProperty).toBe('instance');
-
-    // Decorated method should be replaced with executor
-    expect(typeof instance.getUsers).toBe('function');
   });
 
   it('should handle method with no endpoint metadata', () => {
@@ -145,69 +101,6 @@ describe('apiDecorator - edge cases', () => {
 
     const instance = new TestService();
     // Method should still be replaced with executor
-    expect(typeof instance.getUser).toBe('function');
-  });
-
-  it('should handle class inheritance', () => {
-    @api('/base')
-    class BaseService {
-      @get('/base')
-      getBase() {
-        return Promise.resolve(new Response('{"base": true}'));
-      }
-    }
-
-    @api('/derived')
-    class DerivedService extends BaseService {
-      @get('/derived')
-      getDerived() {
-        return Promise.resolve(new Response('{"derived": true}'));
-      }
-    }
-
-    const baseInstance = new BaseService();
-    const derivedInstance = new DerivedService();
-
-    // Both instances should have their respective methods replaced with executors
-    expect(typeof baseInstance.getBase).toBe('function');
-    expect(typeof derivedInstance.getBase).toBe('function');
-    expect(typeof derivedInstance.getDerived).toBe('function');
-  });
-
-  it('should handle multiple decorators on same method', () => {
-    @api('/test')
-    class TestService {
-      @get('/users/{id}')
-      getUser(@path('id') id: number) {
-        return Promise.resolve(new Response('{"user": {"id": 1}}'));
-      }
-    }
-
-    const instance = new TestService();
-    const endpointMetadata = Reflect.getMetadata(
-      ENDPOINT_METADATA_KEY,
-      Object.getPrototypeOf(instance),
-      'getUser',
-    );
-
-    const parameterMetadata = Reflect.getMetadata(
-      PARAMETER_METADATA_KEY,
-      Object.getPrototypeOf(instance),
-      'getUser',
-    );
-
-    // Should have both endpoint and parameter metadata
-    expect(endpointMetadata).toBeDefined();
-    expect(parameterMetadata).toBeDefined();
-    expect(parameterMetadata).toEqual([
-      {
-        type: ParameterType.PATH,
-        name: 'id',
-        index: 0,
-      },
-    ]);
-
-    // Method should be replaced with executor
     expect(typeof instance.getUser).toBe('function');
   });
 

--- a/packages/decorator/test/reflection.branch.test.ts
+++ b/packages/decorator/test/reflection.branch.test.ts
@@ -1,5 +1,18 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, it } from 'vitest';
-import { getParameterName, getParameterNames } from '../src/reflection';
+import { getParameterName, getParameterNames } from '../src';
 
 describe('reflection - branch coverage', () => {
   it('should handle non-function input to getParameterNames', () => {


### PR DESCRIPTION
- Remove unused import of 'path' and 'ParameterType' in apiDecorator.edge-case.test.ts
- Delete redundant tests for class constructor, non-function properties, inheritance, and multiple decorators
- Simplify import statement in apiDecorator.branch.test.ts