### PR TITLE
refactor(fetcher): remove FetchError and simplify error handling 

### DIFF
--- a/packages/fetcher/src/fetchExchange.ts
+++ b/packages/fetcher/src/fetchExchange.ts
@@ -13,6 +13,7 @@
 
 import { Fetcher } from './fetcher';
 import { FetchRequest } from './fetchRequest';
+import { ExchangeError } from './interceptorManager';
 
 /**
  * Container for HTTP request/response data that flows through the interceptor chain.
@@ -120,5 +121,25 @@ export class FetchExchange {
    */
   hasResponse(): boolean {
     return !!this.response;
+  }
+
+  /**
+   * Gets the required response object, throwing an error if no response is available.
+   *
+   * This getter ensures that a response object is available, and throws an ExchangeError
+   * with details about the request if no response was received. This is useful for
+   * guaranteeing that downstream code always has a valid Response object to work with.
+   *
+   * @throws {ExchangeError} If no response is available for the current exchange
+   * @returns The Response object for this exchange
+   */
+  get requiredResponse(): Response {
+    if (!this.response) {
+      throw new ExchangeError(
+        this,
+        `Request to ${this.request.url} failed with no response`,
+      );
+    }
+    return this.response;
   }
 }

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -24,7 +24,6 @@ import {
   RequestHeadersCapable,
 } from './fetchRequest';
 import { mergeRecords } from './utils';
-import { FetchError } from './fetcherError';
 import { InterceptorManager } from './interceptorManager';
 
 /**
@@ -79,8 +78,7 @@ export const DEFAULT_OPTIONS: FetcherOptions = {
  * ```
  */
 export class Fetcher
