### PR TITLE
feat(query): introduce QueryServiceApi and simplify EventStreamQueryApi

### DIFF
--- a/packages/wow/src/query/index.ts
+++ b/packages/wow/src/query/index.ts
@@ -16,3 +16,4 @@ export * from './operator';
 export * from './queryable';
 export * from './event';
 export * from './snapshot';
+export * from './queryServiceApi';

--- a/packages/wow/src/query/queryServiceApi.ts
+++ b/packages/wow/src/query/queryServiceApi.ts
@@ -11,9 +11,19 @@
  * limitations under the License.
  */
 
-import { DomainEventStream } from './domainEventStream';
-import { QueryServiceApi } from '../queryServiceApi';
+import { ListQuery, PagedList, PagedQuery, SingleQuery } from './queryable';
+import { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
+import { Condition } from './condition';
 
-export interface EventStreamQueryApi extends Omit<QueryServiceApi<DomainEventStream>, 'single'> {
+export interface QueryServiceApi<R> {
 
+  single(singleQuery: SingleQuery): Promise<Partial<R>>;
+
+  list(listQuery: ListQuery): Promise<Partial<R>[]>;
+
+  listStream(listQuery: ListQuery): Promise<ReadableStream<JsonServerSentEvent<Partial<R>>>>;
+
+  paged(pagedQuery: PagedQuery): Promise<PagedList<Partial<R>>>;
+
+  count(condition: Condition): Promise<number>;
 }

--- a/packages/wow/src/query/snapshot/snapshotApi.ts
+++ b/packages/wow/src/query/snapshot/snapshotApi.ts
@@ -11,9 +11,9 @@
  * limitations under the License.
  */
 
-import { DomainEventStream } from './domainEventStream';
 import { QueryServiceApi } from '../queryServiceApi';
+import { MaterializedSnapshot } from './snapshot';
 
-export interface EventStreamQueryApi extends Omit<QueryServiceApi<DomainEventStream>, 'single'> {
+export interface SnapshotApi<S> extends QueryServiceApi<MaterializedSnapshot<S>> {
 
 }


### PR DESCRIPTION
- Introduce QueryServiceApi interface to provide a common query API
- Simplify EventStreamQueryApi by extending QueryServiceApi
- Add SnapshotApi interface for materialized snapshot queries
- Update query index to include new QueryServiceApi
- Remove redundant interfaces and methods from EventStreamQueryApi