### PR TITLE
refactor(fetcher): make interceptor properties readonly

### DIFF
--- a/packages/cosec/src/cosecRequestInterceptor.ts
+++ b/packages/cosec/src/cosecRequestInterceptor.ts
@@ -31,8 +31,8 @@ import { idGenerator } from './idGenerator';
  * while ensuring it runs before FetchInterceptor.
  */
 export class CoSecRequestInterceptor implements Interceptor {
-  name = 'CoSecRequestInterceptor';
-  order = Number.MIN_SAFE_INTEGER + 1000;
+  readonly name = 'CoSecRequestInterceptor';
+  readonly order = Number.MIN_SAFE_INTEGER + 1000;
   private options: CoSecOptions;
 
   constructor(options: CoSecOptions) {

--- a/packages/cosec/src/cosecResponseInterceptor.ts
+++ b/packages/cosec/src/cosecResponseInterceptor.ts
@@ -25,8 +25,8 @@ import { FetchExchange, Interceptor } from '@ahoo-wang/fetcher';
  * response enhancement interceptors like EventStreamInterceptor.
  */
 export class CoSecResponseInterceptor implements Interceptor {
-  name = 'CoSecResponseInterceptor';
-  order = Number.MAX_SAFE_INTEGER - 100;
+  readonly name = 'CoSecResponseInterceptor';
+  readonly order = Number.MAX_SAFE_INTEGER - 100;
   private options: CoSecOptions;
 
   constructor(options: CoSecOptions) {

--- a/packages/eventstream/src/eventStreamInterceptor.ts
+++ b/packages/eventstream/src/eventStreamInterceptor.ts
@@ -12,12 +12,7 @@
  */
 
 import { toServerSentEventStream } from './eventStreamConverter';
-import {
-  ContentTypeHeader,
-  ContentTypeValues,
-  FetchExchange,
-  Interceptor,
-} from '@ahoo-wang/fetcher';
+import { ContentTypeHeader, ContentTypeValues, FetchExchange, Interceptor } from '@ahoo-wang/fetcher';
 
 /**
  * Interceptor that enhances Response objects with event stream capabilities.
@@ -46,8 +41,8 @@ import {
  * ```
  */
 export class EventStreamInterceptor implements Interceptor {
-  name = 'EventStreamInterceptor';
-  order = Number.MAX_SAFE_INTEGER - 100;
+  readonly name = 'EventStreamInterceptor';
+  readonly order = Number.MAX_SAFE_INTEGER - 100;
 
   intercept(exchange: FetchExchange) {
     // Check if the response is an event stream

--- a/packages/fetcher/src/fetchInterceptor.ts
+++ b/packages/fetcher/src/fetchInterceptor.ts
@@ -35,7 +35,7 @@ export class FetchInterceptor implements Interceptor {
    * Each interceptor must have a unique name for identification and manipulation
    * within the interceptor manager.
    */
-  name = 'FetchInterceptor';
+  readonly name = 'FetchInterceptor';
 
   /**
    * Interceptor execution order, set to near maximum safe integer to ensure last execution.
@@ -46,7 +46,7 @@ export class FetchInterceptor implements Interceptor {
    * completed before the actual network request is made, while still allowing
    * other interceptors to run after it if needed.
    */
-  order = Number.MAX_SAFE_INTEGER - 100;
+  readonly order = Number.MAX_SAFE_INTEGER - 100;
 
   /**
    * Intercept and process HTTP requests.

--- a/packages/fetcher/src/interceptor.ts
+++ b/packages/fetcher/src/interceptor.ts
@@ -46,7 +46,15 @@ export interface Interceptor extends NamedCapable, OrderedCapable {
    * Used by InterceptorManager to manage interceptors, including adding, removing,
    * and preventing duplicates. Each interceptor must have a unique name.
    */
-  name: string;
+  readonly name: string;
+
+  /**
+   * Interceptor method that modifies the request or response.
+   *
+   * @param exchange - The current exchange object, which contains the request and response.
+   * @returns A promise that resolves to the modified exchange object.
+   */
+  readonly order: number;
 
   /**
    * Process the exchange object in the interceptor pipeline.

--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -26,7 +26,7 @@ export class RequestBodyInterceptor implements Interceptor {
   /**
    * Interceptor name, used for identification and management.
    */
-  name = 'RequestBodyInterceptor';
+  readonly name = 'RequestBodyInterceptor';
 
   /**
    * Interceptor execution order, set to run after UrlResolveInterceptor but before FetchInterceptor.
@@ -37,7 +37,7 @@ export class RequestBodyInterceptor implements Interceptor {
    * in the interceptor chain, allowing for other interceptors to run between URL resolution
    * and request body processing.
    */
-  order = Number.MIN_SAFE_INTEGER + 200;
+  readonly order = Number.MIN_SAFE_INTEGER + 200;
 
   /**
    * Attempts to convert request body to a valid fetch API body type.

--- a/packages/fetcher/src/urlResolveInterceptor.ts
+++ b/packages/fetcher/src/urlResolveInterceptor.ts
@@ -33,7 +33,7 @@ export class UrlResolveInterceptor implements Interceptor {
   /**
    * The name of this interceptor.
    */
-  name = 'UrlResolveInterceptor';
+  readonly name = 'UrlResolveInterceptor';
 
   /**
    * The order of this interceptor (executed first).
@@ -43,7 +43,7 @@ export class UrlResolveInterceptor implements Interceptor {
    * Number.MIN_SAFE_INTEGER + 100 to allow for other interceptors that need to run
    * even earlier while still maintaining a high priority.
    */
-  order = Number.MIN_SAFE_INTEGER + 100;
+  readonly order = Number.MIN_SAFE_INTEGER + 100;
 
   /**
    * Resolves the final URL by combining the base URL, path parameters, and query parameters.


### PR DESCRIPTION
- Update interceptor classes to use readonly keyword for name and order properties
- Improve type safety and prevent unintended modifications
- Affected files:
  - cosecRequestInterceptor.ts
  - cosecResponseInterceptor.ts
  - eventStreamInterceptor.ts
  - fetchInterceptor.ts
  - interceptor.ts
  - requestBodyInterceptor.ts
  - urlResolveInterceptor.ts