### PR TITLE
refactor(decorator): change default result extractor to Json

### DIFF
--- a/packages/decorator/src/resultExtractor.ts
+++ b/packages/decorator/src/resultExtractor.ts
@@ -150,5 +150,5 @@ export const ResultExtractors = {
   Text: TextResultExtractor,
   ServerSentEventStream: ServerSentEventStreamResultExtractor,
   CommandResultEventStream: CommandResultEventStreamResultExtractor,
-  DEFAULT: ResponseResultExtractor,
+  DEFAULT: JsonResultExtractor,
 };

--- a/packages/decorator/test/requestExecutor.branch.test.ts
+++ b/packages/decorator/test/requestExecutor.branch.test.ts
@@ -249,6 +249,6 @@ describe('FunctionMetadata - branch coverage', () => {
       [],
     );
 
-    expect(metadata3.resolveResultExtractor()).toBe(ResultExtractors.DEFAULT);
+    expect(metadata3.resolveResultExtractor()).toBe(ResultExtractors.Json);
   });
 });

--- a/packages/decorator/test/requestExecutor.execute.test.ts
+++ b/packages/decorator/test/requestExecutor.execute.test.ts
@@ -74,7 +74,7 @@ describe('RequestExecutor - execute method', () => {
       signal: undefined,
     });
 
-    expect(result).toBe(mockResponse);
+    expect(result).toEqual({ id: 1, name: 'John' });
   });
 
   it('should execute HTTP request with query parameters', async () => {
@@ -121,7 +121,7 @@ describe('RequestExecutor - execute method', () => {
       signal: undefined,
     });
 
-    expect(result).toBe(mockResponse);
+    expect(result).toEqual({ users: [{ id: 1, name: 'John' }] });
   });
 
   it('should execute HTTP request with headers', async () => {
@@ -167,7 +167,7 @@ describe('RequestExecutor - execute method', () => {
       signal: undefined,
     });
 
-    expect(result).toBe(mockResponse);
+    expect(result).toEqual({ id: 1, name: 'John' });
   });
 
   it('should execute HTTP request with timeout', async () => {
@@ -209,7 +209,7 @@ describe('RequestExecutor - execute method', () => {
       signal: undefined,
     });
 
-    expect(result).toBe(mockResponse);
+    expect(result).toEqual({ id: 1, name: 'John' });
   });
 
   it('should execute HTTP request with AbortSignal', async () => {
@@ -252,6 +252,6 @@ describe('RequestExecutor - execute method', () => {
       signal: abortController.signal,
     });
 
-    expect(result).toBe(mockResponse);
+    expect(result).toEqual({ id: 1, name: 'John' });
   });
 });


### PR DESCRIPTION
- Set ResultExtractors.DEFAULT to JsonResultExtractor instead of ResponseResultExtractor
- Update tests to reflect the new default result extractor behavior
- Modify expectations in tests to match the output of JsonResultExtractor