### PR TITLE
refactor(fetcher): rename FetcherInterceptors to InterceptorManager

### DIFF
--- a/packages/fetcher/README.md
+++ b/packages/fetcher/README.md
@@ -333,7 +333,7 @@ Interceptor interface that defines the basic structure of interceptors.
 
 - `intercept(exchange: FetchExchange): void | Promise<void>` - Intercept and process data
 
-#### InterceptorManager Class
+#### InterceptorRegistry Class
 
 Interceptor manager for managing multiple interceptors of the same type.
 
@@ -344,7 +344,7 @@ Interceptor manager for managing multiple interceptors of the same type.
 - `clear(): void` - Clear all interceptors
 - `intercept(exchange: FetchExchange): Promise<void>` - Execute all interceptors in sequence
 
-#### FetcherInterceptors Class
+#### InterceptorManager Class
 
 Fetcher interceptor collection, including request, response, and error interceptor managers.
 

--- a/packages/fetcher/README.zh-CN.md
+++ b/packages/fetcher/README.zh-CN.md
@@ -330,7 +330,7 @@ string, options ? : FetcherOptions
 
 - `intercept(exchange: FetchExchange): void | Promise<void>` - 拦截并处理数据
 
-#### InterceptorManager 类
+#### InterceptorRegistry 类
 
 用于管理同一类型多个拦截器的拦截器管理器。
 
@@ -341,7 +341,7 @@ string, options ? : FetcherOptions
 - `clear(): void` - 清除所有拦截器
 - `intercept(exchange: FetchExchange): Promise<void>` - 顺序执行所有拦截器
 
-#### FetcherInterceptors 类
+#### InterceptorManager 类
 
 Fetcher 拦截器集合，包括请求、响应和错误拦截器管理器。
 

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -25,7 +25,7 @@ import {
 } from './fetchRequest';
 import { mergeRecords } from './utils';
 import { FetchError } from './fetcherError';
-import { FetcherInterceptors } from './fetcherInterceptors';
+import { InterceptorManager } from './interceptorManager';
 
 /**
  * Configuration options for the Fetcher client.
@@ -39,7 +39,7 @@ import { FetcherInterceptors } from './fetcherInterceptors';
  *   baseURL: 'https://api.example.com',
  *   headers: { 'Content-Type': 'application/json' },
  *   timeout: 5000,
- *   interceptors: new FetcherInterceptors()
+ *   interceptors: new InterceptorManager()
  * };
  * ```
  */
