### PR TITLE
build(cosec): add nanoid as an external dependency

### DIFF
--- a/packages/cosec/vite.config.ts
+++ b/packages/cosec/vite.config.ts
@@ -23,10 +23,11 @@ export default defineConfig({
       fileName: format => `index.${format}.js`,
     },
     rollupOptions: {
-      external: ['@ahoo-wang/fetcher'],
+      external: ['@ahoo-wang/fetcher', 'nanoid'],
       output: {
         globals: {
           '@ahoo-wang/fetcher': 'Fetcher',
+          'nanoid': 'nanoid',
         },
       },
     },


### PR DESCRIPTION
- Include 'nanoid' in the external dependencies for the Vite build configuration
- Add a global reference for 'nanoid' to ensure proper module resolution