### PR TITLE
build: enable source map generation for all packages

### DIFF
--- a/packages/cosec/vite.config.ts
+++ b/packages/cosec/vite.config.ts
@@ -16,6 +16,7 @@ import dts from 'unplugin-dts/vite';
 
 export default defineConfig({
   build: {
+    sourcemap: true,
     lib: {
       entry: 'src/index.ts',
       name: 'FetcherCoSec',

--- a/packages/decorator/vite.config.ts
+++ b/packages/decorator/vite.config.ts
@@ -3,6 +3,7 @@ import dts from 'unplugin-dts/vite';
 
 export default defineConfig({
   build: {
+    sourcemap: true,
     lib: {
       entry: 'src/index.ts',
       name: 'FetcherDecorator',

--- a/packages/eventstream/vite.config.ts
+++ b/packages/eventstream/vite.config.ts
@@ -16,6 +16,7 @@ import dts from 'unplugin-dts/vite';
 
 export default defineConfig({
   build: {
+    sourcemap: true,
     lib: {
       entry: 'src/index.ts',
       name: 'FetcherEventStream',

--- a/packages/fetcher/vite.config.ts
+++ b/packages/fetcher/vite.config.ts
@@ -16,6 +16,7 @@ import dts from 'unplugin-dts/vite';
 
 export default defineConfig({
   build: {
+    sourcemap: true,
     lib: {
       entry: 'src/index.ts',
       name: 'Fetcher',

--- a/packages/wow/vite.config.ts
+++ b/packages/wow/vite.config.ts
@@ -16,6 +16,7 @@ import dts from 'unplugin-dts/vite';
 
 export default defineConfig({
   build: {
+    sourcemap: true,
     lib: {
       entry: 'src/index.ts',
       name: 'FetcherWow',


### PR DESCRIPTION
- Add sourcemap: true to vite.config.ts for cosec, decorator, eventstream, fetcher, and wow packages
- This change improves debugging by providing source maps for all components