@@ -47,7 +47,7 @@ export interface FetcherOptions
   extends BaseURLCapable,
     RequestHeadersCapable,
     TimeoutCapable {
-  interceptors?: FetcherInterceptors;
+  interceptors?: InterceptorManager;
 }
 
 const DEFAULT_HEADERS: RequestHeaders = {
@@ -84,7 +84,7 @@ export class Fetcher
   urlBuilder: UrlBuilder;
   headers?: RequestHeaders = DEFAULT_HEADERS;
   timeout?: number;
-  interceptors: FetcherInterceptors;
+  interceptors: InterceptorManager;
 
   /**
    * Initializes a new Fetcher instance with optional configuration.
@@ -98,7 +98,7 @@ export class Fetcher
     this.urlBuilder = new UrlBuilder(options.baseURL);
     this.headers = options.headers ?? DEFAULT_HEADERS;
     this.timeout = options.timeout;
-    this.interceptors = options.interceptors ?? new FetcherInterceptors();
+    this.interceptors = options.interceptors ?? new InterceptorManager();
   }
 
   /**

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -13,7 +13,7 @@
 
 export * from './fetcher';
 export * from './fetcherError';
-export * from './fetcherInterceptors';
+export * from './interceptorManager';
 export * from './fetcherRegistrar';
 export * from './fetchExchange';
 export * from './fetchInterceptor';

--- a/packages/fetcher/src/interceptorManager.ts
+++ b/packages/fetcher/src/interceptorManager.ts
@@ -41,7 +41,7 @@ import { InterceptorRegistry } from './interceptor';
  * 2. RequestBodyInterceptor - Automatically converts object-type request bodies to JSON strings
  * 3. FetchInterceptor - Executes actual HTTP requests and handles timeouts
  */
-export class FetcherInterceptors {
+export class InterceptorManager {
   /**
    * Manager for request-phase interceptors.
    *

--- a/packages/fetcher/test/fetcher-exchange.test.ts
+++ b/packages/fetcher/test/fetcher-exchange.test.ts
@@ -18,7 +18,7 @@ import { Fetcher, FetchExchange, Interceptor, InterceptorRegistry, } from '../sr
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
 
-describe('FetcherInterceptors - exchange', () => {
+describe('InterceptorManager - exchange', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     mockFetch.mockClear();

--- a/packages/fetcher/test/fetcherInterceptors.test.ts
+++ b/packages/fetcher/test/fetcherInterceptors.test.ts
@@ -12,11 +12,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { FetcherInterceptors, FetchInterceptor, RequestBodyInterceptor, UrlResolveInterceptor } from '../src';
+import { FetchInterceptor, InterceptorManager, RequestBodyInterceptor, UrlResolveInterceptor, } from '../src';
 
-describe('FetcherInterceptors', () => {
-  it('should create FetcherInterceptors with default interceptors', () => {
-    const interceptors = new FetcherInterceptors();
+describe('InterceptorManager', () => {
+  it('should create InterceptorManager with default interceptors', () => {
+    const interceptors = new InterceptorManager();
 
     expect(interceptors).toBeDefined();
     expect(interceptors.request).toBeDefined();
@@ -25,7 +25,7 @@ describe('FetcherInterceptors', () => {
   });
 
   it('should have UrlResolveInterceptor in request interceptors', () => {
-    const interceptors = new FetcherInterceptors();
+    const interceptors = new InterceptorManager();
 
     // Check that UrlResolveInterceptor is in the request interceptors
     const requestInterceptors = (interceptors.request as any)
@@ -39,7 +39,7 @@ describe('FetcherInterceptors', () => {
   });
 
   it('should have RequestBodyInterceptor in request interceptors', () => {
-    const interceptors = new FetcherInterceptors();
+    const interceptors = new InterceptorManager();
 
     // Check that RequestBodyInterceptor is in the request interceptors
     const requestInterceptors = (interceptors.request as any)
@@ -53,7 +53,7 @@ describe('FetcherInterceptors', () => {
   });
 
   it('should have FetchInterceptor in request interceptors', () => {
-    const interceptors = new FetcherInterceptors();
+    const interceptors = new InterceptorManager();
 
     // Check that FetchInterceptor is in the request interceptors
     const requestInterceptors = (interceptors.request as any)
@@ -67,7 +67,7 @@ describe('FetcherInterceptors', () => {
   });
 
   it('should have correct order of default request interceptors', () => {
-    const interceptors = new FetcherInterceptors();
+    const interceptors = new InterceptorManager();
 
     const requestInterceptors = (interceptors.request as any)
       .sortedInterceptors;
@@ -84,7 +84,7 @@ describe('FetcherInterceptors', () => {
   });
 
   it('should start with empty response and error interceptors', () => {
-    const interceptors = new FetcherInterceptors();
+    const interceptors = new InterceptorManager();
 
     const responseInterceptors = (interceptors.response as any)
       .sortedInterceptors;

--- a/packages/fetcher/test/interceptor.test.ts
+++ b/packages/fetcher/test/interceptor.test.ts
@@ -13,7 +13,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Fetcher, FetcherInterceptors, FetchExchange, HttpMethod, Interceptor, InterceptorRegistry, } from '../src';
+import { Fetcher, FetchExchange, HttpMethod, Interceptor, InterceptorManager, InterceptorRegistry, } from '../src';
 
 describe('interceptor.ts', () => {
   describe('InterceptorRegistry', () => {
@@ -238,9 +238,9 @@ describe('interceptor.ts', () => {
     });
   });
 
-  describe('FetcherInterceptors', () => {
+  describe('InterceptorManager', () => {
     it('should create interceptor managers for request, response and error', () => {
-      const interceptors = new FetcherInterceptors();
+      const interceptors = new InterceptorManager();
 
       expect(interceptors.request).toBeInstanceOf(InterceptorRegistry);
       expect(interceptors.response).toBeInstanceOf(InterceptorRegistry);
@@ -248,7 +248,7 @@ describe('interceptor.ts', () => {
     });
 
     it('should allow adding request interceptors', () => {
-      const interceptors = new FetcherInterceptors();
+      const interceptors = new InterceptorManager();
       const requestInterceptor: Interceptor = {
         name: 'request-interceptor',
         order: 0,
@@ -260,7 +260,7 @@ describe('interceptor.ts', () => {
     });
 
     it('should allow adding response interceptors', () => {
-      const interceptors = new FetcherInterceptors();
+      const interceptors = new InterceptorManager();
       const responseInterceptor: Interceptor = {
         name: 'response-interceptor',
         order: 0,
@@ -272,7 +272,7 @@ describe('interceptor.ts', () => {
     });
 
     it('should allow adding error interceptors', () => {
-      const interceptors = new FetcherInterceptors();
+      const interceptors = new InterceptorManager();
       const errorInterceptor: Interceptor = {
         name: 'error-interceptor',
         order: 0,

--- a/packages/fetcher/test/interceptorManager.test.ts
+++ b/packages/fetcher/test/interceptorManager.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Fetcher, FetcherInterceptors, FetchExchange, HttpMethod, Interceptor, InterceptorRegistry, } from '../src';
+import { Fetcher, FetchExchange, HttpMethod, Interceptor, InterceptorManager, InterceptorRegistry, } from '../src';
 
 // Mock fetch
 const mockFetch = vi.fn();
@@ -251,9 +251,9 @@ describe('InterceptorRegistry', () => {
     });
   });
 
-  describe('FetcherInterceptors', () => {
+  describe('InterceptorManager', () => {
     it('should create interceptor managers for request, response and error', () => {
-      const interceptors = new FetcherInterceptors();
+      const interceptors = new InterceptorManager();
 
       expect(interceptors.request).toBeInstanceOf(InterceptorRegistry);
       expect(interceptors.response).toBeInstanceOf(InterceptorRegistry);
@@ -261,7 +261,7 @@ describe('InterceptorRegistry', () => {
     });
 
     it('should allow adding request interceptors', () => {
-      const interceptors = new FetcherInterceptors();
+      const interceptors = new InterceptorManager();
       const requestInterceptor: Interceptor = {
         name: 'request-interceptor',
         order: 0,
@@ -273,7 +273,7 @@ describe('InterceptorRegistry', () => {
     });
 
     it('should allow adding response interceptors', () => {
-      const interceptors = new FetcherInterceptors();
+      const interceptors = new InterceptorManager();
       const responseInterceptor: Interceptor = {
         name: 'response-interceptor',
         order: 0,
@@ -285,7 +285,7 @@ describe('InterceptorRegistry', () => {
     });
 
     it('should allow adding error interceptors', () => {
-      const interceptors = new FetcherInterceptors();
+      const interceptors = new InterceptorManager();
       const errorInterceptor: Interceptor = {
         name: 'error-interceptor',
         order: 0,


### PR DESCRIPTION
- Rename FetcherInterceptors class to InterceptorManager
- Update related imports and references across the codebase
- Modify test files to use the new InterceptorManager name
- Update README files to reflect the new class name