### PR TITLE
refactor(query): split query related interfaces and functions into separate files

### DIFF
--- a/packages/wow/src/query/index.ts
+++ b/packages/wow/src/query/index.ts
@@ -13,7 +13,10 @@
 
 export * from './condition';
 export * from './operator';
+export * from './pagination';
+export * from './projection';
 export * from './queryable';
+export * from './queryApi';
+export * from './sort';
 export * from './event';
 export * from './snapshot';
-export * from './queryApi';

--- a/packages/wow/src/query/pagination.ts
+++ b/packages/wow/src/query/pagination.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Interface for pagination information.
+ *
+ * Page number, starting from 1
+ * Page size
+ */
+export interface Pagination {
+  index: number;
+  size: number;
+}
+
+/**
+ * Default pagination configuration.
+ * Page index starts at 1, page size is 10.
+ */
+export const DEFAULT_PAGINATION: Pagination = {
+  index: 1,
+  size: 10,
+};
+
+/**
+ * Creates a pagination object with the specified index and size.
+ * @param index - The page index, starting from 1. Defaults to DEFAULT_PAGINATION.index (1)
+ * @param size - The page size. Defaults to DEFAULT_PAGINATION.size (10)
+ * @returns A Pagination object with the specified index and size
+ */
+export function pagination(index: number = DEFAULT_PAGINATION.index, size: number = DEFAULT_PAGINATION.size): Pagination {
+  return {
+    index,
+    size,
+  };
+}

--- a/packages/wow/src/query/projection.ts
+++ b/packages/wow/src/query/projection.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Interface for field projection.
+ */
+export interface Projection {
+  include?: string[];
+  exclude?: string[];
+}
+
+/**
+ * Default projection configuration.
+ * Empty projection object includes all fields.
+ */
+export const DEFAULT_PROJECTION: Projection = {};
+
+/**
+ * Creates a projection object with optional include and exclude field arrays.
+ * @param include - Array of field names to include in the projection. If provided, only these fields will be included.
+ * @param exclude - Array of field names to exclude from the projection. If provided, these fields will be excluded.
+ * @returns A Projection object with the specified include and exclude arrays
+ */
+export function projection(include?: string[], exclude?: string[]): Projection {
+  return {
+    include,
+    exclude,
+  };
+}
+
+/**
+ * Interface for objects that support field projection.
+ */
+export interface ProjectionCapable {
+  projection?: Projection;
+}

--- a/packages/wow/src/query/queryable.ts
+++ b/packages/wow/src/query/queryable.ts
@@ -12,59 +12,9 @@
  */
 
 import { ConditionCapable } from './condition';
-
-export enum SortDirection {
-  ASC = 'ASC',
-  DESC = 'DESC',
-}
-
-/**
- * Interface for sort criteria.
- */
-export interface Sort {
-  field: string;
-  direction: SortDirection;
-}
-
-/**
- * Interface for objects that support sorting.
- */
-export interface SortCapable {
-  sort?: Sort[];
-}
-
-/**
- * Interface for pagination information.
- *
- * Page number, starting from 1
- * Page size
- */
-export interface Pagination {
-  index: number;
-  size: number;
-}
-
-export const DEFAULT_PAGINATION: Pagination = {
-  index: 1,
-  size: 10,
-};
-
-/**
- * Interface for field projection.
- */
-export interface Projection {
-  include?: string[];
-  exclude?: string[];
-}
-
-export const DEFAULT_PROJECTION: Projection = {};
-
-/**
- * Interface for objects that support field projection.
- */
-export interface ProjectionCapable {
-  projection?: Projection;
-}
+import { SortCapable } from './sort';
+import { Pagination } from './pagination';
+import { ProjectionCapable } from './projection';
 
 /**
  * Interface for queryable objects that support conditions, projection, and sorting.
@@ -72,13 +22,15 @@ export interface ProjectionCapable {
 export interface Queryable
   extends ConditionCapable,
     ProjectionCapable,
-    SortCapable {}
+    SortCapable {
+}
 
 /**
  * Interface for single query objects.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface SingleQuery extends Queryable {}
+export interface SingleQuery extends Queryable {
+}
 
 /**
  * Interface for list query objects.

--- a/packages/wow/src/query/sort.ts
+++ b/packages/wow/src/query/sort.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export enum SortDirection {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
+
+/**
+ * Interface for sort criteria.
+ */
+export interface Sort {
+  field: string;
+  direction: SortDirection;
+}
+
+/**
+ * Creates a sort object with ascending direction for the specified field.
+ * @param field - The field to sort by
+ * @returns A Sort object with the specified field and ascending direction
+ */
+export function sort(field: string): Sort {
+  return {
+    field,
+    direction: SortDirection.ASC,
+  };
+}
+
+/**
+ * Creates a sort object with descending direction for the specified field.
+ * @param field - The field to sort by
+ * @returns A Sort object with the specified field and descending direction
+ */
+export function sortDesc(field: string): Sort {
+  return {
+    field,
+    direction: SortDirection.DESC,
+  };
+}
+
+/**
+ * Interface for objects that support sorting.
+ */
+export interface SortCapable {
+  sort?: Sort[];
+}

