### PR TITLE
refactor(fetcher): change interceptor return type to void

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,11 @@ fetcher.interceptors.request.use({
   name: 'auth-interceptor',
   order: 100, // Lower values execute first
   intercept(exchange) {
-    return {
-      ...exchange,
-      request: {
-        ...exchange.request,
-        headers: {
-          ...exchange.request.headers,
-          Authorization: 'Bearer ' + getAuthToken(),
-        },
+    exchange.request = {
+      ...exchange.request,
+      headers: {
+        ...exchange.request.headers,
+        Authorization: 'Bearer ' + getAuthToken(),
       },
     };
   },
@@ -176,8 +173,11 @@ fetcher.interceptors.request.use({
   name: 'logging-interceptor',
   order: 50, // Executes before auth-interceptor
   intercept(exchange) {
-    console.log('Request sending:', exchange.request.method, exchange.url);
-    return exchange;
+    console.log(
+      'Request sending:',
+      exchange.request.method,
+      exchange.request.url,
+    );
   },
 });
 
@@ -187,7 +187,6 @@ fetcher.interceptors.response.use({
   order: 10,
   intercept(exchange) {
     console.log('Response received:', exchange.response.status);
-    return exchange;
   },
 });
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,14 +154,11 @@ fetcher.interceptors.request.use({
   name: 'auth-interceptor',
   order: 100, // 数值越小优先级越高
   intercept(exchange) {
-    return {
-      ...exchange,
-      request: {
-        ...exchange.request,
-        headers: {
-          ...exchange.request.headers,
-          Authorization: 'Bearer ' + getAuthToken(),
-        },
+    exchange.request = {
+      ...exchange.request,
+      headers: {
+        ...exchange.request.headers,
+        Authorization: 'Bearer ' + getAuthToken(),
       },
     };
   },
@@ -172,8 +169,7 @@ fetcher.interceptors.request.use({
   name: 'logging-interceptor',
   order: 50, // 在 auth-interceptor 之前执行
   intercept(exchange) {
-    console.log('发送请求:', exchange.request.method, exchange.url);
-    return exchange;
+    console.log('发送请求:', exchange.request.method, exchange.request.url);
   },
 });
 
@@ -183,7 +179,6 @@ fetcher.interceptors.response.use({
   order: 10,
   intercept(exchange) {
     console.log('收到响应:', exchange.response.status);
-    return exchange;
   },
 });
 

--- a/examples/src/interceptorExample.ts
+++ b/examples/src/interceptorExample.ts
@@ -42,7 +42,6 @@ export function initInterceptorExample(): void {
               'X-Custom-Header': 'Added by interceptor',
             },
           };
-          return exchange;
         },
       };
       const requestInterceptorId =

--- a/packages/cosec/src/cosecRequestInterceptor.ts
+++ b/packages/cosec/src/cosecRequestInterceptor.ts
@@ -48,10 +48,9 @@ export class CoSecRequestInterceptor implements Interceptor {
    * - CoSec-Request-Id: A unique identifier for this specific request
    * - Authorization: Bearer token if available in token storage
    *
-   * @param exchange - The fetch exchange containing the request to be processed
    * @returns The modified exchange with CoSec authentication headers added
    */
-  intercept(exchange: FetchExchange): FetchExchange {
+  intercept(exchange: FetchExchange) {
     const requestId = idGenerator.generateId();
     const deviceId = this.options.deviceIdStorage.getOrCreate();
     const token = this.options.tokenStorage.get();
@@ -73,6 +72,5 @@ export class CoSecRequestInterceptor implements Interceptor {
         `Bearer ${token.accessToken}`;
     }
     exchange.request = newRequest;
-    return exchange;
   }
 }

--- a/packages/cosec/src/cosecResponseInterceptor.ts
+++ b/packages/cosec/src/cosecResponseInterceptor.ts
@@ -47,22 +47,22 @@ export class CoSecResponseInterceptor implements Interceptor {
    * @returns Promise<FetchExchange> The processed exchange, either with a refreshed token or original error
    * @throws Error if token refresh fails or other errors occur during processing
    */
-  async intercept(exchange: FetchExchange): Promise<FetchExchange> {
+  async intercept(exchange: FetchExchange): Promise<void> {
     const response = exchange.response;
     if (!response) {
-      return exchange;
+      return;
     }
     if (response.status !== ResponseCodes.UNAUTHORIZED) {
-      return exchange;
+      return;
     }
     const currentToken = this.options.tokenStorage.get();
     if (!currentToken) {
-      return exchange;
+      return;
     }
     try {
       const newToken = await this.options.tokenRefresher.refresh(currentToken);
       this.options.tokenStorage.set(newToken);
-      return exchange.fetcher.request(exchange.request);
+      await exchange.fetcher.request(exchange.request);
     } catch (error) {
       // If token refresh fails, clear stored tokens and re-throw the error
       this.options.tokenStorage.clear();

--- a/packages/cosec/test/cosecRequestInterceptor.test.ts
+++ b/packages/cosec/test/cosecRequestInterceptor.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { CoSecHeaders, CoSecRequestInterceptor, DeviceIdStorage, InMemoryStorage, TokenStorage } from '../src';
-import { Fetcher, FetchExchange } from '@ahoo-wang/fetcher';
+import { Fetcher, FetchExchange, RequestHeaders } from '@ahoo-wang/fetcher';
 
 describe('CoSecRequestInterceptor', () => {
   it('should add CoSec headers to request', () => {
@@ -48,10 +48,10 @@ describe('CoSecRequestInterceptor', () => {
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(result.request.headers).toBeDefined();
-    const headers = result.request.headers as Record<string, string>;
+    expect(exchange.request.headers).toBeDefined();
+    const headers = exchange.request.headers as Record<string, string>;
     expect(headers[CoSecHeaders.APP_ID]).toBe('test-app-id');
     expect(headers[CoSecHeaders.DEVICE_ID]).toBe('test-device-id-123');
     expect(headers[CoSecHeaders.AUTHORIZATION]).toBe(
@@ -85,10 +85,10 @@ describe('CoSecRequestInterceptor', () => {
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(result.request.headers).toBeDefined();
-    const headers = result.request.headers as Record<string, string>;
+    expect(exchange.request.headers).toBeDefined();
+    const headers = exchange.request.headers as RequestHeaders;
     expect(headers[CoSecHeaders.APP_ID]).toBe('test-app-id');
     expect(headers[CoSecHeaders.DEVICE_ID]).toBeDefined();
     expect(headers[CoSecHeaders.DEVICE_ID]).toBeTruthy();
@@ -123,10 +123,10 @@ describe('CoSecRequestInterceptor', () => {
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(result.request.headers).toBeDefined();
-    const headers = result.request.headers as Record<string, string>;
+    expect(exchange.request.headers).toBeDefined();
+    const headers = exchange.request.headers as RequestHeaders;
     expect(headers[CoSecHeaders.APP_ID]).toBe('test-app-id');
     expect(headers[CoSecHeaders.DEVICE_ID]).toBe('test-device-id-123');
     expect(headers[CoSecHeaders.AUTHORIZATION]).toBeUndefined();
@@ -168,10 +168,10 @@ describe('CoSecRequestInterceptor', () => {
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(result.request.headers).toBeDefined();
-    const headers = result.request.headers as Record<string, string>;
+    expect(exchange.request.headers).toBeDefined();
+    const headers = exchange.request.headers as RequestHeaders;
     expect(headers['Content-Type']).toBe('application/json');
     expect(headers['X-Custom-Header']).toBe('custom-value');
     expect(headers[CoSecHeaders.APP_ID]).toBe('test-app-id');

--- a/packages/cosec/test/cosecResponseInterceptor.test.ts
+++ b/packages/cosec/test/cosecResponseInterceptor.test.ts
@@ -43,9 +43,8 @@ describe('CoSecResponseInterceptor', () => {
       error: undefined,
     };
 
-    const result = await interceptor.intercept(exchange);
+    await interceptor.intercept(exchange);
 
-    expect(result).toBe(exchange);
     expect(tokenRefresher.refresh).not.toHaveBeenCalled();
   });
 
@@ -76,9 +75,8 @@ describe('CoSecResponseInterceptor', () => {
       error: undefined,
     };
 
-    const result = await interceptor.intercept(exchange);
+    await interceptor.intercept(exchange);
 
-    expect(result).toBe(exchange);
     expect(tokenRefresher.refresh).not.toHaveBeenCalled();
   });
 
@@ -111,9 +109,8 @@ describe('CoSecResponseInterceptor', () => {
       error: undefined,
     };
 
-    const result = await interceptor.intercept(exchange);
+    await interceptor.intercept(exchange);
 
-    expect(result).toBe(exchange);
     expect(tokenRefresher.refresh).not.toHaveBeenCalled();
   });
 

--- a/packages/decorator/src/requestExecutor.ts
+++ b/packages/decorator/src/requestExecutor.ts
@@ -18,6 +18,7 @@ import {
   FetchRequestInit,
   mergeRequest,
   NamedCapable,
+  RequestHeaders,
   UrlParams,
 } from '@ahoo-wang/fetcher';
 import { ApiMetadata } from './apiDecorator';
@@ -135,7 +136,7 @@ export class FunctionMetadata implements NamedCapable {
   resolveRequest(args: any[]): FetchRequestInit {
     const path: Record<string, any> = {};
     const query: Record<string, any> = {};
-    const headers: Record<string, string> = {
+    const headers: RequestHeaders = {
       ...this.api.headers,
       ...this.endpoint.headers,
     };
@@ -205,7 +206,7 @@ export class FunctionMetadata implements NamedCapable {
   private processHeaderParam(
     param: ParameterMetadata,
     value: any,
-    headers: Record<string, string>,
+    headers: RequestHeaders,
   ) {
     if (param.name && value !== undefined) {
       headers[param.name] = String(value);

--- a/packages/eventstream/src/eventStreamInterceptor.ts
+++ b/packages/eventstream/src/eventStreamInterceptor.ts
@@ -47,11 +47,11 @@ export class EventStreamInterceptor implements Interceptor {
   name = 'EventStreamInterceptor';
   order = Number.MAX_SAFE_INTEGER - 100;
 
-  intercept(exchange: FetchExchange): FetchExchange {
+  intercept(exchange: FetchExchange) {
     // Check if the response is an event stream
     const response = exchange.response;
     if (!response) {
-      return exchange;
+      return;
     }
     const contentType = response.headers.get(ContentTypeHeader);
     if (
@@ -61,6 +61,5 @@ export class EventStreamInterceptor implements Interceptor {
       // Add eventStream method to response
       response.eventStream = () => toServerSentEventStream(response);
     }
-    return exchange;
   }
 }

--- a/packages/eventstream/test/eventStreamInterceptor.comprehensive.test.ts
+++ b/packages/eventstream/test/eventStreamInterceptor.comprehensive.test.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { EventStreamInterceptor } from '../src';
 import { Fetcher, FetchExchange } from '@ahoo-wang/fetcher';
 
@@ -38,16 +38,15 @@ describe('EventStreamInterceptor Comprehensive', () => {
 
       const exchange: FetchExchange = {
         fetcher: mockFetcher,
-        url: 'http://example.com/events',
-        request: {},
+        request: { url: 'http://example.com/events' },
         response: response,
         error: undefined,
       };
 
-      const result = interceptor.intercept(exchange);
+      interceptor.intercept(exchange);
 
-      expect(result.response?.eventStream).toBeDefined();
-      expect(typeof result.response?.eventStream).toBe('function');
+      expect(exchange.response?.eventStream).toBeDefined();
+      expect(typeof exchange.response?.eventStream).toBe('function');
     }
   });
 
@@ -73,15 +72,14 @@ describe('EventStreamInterceptor Comprehensive', () => {
 
       const exchange: FetchExchange = {
         fetcher: mockFetcher,
-        url: 'http://example.com/api',
-        request: {},
+        request: { url: 'http://example.com/events' },
         response: response,
         error: undefined,
       };
 
-      const result = interceptor.intercept(exchange);
+      interceptor.intercept(exchange);
 
-      expect(result.response?.eventStream).toBeUndefined();
+      expect(exchange.response?.eventStream).toBeUndefined();
     }
   });
 
@@ -93,16 +91,15 @@ describe('EventStreamInterceptor Comprehensive', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
-      request: {},
+      request: { url: 'http://example.com/events' },
       response: response,
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // Should still add eventStream method if any header matches
-    expect(result.response?.eventStream).toBeDefined();
+    expect(exchange.response?.eventStream).toBeDefined();
   });
 
   it('should preserve existing response properties', () => {
@@ -117,21 +114,20 @@ describe('EventStreamInterceptor Comprehensive', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
-      request: {},
+      request: { url: 'http://example.com/events' },
       response: response,
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // Should preserve all original response properties
-    expect(result.response?.status).toBe(201);
-    expect(result.response?.statusText).toBe('Created');
-    expect(result.response?.headers.get('custom-header')).toBe('custom-value');
+    expect(exchange.response?.status).toBe(201);
+    expect(exchange.response?.statusText).toBe('Created');
+    expect(exchange.response?.headers.get('custom-header')).toBe('custom-value');
 
     // Should add eventStream method
-    expect(result.response?.eventStream).toBeDefined();
+    expect(exchange.response?.eventStream).toBeDefined();
   });
 
   it('should handle response with no body', () => {
@@ -141,16 +137,15 @@ describe('EventStreamInterceptor Comprehensive', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
-      request: {},
+      request: { url: 'http://example.com/events' },
       response: response,
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // Should still add eventStream method even with null body
-    expect(result.response?.eventStream).toBeDefined();
+    expect(exchange.response?.eventStream).toBeDefined();
   });
 
   it('should handle response with empty body', () => {
@@ -160,48 +155,43 @@ describe('EventStreamInterceptor Comprehensive', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
-      request: {},
+      request: { url: 'http://example.com/events' },
       response: response,
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // Should still add eventStream method even with empty body
-    expect(result.response?.eventStream).toBeDefined();
+    expect(exchange.response?.eventStream).toBeDefined();
   });
 
   it('should not modify exchange when response is undefined', () => {
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
-      request: {},
+      request: { url: 'http://example.com/events' },
       response: undefined,
       error: new Error('Test error'),
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // Should return the same exchange object
-    expect(result).toBe(exchange);
-    expect(result.response).toBeUndefined();
+    expect(exchange.response).toBeUndefined();
   });
 
   it('should not modify exchange when response is null', () => {
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
-      request: {},
+      request: { url: 'http://example.com/events' },
       response: null,
       error: undefined,
     } as unknown as FetchExchange;
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // Should return the same exchange object
-    expect(result).toBe(exchange);
-    expect(result.response).toBeNull();
+    expect(exchange.response).toBeNull();
   });
 
   it('should be idempotent when called multiple times', () => {
@@ -211,25 +201,21 @@ describe('EventStreamInterceptor Comprehensive', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
-      request: {},
+      request: { url: 'http://example.com/events' },
       response: response,
       error: undefined,
     };
 
     // Call interceptor multiple times
-    const result1 = interceptor.intercept(exchange);
-    const result2 = interceptor.intercept(result1);
-    const result3 = interceptor.intercept(result2);
+    interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // All results should be the same object
-    expect(result1).toBe(exchange);
-    expect(result2).toBe(exchange);
-    expect(result3).toBe(exchange);
 
     // Response should have eventStream method
-    expect(result1.response?.eventStream).toBeDefined();
-    expect(result2.response?.eventStream).toBeDefined();
-    expect(result3.response?.eventStream).toBeDefined();
+    expect(exchange.response?.eventStream).toBeDefined();
+    expect(exchange.response?.eventStream).toBeDefined();
+    expect(exchange.response?.eventStream).toBeDefined();
   });
 });

--- a/packages/eventstream/test/eventStreamInterceptor.integration.test.ts
+++ b/packages/eventstream/test/eventStreamInterceptor.integration.test.ts
@@ -11,9 +11,8 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { EventStreamInterceptor } from '../src';
-import { toServerSentEventStream } from '../src';
+import { describe, expect, it, vi } from 'vitest';
+import { EventStreamInterceptor, toServerSentEventStream } from '../src';
 import { Fetcher, FetchExchange } from '@ahoo-wang/fetcher';
 
 // Mock the EventStreamConverter
@@ -36,42 +35,37 @@ describe('EventStreamInterceptor Integration', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
       request: {
+        url: 'http://example.com/events',
         method: 'GET',
       },
       response: response,
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
-
-    // Should return the same exchange object
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
 
     // Response should have eventStream method
-    expect(result.response?.eventStream).toBeDefined();
-    expect(typeof result.response?.eventStream).toBe('function');
+    expect(exchange.response?.eventStream).toBeDefined();
+    expect(typeof exchange.response?.eventStream).toBe('function');
   });
 
   it('should not modify exchange when response is undefined', () => {
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
       request: {
+        url: 'http://example.com/events',
         method: 'GET',
       },
       response: undefined,
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    // Should return the same exchange object
-    expect(result).toBe(exchange);
 
     // Response should remain undefined
-    expect(result.response).toBeUndefined();
+    expect(exchange.response).toBeUndefined();
   });
 
   it('should not modify exchange when content-type is not event-stream', () => {
@@ -81,21 +75,18 @@ describe('EventStreamInterceptor Integration', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/api',
       request: {
+        url: 'http://example.com/api',
         method: 'GET',
       },
       response: response,
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
-
-    // Should return the same exchange object
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
 
     // Response should not have eventStream method
-    expect(result.response?.eventStream).toBeUndefined();
+    expect(exchange.response?.eventStream).toBeUndefined();
   });
 
   it('should work with actual event stream conversion', () => {
@@ -105,19 +96,19 @@ describe('EventStreamInterceptor Integration', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com/events',
       request: {
+        url: 'http://example.com/events',
         method: 'GET',
       },
       response: response,
       error: undefined,
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // Call the eventStream method
-    if (result.response?.eventStream) {
-      const stream = result.response.eventStream();
+    if (exchange.response?.eventStream) {
+      const stream = exchange.response.eventStream();
 
       // Verify it returns a ReadableStream
       expect(stream).toBeInstanceOf(ReadableStream);

--- a/packages/eventstream/test/eventStreamInterceptor.test.ts
+++ b/packages/eventstream/test/eventStreamInterceptor.test.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { EventStreamInterceptor, toServerSentEventStream } from '../src';
 import { Fetcher, FetchExchange } from '@ahoo-wang/fetcher';
 
@@ -35,16 +35,15 @@ describe('EventStreamInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com',
-      request: {},
+      request: { url: 'http://example.com' },
       response: response,
       error: undefined,
     };
 
-    const interceptedExchange = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(interceptedExchange.response?.eventStream).toBeDefined();
-    expect(typeof interceptedExchange.response?.eventStream).toBe('function');
+    expect(exchange.response?.eventStream).toBeDefined();
+    expect(typeof exchange.response?.eventStream).toBe('function');
   });
 
   it('should not add eventStream method to response when content-type is not text/event-stream', () => {
@@ -55,15 +54,12 @@ describe('EventStreamInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com',
-      request: {},
+      request: { url: 'http://example.com' },
       response: response,
       error: undefined,
     };
-
-    const interceptedExchange = interceptor.intercept(exchange);
-
-    expect(interceptedExchange.response?.eventStream).toBeUndefined();
+    interceptor.intercept(exchange);
+    expect(exchange.response?.eventStream).toBeUndefined();
   });
 
   it('should not add eventStream method to response when content-type is null', () => {
@@ -72,15 +68,12 @@ describe('EventStreamInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com',
-      request: {},
+      request: { url: 'http://example.com' },
       response: response,
       error: undefined,
     };
-
-    const interceptedExchange = interceptor.intercept(exchange);
-
-    expect(interceptedExchange.response?.eventStream).toBeUndefined();
+    interceptor.intercept(exchange);
+    expect(exchange.response?.eventStream).toBeUndefined();
   });
 
   it('should return the same exchange object', () => {
@@ -91,15 +84,12 @@ describe('EventStreamInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com',
-      request: {},
+      request: { url: 'http://example.com' },
       response: response,
       error: undefined,
     };
-
-    const interceptedExchange = interceptor.intercept(exchange);
-
-    expect(interceptedExchange).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange).toBe(exchange);
   });
 
   it('should call EventStreamConverter when eventStream method is called', async () => {
@@ -110,16 +100,15 @@ describe('EventStreamInterceptor', () => {
 
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
-      url: 'http://example.com',
-      request: {},
+      request: { url: 'http://example.com' },
       response: response,
       error: undefined,
     };
 
-    const interceptedExchange = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    if (interceptedExchange.response?.eventStream) {
-      interceptedExchange.response.eventStream();
+    if (exchange.response?.eventStream) {
+      exchange.response.eventStream();
 
       // Verify that EventStreamConverter.toEventStream was called with the response
       expect(toServerSentEventStream).toHaveBeenCalledWith(response);

--- a/packages/fetcher/README.md
+++ b/packages/fetcher/README.md
@@ -139,14 +139,11 @@ const success = fetcher.interceptors.request.use({
   name: 'auth-interceptor',
   order: 100,
   intercept(exchange) {
-    return {
-      ...exchange,
-      request: {
-        ...exchange.request,
-        headers: {
-          ...exchange.request.headers,
-          Authorization: 'Bearer ' + getAuthToken(),
-        },
+    exchange.request = {
+      ...exchange.request,
+      headers: {
+        ...exchange.request.headers,
+        Authorization: 'Bearer ' + getAuthToken(),
       },
     };
   },
@@ -158,7 +155,6 @@ fetcher.interceptors.response.use({
   order: 10,
   intercept(exchange) {
     console.log('Response received:', exchange.response?.status);
-    return exchange;
   },
 });
 
@@ -172,7 +168,6 @@ fetcher.interceptors.error.use({
     } else {
       console.error('Network error:', exchange.error?.message);
     }
-    return exchange;
   },
 });
 
@@ -335,7 +330,7 @@ Interceptor interface that defines the basic structure of interceptors.
 
 **Methods:**
 
-- `intercept(exchange: FetchExchange): FetchExchange | Promise<FetchExchange>` - Intercept and process data
+- `intercept(exchange: FetchExchange): void | Promise<void>` - Intercept and process data
 
 #### InterceptorManager Class
 
@@ -346,7 +341,7 @@ Interceptor manager for managing multiple interceptors of the same type.
 - `use(interceptor: Interceptor): boolean` - Add interceptor, returns whether the addition was successful
 - `eject(name: string): boolean` - Remove interceptor by name, returns whether the removal was successful
 - `clear(): void` - Clear all interceptors
-- `intercept(exchange: FetchExchange): Promise<FetchExchange>` - Execute all interceptors in sequence
+- `intercept(exchange: FetchExchange): Promise<void>` - Execute all interceptors in sequence
 
 #### FetcherInterceptors Class
 

--- a/packages/fetcher/README.zh-CN.md
+++ b/packages/fetcher/README.zh-CN.md
@@ -137,14 +137,11 @@ const success = fetcher.interceptors.request.use({
   name: 'auth-interceptor',
   order: 100,
   intercept(exchange) {
-    return {
-      ...exchange,
-      request: {
-        ...exchange.request,
-        headers: {
-          ...exchange.request.headers,
-          Authorization: 'Bearer ' + getAuthToken(),
-        },
+    exchange.request = {
+      ...exchange.request,
+      headers: {
+        ...exchange.request.headers,
+        Authorization: 'Bearer ' + getAuthToken(),
       },
     };
   },
@@ -156,7 +153,6 @@ fetcher.interceptors.response.use({
   order: 10,
   intercept(exchange) {
     console.log('收到响应:', exchange.response?.status);
-    return exchange;
   },
 });
 
@@ -170,7 +166,6 @@ fetcher.interceptors.error.use({
     } else {
       console.error('网络错误:', exchange.error?.message);
     }
-    return exchange;
   },
 });
 
@@ -333,7 +328,7 @@ string, options ? : FetcherOptions
 
 **方法：**
 
-- `intercept(exchange: FetchExchange): FetchExchange | Promise<FetchExchange>` - 拦截并处理数据
+- `intercept(exchange: FetchExchange): void | Promise<void>` - 拦截并处理数据
 
 #### InterceptorManager 类
 
@@ -344,7 +339,7 @@ string, options ? : FetcherOptions
 - `use(interceptor: Interceptor): boolean` - 添加拦截器，返回是否添加成功
 - `eject(name: string): boolean` - 按名称移除拦截器，返回是否移除成功
 - `clear(): void` - 清除所有拦截器
-- `intercept(exchange: FetchExchange): Promise<FetchExchange>` - 顺序执行所有拦截器
+- `intercept(exchange: FetchExchange): Promise<void>` - 顺序执行所有拦截器
 
 #### FetcherInterceptors 类
 

--- a/packages/fetcher/src/fetchExchange.ts
+++ b/packages/fetcher/src/fetchExchange.ts
@@ -22,18 +22,21 @@ import { FetchRequest } from './fetchRequest';
  * that occur during the HTTP request lifecycle. It also provides a mechanism for
  * sharing data between interceptors through the attributes property.
  *
+ * FetchExchange instances are unique within a single request scope, meaning each HTTP
+ * request creates its own FetchExchange instance that is passed through the interceptor
+ * chain for that specific request.
+ *
  * @example
  * ```typescript
  * // In a request interceptor
  * const requestInterceptor: Interceptor = {
  *   name: 'RequestInterceptor',
  *   order: 0,
- *   async intercept(exchange: FetchExchange): Promise<FetchExchange> {
+ *   intercept(exchange: FetchExchange) {
  *     // Add custom data to share with other interceptors
  *     exchange.attributes = exchange.attributes || {};
  *     exchange.attributes.startTime = Date.now();
  *     exchange.attributes.customHeader = 'my-value';
- *     return exchange;
  *   }
  * };
  *
@@ -41,14 +44,13 @@ import { FetchRequest } from './fetchRequest';
  * const responseInterceptor: Interceptor = {
  *   name: 'ResponseInterceptor',
  *   order: 0,
- *   async intercept(exchange: FetchExchange): Promise<FetchExchange> {
+ *   intercept(exchange: FetchExchange) {
  *     // Access data shared by previous interceptors
  *     if (exchange.attributes && exchange.attributes.startTime) {
  *       const startTime = exchange.attributes.startTime;
  *       const duration = Date.now() - startTime;
  *       console.log(`Request took ${duration}ms`);
  *     }
- *     return exchange;
  *   }
  * };
  * ```

--- a/packages/fetcher/src/fetchInterceptor.ts
+++ b/packages/fetcher/src/fetchInterceptor.ts
@@ -58,7 +58,6 @@ export class FetchInterceptor implements Interceptor {
    * function to send the network request.
    *
    * @param exchange - Exchange object containing request information
-   * @returns Promise<FetchExchange> Processed exchange object containing response information
    *
    * @throws {FetchTimeoutError} Throws timeout exception when request times out
    *
@@ -74,8 +73,7 @@ export class FetchInterceptor implements Interceptor {
    * const result = await fetchInterceptor.intercept(exchange);
    * console.log(result.response); // HTTP response object
    */
-  async intercept(exchange: FetchExchange): Promise<FetchExchange> {
+  async intercept(exchange: FetchExchange) {
     exchange.response = await timeoutFetch(exchange.request);
-    return exchange;
   }
 }

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -71,8 +71,7 @@ export const DEFAULT_OPTIONS: FetcherOptions = {
  * ```
  */
 export class Fetcher
-  implements UrlBuilderCapable, RequestHeadersCapable, TimeoutCapable
-{
+  implements UrlBuilderCapable, RequestHeadersCapable, TimeoutCapable {
   urlBuilder: UrlBuilder;
   headers?: RequestHeaders = DEFAULT_HEADERS;
   timeout?: number;
@@ -153,14 +152,14 @@ export class Fetcher
   async exchange(fetchExchange: FetchExchange): Promise<FetchExchange> {
     try {
       // Apply request interceptors
-      fetchExchange = await this.interceptors.request.intercept(fetchExchange);
+      await this.interceptors.request.intercept(fetchExchange);
       // Apply response interceptors
-      fetchExchange = await this.interceptors.response.intercept(fetchExchange);
+      await this.interceptors.response.intercept(fetchExchange);
       return fetchExchange;
     } catch (error) {
       // Apply error interceptors
       fetchExchange.error = error;
-      fetchExchange = await this.interceptors.error.intercept(fetchExchange);
+      await this.interceptors.error.intercept(fetchExchange);
       if (fetchExchange.response) {
         return fetchExchange;
       }

--- a/packages/fetcher/src/interceptor.ts
+++ b/packages/fetcher/src/interceptor.ts
@@ -30,14 +30,15 @@ import { UrlResolveInterceptor } from './urlResolveInterceptor';
  *
  * @example
  * // Example of a custom request interceptor
- * const loggingInterceptor: Interceptor = {
- *   name: 'LoggingInterceptor',
- *   order: 0,
- *   async intercept(exchange: FetchExchange): Promise<FetchExchange> {
- *     console.log(`Making request to ${exchange.url}`);
- *     const result = await next.intercept(exchange);
- *     console.log(`Received response with status ${result.response?.status}`);
- *     return result;
+ * const customRequestInterceptor: Interceptor = {
+ *   name: 'CustomRequestInterceptor',
+ *   order: 100,
+ *   async intercept(exchange: FetchExchange): Promise<void> {
+ *     // Modify request headers
+ *     exchange.request.headers = {
+ *       ...exchange.request.headers,
+ *       'X-Custom-Header': 'custom-value'
+ *     };
  *   }
  * };
  */
@@ -56,13 +57,13 @@ export interface Interceptor extends NamedCapable, OrderedCapable {
    *
    * This method is called by the InterceptorManager to process the exchange object.
    * The interceptor can modify the request, response, or error properties of the
-   * exchange object and then pass it to the next interceptor in the chain.
+   * exchange object directly.
    *
    * @param exchange - The data to be processed, containing request, response, and error information
    *
    * @remarks
-   * Interceptors should either return the exchange object (possibly modified) or
-   * a new exchange object. They can also throw errors or transform errors into responses.
+   * Interceptors should modify the exchange object directly rather than returning it.
+   * They can also throw errors or transform errors into responses.
    */
   intercept(exchange: FetchExchange): void | Promise<void>;
 }

--- a/packages/fetcher/src/interceptor.ts
+++ b/packages/fetcher/src/interceptor.ts
@@ -59,13 +59,12 @@ export interface Interceptor extends NamedCapable, OrderedCapable {
    * exchange object and then pass it to the next interceptor in the chain.
    *
    * @param exchange - The data to be processed, containing request, response, and error information
-   * @returns The processed data, which can be returned synchronously or asynchronously
    *
    * @remarks
    * Interceptors should either return the exchange object (possibly modified) or
    * a new exchange object. They can also throw errors or transform errors into responses.
    */
-  intercept(exchange: FetchExchange): FetchExchange | Promise<FetchExchange>;
+  intercept(exchange: FetchExchange): void | Promise<void>;
 }
 
 /**
@@ -190,13 +189,11 @@ export class InterceptorManager implements Interceptor {
    * If any interceptor throws an error, the execution chain is broken and the error
    * is propagated to the caller.
    */
-  async intercept(exchange: FetchExchange): Promise<FetchExchange> {
-    let processedExchange = exchange;
+  async intercept(exchange: FetchExchange): Promise<void> {
     for (const interceptor of this.sortedInterceptors) {
       // Each interceptor processes the output of the previous interceptor
-      processedExchange = await interceptor.intercept(processedExchange);
+      await interceptor.intercept(exchange);
     }
-    return processedExchange;
   }
 }
 

--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -81,16 +81,16 @@ export class RequestBodyInterceptor implements Interceptor {
    * // result.request.body will be '{"name":"John","age":30}'
    * // result.request.headers will include 'Content-Type: application/json'
    */
-  intercept(exchange: FetchExchange): FetchExchange {
+  intercept(exchange: FetchExchange) {
     const request = exchange.request;
     // If there's no request body, return unchanged
     if (request.body === undefined || request.body === null) {
-      return exchange;
+      return;
     }
 
     // If request body is not an object, return unchanged
     if (typeof request.body !== 'object') {
-      return exchange;
+      return;
     }
 
     // Check if it's a supported type
@@ -103,7 +103,7 @@ export class RequestBodyInterceptor implements Interceptor {
       request.body instanceof FormData ||
       request.body instanceof ReadableStream
     ) {
-      return exchange;
+      return;
     }
 
     // For plain objects, convert to JSON string
@@ -122,6 +122,5 @@ export class RequestBodyInterceptor implements Interceptor {
       headers['Content-Type'] = ContentTypeValues.APPLICATION_JSON;
     }
     exchange.request = modifiedRequest;
-    return exchange;
   }
 }

--- a/packages/fetcher/src/timeout.ts
+++ b/packages/fetcher/src/timeout.ts
@@ -96,7 +96,6 @@ export class FetchTimeoutError extends Error {
  * it returns the result or throws an exception.
  *
  * @param request - The request initialization options
- * @param timeout - Optional timeout in milliseconds
  * @returns Promise<Response> HTTP response Promise
  * @throws FetchTimeoutError Thrown when the request times out
  *

--- a/packages/fetcher/src/urlResolveInterceptor.ts
+++ b/packages/fetcher/src/urlResolveInterceptor.ts
@@ -56,9 +56,8 @@ export class UrlResolveInterceptor implements Interceptor {
    * @param exchange - The fetch exchange containing the request information
    * @returns The modified exchange with the resolved URL
    */
-  intercept(exchange: FetchExchange): FetchExchange {
+  intercept(exchange: FetchExchange) {
     const request = exchange.request;
     request.url = exchange.fetcher.urlBuilder.resolveRequestUrl(request);
-    return exchange;
   }
 }

--- a/packages/fetcher/test/fetcher-exchange.test.ts
+++ b/packages/fetcher/test/fetcher-exchange.test.ts
@@ -35,23 +35,21 @@ describe('Fetcher - exchange', () => {
     const requestInterceptor: Interceptor = {
       name: 'RequestInterceptor',
       order: 0,
-      async intercept(exchange: FetchExchange): Promise<FetchExchange> {
+      async intercept(exchange: FetchExchange): Promise<void> {
         // Modify the exchange in the request interceptor
         exchange.attributes = exchange.attributes || {};
         exchange.attributes.requestModified = true;
-        return exchange;
       },
     };
 
     const responseInterceptor: Interceptor = {
       name: 'ResponseInterceptor',
       order: 0,
-      async intercept(exchange: FetchExchange): Promise<FetchExchange> {
+      async intercept(exchange: FetchExchange): Promise<void> {
         // Create a mock response
         exchange.response = new Response('OK');
         exchange.attributes = exchange.attributes || {};
         exchange.attributes.responseModified = true;
-        return exchange;
       },
     };
 
@@ -92,7 +90,7 @@ describe('Fetcher - exchange', () => {
     const requestInterceptor: Interceptor = {
       name: 'RequestInterceptor',
       order: 0,
-      async intercept(_exchange: FetchExchange): Promise<FetchExchange> {
+      async intercept(_exchange: FetchExchange): Promise<void> {
         // Throw an error to trigger error interceptor
         throw new Error('Request failed');
       },
@@ -101,10 +99,9 @@ describe('Fetcher - exchange', () => {
     const errorInterceptor: Interceptor = {
       name: 'ErrorInterceptor',
       order: 0,
-      async intercept(exchange: FetchExchange): Promise<FetchExchange> {
+      async intercept(exchange: FetchExchange): Promise<void> {
         // Handle the error and create a response
         exchange.response = new Response('Error handled', { status: 500 });
-        return exchange;
       },
     };
 
@@ -144,7 +141,7 @@ describe('Fetcher - exchange', () => {
       name: 'RequestInterceptor',
       order: 0,
       //@typescript-eslint/no-unused-vars
-      async intercept(_exchange: FetchExchange): Promise<FetchExchange> {
+      async intercept(_exchange: FetchExchange): Promise<void> {
         // Throw an error to trigger error interceptor
         throw new Error('Request failed');
       },
@@ -153,7 +150,7 @@ describe('Fetcher - exchange', () => {
     const errorInterceptor: Interceptor = {
       name: 'ErrorInterceptor',
       order: 0,
-      async intercept(exchange: FetchExchange): Promise<FetchExchange> {
+      async intercept(exchange: FetchExchange): Promise<void> {
         // Just rethrow the error without creating a response
         throw exchange.error;
       },

--- a/packages/fetcher/test/fetcher-interceptor.test.ts
+++ b/packages/fetcher/test/fetcher-interceptor.test.ts
@@ -36,14 +36,11 @@ describe('Fetcher Interceptors', () => {
       name: 'request-interceptor-1',
       order: 0,
       intercept: vi.fn((exchange: FetchExchange) => {
-        return {
-          ...exchange,
-          request: {
-            ...exchange.request,
-            headers: {
-              ...exchange.request.headers,
-              'X-Test-Header': 'test-value',
-            },
+        exchange.request = {
+          ...exchange.request,
+          headers: {
+            ...exchange.request.headers,
+            'X-Test-Header': 'test-value',
           },
         };
       }),
@@ -78,7 +75,6 @@ describe('Fetcher Interceptors', () => {
             writable: false,
           });
         }
-        return exchange;
       }),
     };
 
@@ -103,7 +99,6 @@ describe('Fetcher Interceptors', () => {
       order: 0,
       intercept: vi.fn(async (exchange: FetchExchange) => {
         exchange.error = new Error(`Intercepted: ${exchange.error?.message}`);
-        return exchange;
       }),
     };
 
@@ -124,14 +119,11 @@ describe('Fetcher Interceptors', () => {
       name: 'multi-request-interceptor-1',
       order: 0,
       intercept: vi.fn((exchange: FetchExchange) => {
-        return {
-          ...exchange,
-          request: {
-            ...exchange.request,
-            headers: {
-              ...exchange.request.headers,
-              'X-Interceptor-1': 'value-1',
-            },
+        exchange.request = {
+          ...exchange.request,
+          headers: {
+            ...exchange.request.headers,
+            'X-Interceptor-1': 'value-1',
           },
         };
       }),
@@ -141,14 +133,11 @@ describe('Fetcher Interceptors', () => {
       name: 'multi-request-interceptor-2',
       order: 0,
       intercept: vi.fn((exchange: FetchExchange) => {
-        return {
-          ...exchange,
-          request: {
-            ...exchange.request,
-            headers: {
-              ...exchange.request.headers,
-              'X-Interceptor-2': 'value-2',
-            },
+        exchange.request = {
+          ...exchange.request,
+          headers: {
+            ...exchange.request.headers,
+            'X-Interceptor-2': 'value-2',
           },
         };
       }),
@@ -178,17 +167,14 @@ describe('Fetcher Interceptors', () => {
     const asyncInterceptor: Interceptor = {
       name: 'async-interceptor-1',
       order: 0,
-      intercept: vi.fn((exchange: FetchExchange) => {
-        return Promise.resolve({
-          ...exchange,
-          request: {
-            ...exchange.request,
-            headers: {
-              ...exchange.request.headers,
-              'X-Async-Header': 'async-value',
-            },
+      intercept: vi.fn(async (exchange: FetchExchange) => {
+        exchange.request = {
+          ...exchange.request,
+          headers: {
+            ...exchange.request.headers,
+            'X-Async-Header': 'async-value',
           },
-        });
+        };
       }),
     };
 
@@ -214,14 +200,11 @@ describe('Fetcher Interceptors', () => {
       name: 'ejected-interceptor-1',
       order: 0,
       intercept: vi.fn((exchange: FetchExchange) => {
-        return {
-          ...exchange,
-          request: {
-            ...exchange.request,
-            headers: {
-              ...exchange.request.headers,
-              'X-Ejected-Header': 'ejected-value',
-            },
+        exchange.request = {
+          ...exchange.request,
+          headers: {
+            ...exchange.request.headers,
+            'X-Ejected-Header': 'ejected-value',
           },
         };
       }),
@@ -256,7 +239,6 @@ describe('Fetcher Interceptors', () => {
         exchange.response = new Response('Error handled by interceptor', {
           status: 200,
         });
-        return exchange;
       }),
     };
 
@@ -284,16 +266,14 @@ describe('Fetcher Interceptors', () => {
       order: 0,
       intercept: vi.fn((exchange: FetchExchange) => {
         calls.push('interceptor1');
-        return exchange;
       }),
     });
 
     fetcher.interceptors.request.use({
       name: 'order-test-interceptor-2',
       order: 0,
-      intercept: vi.fn((exchange: FetchExchange) => {
+      intercept: vi.fn((_exchange: FetchExchange) => {
         calls.push('interceptor2');
-        return exchange;
       }),
     });
 

--- a/packages/fetcher/test/interceptor.test.ts
+++ b/packages/fetcher/test/interceptor.test.ts
@@ -13,14 +13,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  Fetcher,
-  FetcherInterceptors,
-  FetchExchange,
-  HttpMethod,
-  Interceptor,
-  InterceptorManager,
-} from '../src';
+import { Fetcher, FetcherInterceptors, FetchExchange, HttpMethod, Interceptor, InterceptorManager } from '../src';
 
 describe('interceptor.ts', () => {
   describe('InterceptorManager', () => {
@@ -124,9 +117,9 @@ describe('interceptor.ts', () => {
         attributes: {},
       };
 
-      const result = await manager.intercept(mockExchange);
+      await manager.intercept(mockExchange);
 
-      expect(result).toBe(mockExchange);
+      expect(mockExchange).toBe(mockExchange);
       expect(interceptor1.intercept).toHaveBeenCalledWith(mockExchange);
       expect(interceptor2.intercept).toHaveBeenCalledWith(mockExchange);
     });
@@ -158,9 +151,9 @@ describe('interceptor.ts', () => {
         attributes: {},
       };
 
-      const result = await manager.intercept(mockExchange);
+      await manager.intercept(mockExchange);
 
-      expect(result).toBe(mockExchange);
+      expect(mockExchange).toBe(mockExchange);
       expect(interceptor1.intercept).not.toHaveBeenCalled();
       expect(interceptor2.intercept).toHaveBeenCalledWith(mockExchange);
     });
@@ -192,9 +185,9 @@ describe('interceptor.ts', () => {
         attributes: {},
       };
 
-      const result = await manager.intercept(mockExchange);
+      await manager.intercept(mockExchange);
 
-      expect(result).toBe(mockExchange);
+      expect(mockExchange).toBe(mockExchange);
       expect(interceptor1.intercept).not.toHaveBeenCalled();
       expect(interceptor2.intercept).not.toHaveBeenCalled();
     });
@@ -206,12 +199,9 @@ describe('interceptor.ts', () => {
         intercept: vi.fn(async exchange => {
           // Simulate async operation
           await new Promise(resolve => setTimeout(resolve, 10));
-          return {
-            ...exchange,
-            attributes: {
-              ...exchange.attributes,
-              processed: true,
-            },
+          exchange.attributes = {
+            ...exchange.attributes,
+            processed: true,
           };
         }),
       };
@@ -229,9 +219,9 @@ describe('interceptor.ts', () => {
         attributes: {},
       };
 
-      const result = await manager.intercept(mockExchange);
+      await manager.intercept(mockExchange);
 
-      expect(result.attributes?.processed).toBe(true);
+      expect(mockExchange.attributes?.processed).toBe(true);
       expect(asyncInterceptor.intercept).toHaveBeenCalledWith(mockExchange);
     });
 
@@ -354,23 +344,21 @@ describe('interceptor.ts', () => {
       const requestInterceptor: Interceptor = {
         name: 'request-interceptor-1',
         order: 0,
-        intercept: vi.fn(exchange => ({
-          ...exchange,
-          request: {
+        intercept: vi.fn(exchange => {
+          exchange.request = {
             ...exchange.request,
             headers: {
               ...exchange.request.headers,
               Authorization: 'Bearer token',
             },
-          },
-        })),
+          };
+        }),
       };
 
       interceptors.request.use(requestInterceptor);
-      const processedExchange =
-        await interceptors.request.intercept(mockExchange);
+      await interceptors.request.intercept(mockExchange);
 
-      expect(processedExchange.request.headers).toHaveProperty(
+      expect(mockExchange.request.headers).toHaveProperty(
         'Authorization',
         'Bearer token',
       );
@@ -410,13 +398,10 @@ describe('interceptor.ts', () => {
       };
 
       interceptors.response.use(responseInterceptor);
-      const processedExchange =
-        await interceptors.response.intercept(mockExchange);
+      await interceptors.response.intercept(mockExchange);
 
-      expect(processedExchange.response).toBe(response);
-      expect((processedExchange.response as any).customHeader).toBe(
-        'intercepted',
-      );
+      expect(mockExchange.response).toBe(response);
+      expect((mockExchange.response as any).customHeader).toBe('intercepted');
       expect(responseInterceptor.intercept).toHaveBeenCalledWith(mockExchange);
     });
 
@@ -444,12 +429,9 @@ describe('interceptor.ts', () => {
       };
 
       interceptors.error.use(errorInterceptor);
-      const processedExchange =
-        await interceptors.error.intercept(mockExchange);
+      await interceptors.error.intercept(mockExchange);
 
-      expect(processedExchange.error?.message).toBe(
-        'Intercepted: Network error',
-      );
+      expect(mockExchange.error?.message).toBe('Intercepted: Network error');
       expect(errorInterceptor.intercept).toHaveBeenCalledWith(mockExchange);
     });
   });

--- a/packages/fetcher/test/requestBodyInterceptor.test.ts
+++ b/packages/fetcher/test/requestBodyInterceptor.test.ts
@@ -35,8 +35,8 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBeUndefined();
   });
 
   it('should not modify request with null body', () => {
@@ -52,8 +52,8 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBeNull();
   });
 
   it('should not modify request with string body', () => {
@@ -69,8 +69,8 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe('plain text');
   });
 
   it('should not modify request with number body', () => {
@@ -86,8 +86,8 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(42);
   });
 
   it('should not modify request with boolean body', () => {
@@ -103,8 +103,8 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(true);
   });
 
   it('should not modify request with ArrayBuffer body', () => {
@@ -121,8 +121,8 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(arrayBuffer);
   });
 
   it('should not modify request with Blob body', () => {
@@ -139,8 +139,8 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(blob);
   });
 
   it('should not modify request with FormData body', () => {
@@ -151,33 +151,34 @@ describe('RequestBodyInterceptor', () => {
       request: {
         url: 'http://example.com',
         method: 'POST',
-        body: formData,
+        body: formData as any,
       },
       response: undefined,
       error: undefined,
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(formData);
   });
 
   it('should not modify request with URLSearchParams body', () => {
-    const params = new URLSearchParams({ key: 'value' });
+    const urlSearchParams = new URLSearchParams();
+    urlSearchParams.append('key', 'value');
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
       request: {
         url: 'http://example.com',
         method: 'POST',
-        body: params,
+        body: urlSearchParams as any,
       },
       response: undefined,
       error: undefined,
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(urlSearchParams);
   });
 
   it('should not modify request with ReadableStream body', () => {
@@ -194,12 +195,12 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(stream);
   });
 
   it('should not modify request with File body', () => {
-    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+    const file = new File(['hello'], 'test.txt', { type: 'text/plain' });
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
       request: {
@@ -212,13 +213,13 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(file);
   });
 
   it('should not modify request with DataView body', () => {
-    const buffer = new ArrayBuffer(16);
-    const dataView = new DataView(buffer);
+    const arrayBuffer = new ArrayBuffer(16);
+    const dataView = new DataView(arrayBuffer);
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
       request: {
@@ -231,26 +232,26 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(dataView);
   });
 
   it('should not modify request with TypedArray body', () => {
-    const uint8Array = new Uint8Array([1, 2, 3]);
+    const typedArray = new Uint8Array([1, 2, 3]);
     const exchange: FetchExchange = {
       fetcher: mockFetcher,
       request: {
         url: 'http://example.com',
         method: 'POST',
-        body: uint8Array as any,
+        body: typedArray as any,
       },
       response: undefined,
       error: undefined,
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange);
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(typedArray);
   });
 
   it('should convert plain object to JSON string and set Content-Type header', () => {
@@ -267,12 +268,12 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange); // Should return the same object (modified in place)
-    expect(result.request.body).toBe(JSON.stringify(requestBody));
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers!;
+    const headers = exchange.request.headers!;
     expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
@@ -293,12 +294,12 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange); // Should return the same object (modified in place)
-    expect(result.request.body).toBe(JSON.stringify(requestBody));
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that existing Content-Type header is preserved
-    const headers = result.request.headers!;
+    const headers = exchange.request.headers!;
     expect(headers['Content-Type']).toBe('text/plain');
   });
 
@@ -316,12 +317,12 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange); // Should return the same object (modified in place)
-    expect(result.request.body).toBe(JSON.stringify(requestBody));
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers!;
+    const headers = exchange.request.headers!;
     expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
@@ -347,12 +348,12 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange); // Should return the same object (modified in place)
-    expect(result.request.body).toBe(JSON.stringify(requestBody));
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers!;
+    const headers = exchange.request.headers!;
     expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
@@ -370,12 +371,12 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange); // Should return the same object (modified in place)
-    expect(result.request.body).toBe(JSON.stringify(requestBody));
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers!;
+    const headers = exchange.request.headers!;
     expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 
@@ -394,12 +395,12 @@ describe('RequestBodyInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
-    expect(result).toBe(exchange); // Should return the same object (modified in place)
-    expect(result.request.body).toBe(JSON.stringify(requestBody));
+    interceptor.intercept(exchange);
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
+    expect(exchange.request.body).toBe(JSON.stringify(requestBody));
 
     // Check that Content-Type header is set
-    const headers = result.request.headers!;
+    const headers = exchange.request.headers!;
     expect(headers['Content-Type']).toBe(ContentTypeValues.APPLICATION_JSON);
   });
 });

--- a/packages/fetcher/test/urlResolveInterceptor.test.ts
+++ b/packages/fetcher/test/urlResolveInterceptor.test.ts
@@ -37,9 +37,9 @@ describe('UrlResolveInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(result.request.url).toBe(
+    expect(exchange.request.url).toBe(
       'https://api.example.com/users/123?filter=active',
     );
   });
@@ -59,9 +59,9 @@ describe('UrlResolveInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(result.request.url).toBe('https://api.example.com/users');
+    expect(exchange.request.url).toBe('https://api.example.com/users');
   });
 
   it('should resolve URL with only path parameters', () => {
@@ -80,9 +80,9 @@ describe('UrlResolveInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(result.request.url).toBe(
+    expect(exchange.request.url).toBe(
       'https://api.example.com/users/123/posts/456',
     );
   });
@@ -99,7 +99,6 @@ describe('UrlResolveInterceptor', () => {
         urlParams: {
           query: {
             filter: 'active',
-            limit: 10,
           },
         },
       },
@@ -108,10 +107,10 @@ describe('UrlResolveInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
-    expect(result.request.url).toBe(
-      'https://api.example.com/users?filter=active&limit=10',
+    expect(exchange.request.url).toBe(
+      'https://api.example.com/users?filter=active',
     );
   });
 
@@ -136,11 +135,11 @@ describe('UrlResolveInterceptor', () => {
       attributes: {},
     };
 
-    const result = interceptor.intercept(exchange);
+    interceptor.intercept(exchange);
 
     // Check that the URL contains the expected parameters
-    expect(result.request.url).toContain('https://api.example.com/users');
-    expect(result.request.url).toContain('tags=important');
-    expect(result.request.url).toContain('status=active');
+    expect(exchange.request.url).toContain('https://api.example.com/users');
+    expect(exchange.request.url).toContain('tags=important');
+    expect(exchange.request.url).toContain('status=active');
   });
 });


### PR DESCRIPTION
- Update interceptor functions to return void instead of FetchExchange
- Modify Fetcher.exchange method to not expect a return value from interceptors
- Remove unnecessary return statements and type annotations in interceptors