### PR TITLE
refactor(query): rename query related APIs and interfaces

### DIFF
--- a/packages/wow/src/query/event/eventStreamQueryApi.ts
+++ b/packages/wow/src/query/event/eventStreamQueryApi.ts
@@ -12,8 +12,8 @@
  */
 
 import { DomainEventStream } from './domainEventStream';
-import { QueryServiceApi } from '../queryServiceApi';
+import { QueryApi } from '../queryApi';
 
-export interface EventStreamQueryApi extends Omit<QueryServiceApi<DomainEventStream>, 'single'> {
+export interface EventStreamQueryApi extends Omit<QueryApi<DomainEventStream>, 'single'> {
 
 }

--- a/packages/wow/src/query/index.ts
+++ b/packages/wow/src/query/index.ts
@@ -16,4 +16,4 @@ export * from './operator';
 export * from './queryable';
 export * from './event';
 export * from './snapshot';
-export * from './queryServiceApi';
+export * from './queryApi';

--- a/packages/wow/src/query/queryApi.ts
+++ b/packages/wow/src/query/queryApi.ts
@@ -15,7 +15,7 @@ import { ListQuery, PagedList, PagedQuery, SingleQuery } from './queryable';
 import { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
 import { Condition } from './condition';
 
-export interface QueryServiceApi<R> {
+export interface QueryApi<R> {
 
   single(singleQuery: SingleQuery): Promise<Partial<R>>;
 

--- a/packages/wow/src/query/snapshot/index.ts
+++ b/packages/wow/src/query/snapshot/index.ts
@@ -12,3 +12,4 @@
  */
 
 export * from './snapshot';
+export * from './snapshotQueryApi';

--- a/packages/wow/src/query/snapshot/snapshotQueryApi.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryApi.ts
@@ -11,9 +11,9 @@
  * limitations under the License.
  */
 
-import { QueryServiceApi } from '../queryServiceApi';
+import { QueryApi } from '../queryApi';
 import { MaterializedSnapshot } from './snapshot';
 
-export interface SnapshotApi<S> extends QueryServiceApi<MaterializedSnapshot<S>> {
+export interface SnapshotQueryApi<S> extends QueryApi<MaterializedSnapshot<S>> {
 
 }


### PR DESCRIPTION
- Rename QueryServiceApi to QueryApi
- Rename EventStreamQueryApi to extend QueryApi instead of QueryServiceApi
- Rename SnapshotApi to SnapshotQueryApi
- Update related imports and exports