--- a/packages/wow/test/command/commandResult.test.ts
+++ b/packages/wow/test/command/commandResult.test.ts
@@ -12,8 +12,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { CommandResult, CommandStage } from '../../src/command';
-import { FunctionKind } from '../../src/types';
+import { CommandResult, CommandStage } from '../../src';
+import { FunctionKind } from '../../src';
 
 describe('CommandResult', () => {
   it('should create a command result with minimal properties', () => {

--- a/packages/wow/test/query/pagination.test.ts
+++ b/packages/wow/test/query/pagination.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PAGINATION, pagination } from '../../src';
+
+describe('pagination', () => {
+  it('should export DEFAULT_PAGINATION with correct values', () => {
+    expect(DEFAULT_PAGINATION.index).toBe(1);
+    expect(DEFAULT_PAGINATION.size).toBe(10);
+  });
+
+  it('should create pagination object with default values', () => {
+    const result = pagination();
+    expect(result.index).toBe(1);
+    expect(result.size).toBe(10);
+  });
+
+  it('should create pagination object with custom index', () => {
+    const result = pagination(2);
+    expect(result.index).toBe(2);
+    expect(result.size).toBe(10);
+  });
+
+  it('should create pagination object with custom index and size', () => {
+    const result = pagination(3, 20);
+    expect(result.index).toBe(3);
+    expect(result.size).toBe(20);
+  });
+});

--- a/packages/wow/test/query/projection.test.ts
+++ b/packages/wow/test/query/projection.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PROJECTION, projection } from '../../src';
+
+describe('projection', () => {
+  it('should export DEFAULT_PROJECTION as empty object', () => {
+    expect(DEFAULT_PROJECTION).toEqual({});
+  });
+
+  it('should create projection object with no parameters', () => {
+    const result = projection();
+    expect(result).toEqual({
+      include: undefined,
+      exclude: undefined,
+    });
+  });
+
+  it('should create projection object with include fields', () => {
+    const includeFields = ['field1', 'field2'];
+    const result = projection(includeFields);
+    expect(result).toEqual({
+      include: includeFields,
+      exclude: undefined,
+    });
+  });
+
+  it('should create projection object with exclude fields', () => {
+    const excludeFields = ['field1', 'field2'];
+    const result = projection(undefined, excludeFields);
+    expect(result).toEqual({
+      include: undefined,
+      exclude: excludeFields,
+    });
+  });
+
+  it('should create projection object with both include and exclude fields', () => {
+    const includeFields = ['field1', 'field2'];
+    const excludeFields = ['field3', 'field4'];
+    const result = projection(includeFields, excludeFields);
+    expect(result).toEqual({
+      include: includeFields,
+      exclude: excludeFields,
+    });
+  });
+});

--- a/packages/wow/test/query/sort.test.ts
+++ b/packages/wow/test/query/sort.test.ts
@@ -12,26 +12,26 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { Identifier, Version } from '../../src';
+import { sort, sortDesc, SortDirection } from '../../src';
 
-describe('Common Types', () => {
-  describe('Identifier', () => {
-    it('should have an id property', () => {
-      const identifier: Identifier = {
-        id: 'test-id',
-      };
+describe('sort', () => {
+  it('should create a sort object with ascending direction', () => {
+    const field = 'testField';
+    const result = sort(field);
 
-      expect(identifier.id).toBe('test-id');
+    expect(result).toEqual({
+      field,
+      direction: SortDirection.ASC,
     });
   });
 
-  describe('Version', () => {
-    it('should have a version property', () => {
-      const version: Version = {
-        version: 1,
-      };
+  it('should create a sort object with descending direction', () => {
+    const field = 'testField';
+    const result = sortDesc(field);
 
-      expect(version.version).toBe(1);
+    expect(result).toEqual({
+      field,
+      direction: SortDirection.DESC,
     });
   });
 });


### PR DESCRIPTION


- Move Pagination, Projection, and Sort interfaces to their own files
- Create new functions for creating pagination and projection objects
- Add unit tests for pagination, projection, and sort functionalities
- Update imports in queryable.ts to use new separate files