### PR TITLE
refactor(jwts): make parseJwtPayload function generic

### DIFF
--- a/packages/cosec/src/jwts.ts
+++ b/packages/cosec/src/jwts.ts
@@ -90,7 +90,7 @@ export interface CoSecJwtPayload extends JwtPayload {
  * @param token - The JWT token string to parse
  * @returns The parsed JWT payload or null if parsing fails
  */
-export function parseJwtPayload(token: string): CoSecJwtPayload | null {
+export function parseJwtPayload<T extends JwtPayload>(token: string): T | null {
   try {
     const parts = token.split('.');
     if (parts.length !== 3) {
@@ -111,7 +111,7 @@ export function parseJwtPayload(token: string): CoSecJwtPayload | null {
         })
         .join(''),
     );
-    return JSON.parse(jsonPayload) as CoSecJwtPayload;
+    return JSON.parse(jsonPayload) as T;
   } catch (error) {
     // Avoid exposing sensitive information in error logs
     console.error('Failed to parse JWT token', error);


### PR DESCRIPTION
- Update parseJwtPayload function to use a generic type parameter T
- This allows the function to return a type specified by the caller
- Improve type safety and flexibility when parsing JWT payloads