### PR TITLE
build: set type to module in package.json files

### DIFF
--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -20,6 +20,7 @@
   "bugs": {
     "url": "https://github.com/Ahoo-Wang/fetcher/issues"
   },
+  "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -11,7 +11,6 @@
   ],
   "author": "Ahoo-Wang",
   "license": "Apache-2.0",
-  "type": "module",
   "homepage": "https://github.com/Ahoo-Wang/fetcher/tree/master/packages/fetcher-decorator",
   "repository": {
     "type": "git",
@@ -21,6 +20,7 @@
   "bugs": {
     "url": "https://github.com/Ahoo-Wang/fetcher/issues"
   },
+  "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -19,6 +19,7 @@
   "bugs": {
     "url": "https://github.com/Ahoo-Wang/fetcher/issues"
   },
+  "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -19,6 +19,7 @@
   "bugs": {
     "url": "https://github.com/Ahoo-Wang/fetcher/issues"
   },
+  "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",

--- a/packages/wow/package.json
+++ b/packages/wow/package.json
@@ -23,6 +23,7 @@
   "bugs": {
     "url": "https://github.com/Ahoo-Wang/fetcher/issues"
   },
+  "type": "module",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Add "type": "module" to package.json files in cosec, eventstream, fetcher, and wow packages
- Remove "type": "module" from decorator package.json