### PR TITLE
refactor(fetcher): move ExchangeError to interceptorManager

### DIFF
--- a/packages/fetcher/src/fetcherError.ts
+++ b/packages/fetcher/src/fetcherError.ts
@@ -60,44 +60,6 @@ export class FetcherError extends Error {
   }
 }
 
-/**
- * Custom error class for FetchExchange related errors.
- *
- * This error is thrown when there are issues with the HTTP exchange process,
- * such as when a request fails and no response is generated. It provides
- * comprehensive information about the failed request through the exchange object.
- *
- * @example
- * ```typescript
- * try {
- *   await fetcher.get('/api/users');
- * } catch (error) {
- *   if (error instanceof ExchangeError) {
- *     console.log('Request URL:', error.exchange.request.url);
- *     console.log('Request method:', error.exchange.request.method);
- *     if (error.exchange.error) {
- *       console.log('Underlying error:', error.exchange.error);
- *     }
- *   }
- * }
- * ```
- */
-export class ExchangeError extends FetcherError {
-  /**
-   * Creates a new ExchangeError instance.
-   *
-   * @param exchange - The FetchExchange object containing request/response/error information.
-   */
-  constructor(public readonly exchange: FetchExchange) {
-    const errorMessage =
-      exchange.error?.message ||
-      exchange.response?.statusText ||
-      `Request to ${exchange.request.url} failed during exchange`;
-    super(errorMessage, exchange.error);
-    this.name = 'ExchangeError';
-    Object.setPrototypeOf(this, ExchangeError.prototype);
-  }
-}
 
 /**
  * Custom error class for Fetcher request failures.

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -13,12 +13,12 @@
 
 export * from './fetcher';
 export * from './fetcherError';
-export * from './interceptorManager';
 export * from './fetcherRegistrar';
 export * from './fetchExchange';
 export * from './fetchInterceptor';
 export * from './fetchRequest';
 export * from './interceptor';
+export * from './interceptorManager';
 export * from './mergeRequest';
 export * from './namedFetcher';
 export * from './orderedCapable';

--- a/packages/fetcher/src/interceptorManager.ts
+++ b/packages/fetcher/src/interceptorManager.ts
@@ -2,8 +2,47 @@ import { UrlResolveInterceptor } from './urlResolveInterceptor';
 import { RequestBodyInterceptor } from './requestBodyInterceptor';
 import { FetchInterceptor } from './fetchInterceptor';
 import { FetchExchange } from './fetchExchange';
-import { ExchangeError } from './fetcherError';
+import { FetcherError } from './fetcherError';
 import { InterceptorRegistry } from './interceptor';
+
+/**
+ * Custom error class for FetchExchange related errors.
+ *
+ * This error is thrown when there are issues with the HTTP exchange process,
+ * such as when a request fails and no response is generated. It provides
+ * comprehensive information about the failed request through the exchange object.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await fetcher.get('/api/users');
+ * } catch (error) {
+ *   if (error instanceof ExchangeError) {
+ *     console.log('Request URL:', error.exchange.request.url);
+ *     console.log('Request method:', error.exchange.request.method);
+ *     if (error.exchange.error) {
+ *       console.log('Underlying error:', error.exchange.error);
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export class ExchangeError extends FetcherError {
+  /**
+   * Creates a new ExchangeError instance.
+   *
+   * @param exchange - The FetchExchange object containing request/response/error information.
+   */
+  constructor(public readonly exchange: FetchExchange) {
+    const errorMessage =
+      exchange.error?.message ||
+      exchange.response?.statusText ||
+      `Request to ${exchange.request.url} failed during exchange`;
+    super(errorMessage, exchange.error);
+    this.name = 'ExchangeError';
+    Object.setPrototypeOf(this, ExchangeError.prototype);
+  }
+}
 
 /**
  * Collection of interceptor managers for the Fetcher client.


### PR DESCRIPTION
- Relocate ExchangeError class from fetcherError.ts to interceptorManager.ts
- Remove ExchangeError import from fetcherError.ts
- Add FetcherError import to interceptorManager.ts
- Update class definition and examples in interceptorManager.ts