### PR TITLE
refactor(fetcher): split Interceptor interface into specific types

### DIFF
--- a/packages/cosec/src/cosecRequestInterceptor.ts
+++ b/packages/cosec/src/cosecRequestInterceptor.ts
@@ -11,7 +11,13 @@
  * limitations under the License.
  */
 
-import { FetchExchange, FetchRequest, Interceptor, REQUEST_BODY_INTERCEPTOR_ORDER } from '@ahoo-wang/fetcher';
+import {
+  FetchExchange,
+  FetchRequest,
+  Interceptor,
+  REQUEST_BODY_INTERCEPTOR_ORDER,
+  RequestInterceptor,
+} from '@ahoo-wang/fetcher';
 import { CoSecHeaders, CoSecOptions } from './types';
 import { idGenerator } from './idGenerator';
 
@@ -44,7 +50,7 @@ export const COSEC_REQUEST_INTERCEPTOR_ORDER =
  * are complete, ensuring that the final request is properly authenticated before
  * being sent over the network.
  */
-export class CoSecRequestInterceptor implements Interceptor {
+export class CoSecRequestInterceptor implements RequestInterceptor {
   readonly name = COSEC_REQUEST_INTERCEPTOR_NAME;
   readonly order = COSEC_REQUEST_INTERCEPTOR_ORDER;
   private options: CoSecOptions;

--- a/packages/cosec/src/cosecResponseInterceptor.ts
+++ b/packages/cosec/src/cosecResponseInterceptor.ts
@@ -12,7 +12,7 @@
  */
 
 import { CoSecOptions, ResponseCodes } from './types';
-import { FetchExchange, Interceptor } from '@ahoo-wang/fetcher';
+import { FetchExchange, Interceptor, ResponseInterceptor } from '@ahoo-wang/fetcher';
 
 /**
  * The name of the CoSecResponseInterceptor.
@@ -35,7 +35,7 @@ export const COSEC_RESPONSE_INTERCEPTOR_ORDER = Number.MIN_SAFE_INTEGER + 1000;
  * 3. On successful refresh, stores the new token and retries the original request
  * 4. On refresh failure, clears stored tokens and propagates the error
  */
-export class CoSecResponseInterceptor implements Interceptor {
+export class CoSecResponseInterceptor implements ResponseInterceptor {
   readonly name = COSEC_RESPONSE_INTERCEPTOR_NAME;
   readonly order = COSEC_RESPONSE_INTERCEPTOR_ORDER;
   private options: CoSecOptions;

--- a/packages/eventstream/src/eventStreamInterceptor.ts
+++ b/packages/eventstream/src/eventStreamInterceptor.ts
@@ -12,7 +12,12 @@
  */
 
 import { toServerSentEventStream } from './eventStreamConverter';
-import { ContentTypeHeader, ContentTypeValues, FetchExchange, Interceptor } from '@ahoo-wang/fetcher';
+import {
+  ContentTypeHeader,
+  ContentTypeValues,
+  FetchExchange,
+  ResponseInterceptor,
+} from '@ahoo-wang/fetcher';
 
 /**
  * The name of the EventStreamInterceptor.
@@ -53,7 +58,7 @@ export const EVENT_STREAM_INTERCEPTOR_ORDER = Number.MAX_SAFE_INTEGER - 1000;
  * }
  * ```
  */
-export class EventStreamInterceptor implements Interceptor {
+export class EventStreamInterceptor implements ResponseInterceptor {
   readonly name = EVENT_STREAM_INTERCEPTOR_NAME;
   readonly order = EVENT_STREAM_INTERCEPTOR_ORDER;
 

--- a/packages/fetcher/src/fetchInterceptor.ts
+++ b/packages/fetcher/src/fetchInterceptor.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { Interceptor } from './interceptor';
+import { RequestInterceptor } from './interceptor';
 import { timeoutFetch } from './timeout';
 import { FetchExchange } from './fetchExchange';
 
@@ -47,7 +47,7 @@ export const FETCH_INTERCEPTOR_ORDER = Number.MAX_SAFE_INTEGER - 1000;
  * const fetcher = new Fetcher();
  * // FetchInterceptor is automatically registered in fetcher.interceptors.request
  */
-export class FetchInterceptor implements Interceptor {
+export class FetchInterceptor implements RequestInterceptor {
   /**
    * Interceptor name, used to identify and manage interceptor instances.
    *

--- a/packages/fetcher/src/interceptor.ts
+++ b/packages/fetcher/src/interceptor.ts
@@ -68,6 +68,21 @@ export interface Interceptor extends NamedCapable, OrderedCapable {
   intercept(exchange: FetchExchange): void | Promise<void>;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface RequestInterceptor extends Interceptor {
+
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ResponseInterceptor extends Interceptor {
+
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ErrorInterceptor extends Interceptor {
+
+}
+
 /**
  * Registry for a collection of interceptors of the same type.
  *

--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { Interceptor } from './interceptor';
+import { RequestInterceptor } from './interceptor';
 import { FetchExchange } from './fetchExchange';
 import { ContentTypeValues } from './fetchRequest';
 import { URL_RESOLVE_INTERCEPTOR_ORDER } from './urlResolveInterceptor';
@@ -43,7 +43,7 @@ export const REQUEST_BODY_INTERCEPTOR_ORDER =
  * and request body processing. This positioning ensures that URL parameters are resolved
  * first, then request bodies are properly formatted, and finally the HTTP request is executed.
  */
-export class RequestBodyInterceptor implements Interceptor {
+export class RequestBodyInterceptor implements RequestInterceptor {
   /**
    * Interceptor name, used for identification and management.
    */

--- a/packages/fetcher/src/urlResolveInterceptor.ts
+++ b/packages/fetcher/src/urlResolveInterceptor.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { Interceptor } from './interceptor';
+import { RequestInterceptor } from './interceptor';
 import { FetchExchange } from './fetchExchange';
 
 /**
@@ -46,7 +46,7 @@ export const URL_RESOLVE_INTERCEPTOR_ORDER = Number.MIN_SAFE_INTEGER + 1000;
  * // Query params: { filter: 'active' }
  * // Final URL: 'https://api.example.com/users/123?filter=active'
  */
-export class UrlResolveInterceptor implements Interceptor {
+export class UrlResolveInterceptor implements RequestInterceptor {
   /**
    * The name of this interceptor.
    */

--- a/packages/fetcher/src/validateStatusInterceptor.ts
+++ b/packages/fetcher/src/validateStatusInterceptor.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { Interceptor } from './interceptor';
+import { ResponseInterceptor } from './interceptor';
 import { FetchExchange } from './fetchExchange';
 import { FetcherError } from './fetcherError';
 
@@ -99,7 +99,7 @@ export const VALIDATE_STATUS_INTERCEPTOR_ORDER = Number.MAX_SAFE_INTEGER - 1000;
  * const interceptor = new ValidateStatusInterceptor((status) => true);
  * ```
  */
-export class ValidateStatusInterceptor implements Interceptor {
+export class ValidateStatusInterceptor implements ResponseInterceptor {
   /**
    * Gets the name of this interceptor.
    *


### PR DESCRIPTION
- Divide the generic Interceptor interface into RequestInterceptor, ResponseInterceptor, and ErrorInterceptor
- Update affected files to use the new specific interceptor types
- This change improves type safety and clarity in the interceptor handling process