-  implements UrlBuilderCapable, RequestHeadersCapable, TimeoutCapable
-{
+  implements UrlBuilderCapable, RequestHeadersCapable, TimeoutCapable {
   readonly urlBuilder: UrlBuilder;
   readonly headers?: RequestHeaders = DEFAULT_HEADERS;
   readonly timeout?: number;
@@ -116,13 +114,7 @@ export class Fetcher
     const fetchRequest = request as FetchRequest;
     fetchRequest.url = url;
     const exchange = await this.request(fetchRequest);
-    if (!exchange.response) {
-      throw new FetchError(
-        exchange,
-        `Request to ${fetchRequest.url} failed with no response`,
-      );
-    }
-    return exchange.response;
+    return exchange.requiredResponse;
   }
 
   /**

--- a/packages/fetcher/src/fetcherError.ts
+++ b/packages/fetcher/src/fetcherError.ts
@@ -11,8 +11,6 @@
  * limitations under the License.
  */
 
-import { FetchExchange } from './fetchExchange';
-
 /**
  * Base error class for all Fetcher-related errors.
  *
@@ -57,47 +55,6 @@ export class FetcherError extends Error {
 
     // Set prototype for instanceof checks to work correctly
     Object.setPrototypeOf(this, FetcherError.prototype);
-  }
-}
-
-
-/**
- * Custom error class for Fetcher request failures.
- *
- * This error is thrown when a fetch request fails and no response is generated.
- * It wraps the FetchExchange object to provide comprehensive information about the failed request.
- *
- * @example
- * ```typescript
- * try {
- *   await fetcher.get('/api/users');
- * } catch (error) {
- *   if (error instanceof FetchError) {
- *     console.log('Failed URL:', error.exchange.request.url);
- *     console.log('Request headers:', error.exchange.request.headers);
- *     console.log('Interceptor attributes:', error.exchange.attributes);
- *   }
- * }
- * ```
- */
-export class FetchError extends FetcherError {
-  /**
-   * Creates a new FetchError instance.
-   *
-   * @param exchange - The FetchExchange object containing request/response/error information.
-   * @param errorMsg - Optional custom error message. If not provided, will use the exchange's error message.
-   */
-  constructor(
-    public readonly exchange: FetchExchange,
-    errorMsg?: string,
-  ) {
-    const errorMessage =
-      errorMsg ||
-      exchange.error?.message ||
-      `Request to ${exchange.request.url} failed with no response`;
-    super(errorMessage, exchange.error);
-    this.name = 'FetchError';
-    Object.setPrototypeOf(this, FetchError.prototype);
   }
 }
 

--- a/packages/fetcher/src/interceptorManager.ts
+++ b/packages/fetcher/src/interceptorManager.ts
@@ -33,9 +33,10 @@ export class ExchangeError extends FetcherError {
    * Creates a new ExchangeError instance.
    *
    * @param exchange - The FetchExchange object containing request/response/error information.
+   * @param errorMsg - An optional error message.
    */
-  constructor(public readonly exchange: FetchExchange) {
-    const errorMessage =
+  constructor(public readonly exchange: FetchExchange, errorMsg?: string) {
+    const errorMessage = errorMsg ||
       exchange.error?.message ||
       exchange.response?.statusText ||
       `Request to ${exchange.request.url} failed during exchange`;

--- a/packages/fetcher/test/fetchExchange.test.ts
+++ b/packages/fetcher/test/fetchExchange.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { Fetcher, FetchExchange, FetchRequest } from '../src';
+import { ExchangeError, Fetcher, FetchExchange, FetchRequest } from '../src';
 
 describe('FetchExchange', () => {
   const mockFetcher = {} as Fetcher;
@@ -77,6 +77,14 @@ describe('FetchExchange', () => {
     const exchange = new FetchExchange(mockFetcher, mockRequest, mockResponse);
 
     expect(exchange.hasResponse()).toBe(true);
+    expect(exchange.requiredResponse).toBe(mockResponse);
   });
+  it('should throw an error when trying to access requiredResponse without a response', () => {
+    expect(() => {
+      const exchange = new FetchExchange(mockFetcher, mockRequest);
+      exchange.requiredResponse;
+    }).toThrowError(ExchangeError);
+  });
+
 });
 

--- a/packages/fetcher/test/fetcherError.test.ts
+++ b/packages/fetcher/test/fetcherError.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { Fetcher, FetcherError, FetchError, FetchExchange } from '../src';
+import { FetcherError } from '../src';
 
 describe('FetcherError', () => {
   it('should create FetcherError with default message', () => {
@@ -48,40 +48,5 @@ describe('FetcherError', () => {
     const cause = new Error('Cause error');
     const error = new FetcherError(undefined, cause);
     expect(error.stack).toBe(cause.stack);
-  });
-});
-
-describe('FetchError', () => {
-  const mockFetcher = {} as Fetcher;
-  const mockRequest = { url: '/test' };
-
-  it('should create FetchError with default message', () => {
-    const exchange = new FetchExchange(mockFetcher, mockRequest);
-    const error = new FetchError(exchange);
-    expect(error).toBeInstanceOf(FetchError);
-    expect(error).toBeInstanceOf(FetcherError);
-    expect(error.name).toBe('FetchError');
-    expect(error.exchange).toBe(exchange);
-    expect(error.message).toBe('Request to /test failed with no response');
-  });
-
-  it('should create FetchError with custom message', () => {
-    const exchange = new FetchExchange(mockFetcher, mockRequest);
-    const errorMessage = 'Custom error message';
-    const error = new FetchError(exchange, errorMessage);
-    expect(error.message).toBe(errorMessage);
-  });
-
-  it('should create FetchError with error in exchange', () => {
-    const cause = new Error('Cause error');
-    const exchange = new FetchExchange(
-      mockFetcher,
-      mockRequest,
-      undefined,
-      cause,
-    );
-    const error = new FetchError(exchange);
-    expect(error.message).toBe(cause.message);
-    expect(error.cause).toBe(cause);
   });
 });


### PR DESCRIPTION
- Remove FetchError class and its related imports
- Add requiredResponse getter to FetchExchange, throwing ExchangeError when no response
- Update Fetcher to use requiredResponse, ensuring a response is always returned
- Modify ExchangeError to accept an optional error message
- Remove FetchError related tests