### PR TITLE
build(decorator): add reflect-metadata as external dependency

### DIFF
--- a/packages/decorator/vite.config.ts
+++ b/packages/decorator/vite.config.ts
@@ -10,11 +10,12 @@ export default defineConfig({
       fileName: format => `index.${format}.js`,
     },
     rollupOptions: {
-      external: ['@ahoo-wang/fetcher', '@ahoo-wang/fetcher-eventstream'],
+      external: ['@ahoo-wang/fetcher', '@ahoo-wang/fetcher-eventstream', 'reflect-metadata'],
       output: {
         globals: {
           '@ahoo-wang/fetcher': 'Fetcher',
           '@ahoo-wang/fetcher-eventstream': 'FetcherEventStream',
+          'reflect-metadata': 'reflect-metadata',
         },
       },
     },


### PR DESCRIPTION
- Add 'reflect-metadata' to external dependencies in vite.config.ts
- This change prevents bundling reflect-metadata with the decorator package