### PR TITLE
refactor(query): disable ESLint empty object type rule for specific interfaces

### DIFF
--- a/packages/wow/src/query/event/eventStreamQueryApi.ts
+++ b/packages/wow/src/query/event/eventStreamQueryApi.ts
@@ -14,6 +14,7 @@
 import { DomainEventStream } from './domainEventStream';
 import { QueryApi } from '../queryApi';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface EventStreamQueryApi extends Omit<QueryApi<DomainEventStream>, 'single'> {
 
 }

--- a/packages/wow/src/query/snapshot/snapshotQueryApi.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryApi.ts
@@ -14,6 +14,7 @@
 import { QueryApi } from '../queryApi';
 import { MaterializedSnapshot } from './snapshot';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface SnapshotQueryApi<S> extends QueryApi<MaterializedSnapshot<S>> {
 
 }


### PR DESCRIPTION


- Add eslint-disable comment for no-empty-object-type rule in EventStreamQueryApi and SnapshotApi interfaces
- This change allows the interfaces to extend QueryServiceApi without including the 'single' method