### PR TITLE
refactor(types): replace enums with static readonly classes

### DIFF
--- a/packages/cosec/src/types.ts
+++ b/packages/cosec/src/types.ts
@@ -18,15 +18,15 @@ import { TokenRefresher } from './tokenRefresher';
 /**
  * CoSec HTTP headers enumeration.
  */
-export enum CoSecHeaders {
-  DEVICE_ID = 'CoSec-Device-Id',
-  APP_ID = 'CoSec-App-Id',
-  AUTHORIZATION = 'Authorization',
-  REQUEST_ID = 'CoSec-Request-Id',
+export class CoSecHeaders {
+  static readonly DEVICE_ID = 'CoSec-Device-Id';
+  static readonly APP_ID = 'CoSec-App-Id';
+  static readonly AUTHORIZATION = 'Authorization';
+  static readonly REQUEST_ID = 'CoSec-Request-Id';
 }
 
-export enum ResponseCodes {
-  UNAUTHORIZED = 401,
+export class ResponseCodes {
+  static readonly UNAUTHORIZED = 401;
 }
 
 /**

--- a/packages/eventstream/src/eventStreamInterceptor.ts
+++ b/packages/eventstream/src/eventStreamInterceptor.ts
@@ -13,7 +13,7 @@
 
 import { toServerSentEventStream } from './eventStreamConverter';
 import {
-  ContentTypeHeader,
+  CONTENT_TYPE_HEADER,
   ContentTypeValues,
   FetchExchange,
   ResponseInterceptor,
@@ -87,7 +87,7 @@ export class EventStreamInterceptor implements ResponseInterceptor {
     if (!response) {
       return;
     }
-    const contentType = response.headers.get(ContentTypeHeader);
+    const contentType = response.headers.get(CONTENT_TYPE_HEADER);
     if (contentType?.includes(ContentTypeValues.TEXT_EVENT_STREAM)) {
       response.eventStream = () => toServerSentEventStream(response);
       response.jsonEventStream = () =>

--- a/packages/eventstream/src/serverSentEventTransformStream.ts
+++ b/packages/eventstream/src/serverSentEventTransformStream.ts
@@ -27,11 +27,11 @@ export interface ServerSentEvent {
   retry?: number;
 }
 
-export enum ServerSentEventField {
-  ID = 'id',
-  RETRY = 'retry',
-  EVENT = 'event',
-  DATA = 'data',
+export class ServerSentEventFields {
+  static readonly ID = 'id';
+  static readonly RETRY = 'retry';
+  static readonly EVENT = 'event';
+  static readonly DATA = 'data';
 }
 
 /**
@@ -46,16 +46,16 @@ function processFieldInternal(
   currentEvent: EventState,
 ) {
   switch (field) {
-    case ServerSentEventField.EVENT:
+    case ServerSentEventFields.EVENT:
       currentEvent.event = value;
       break;
-    case ServerSentEventField.DATA:
+    case ServerSentEventFields.DATA:
       currentEvent.data.push(value);
       break;
-    case ServerSentEventField.ID:
+    case ServerSentEventFields.ID:
       currentEvent.id = value;
       break;
-    case ServerSentEventField.RETRY: {
+    case ServerSentEventFields.RETRY: {
       const retryValue = parseInt(value, 10);
       if (!isNaN(retryValue)) {
         currentEvent.retry = retryValue;
@@ -83,8 +83,7 @@ const DEFAULT_EVENT_TYPE = 'message';
  * Implements the Transformer interface for processing data transformation in TransformStream.
  */
 export class ServerSentEventTransformer
-  implements Transformer<string, ServerSentEvent>
-{
+  implements Transformer<string, ServerSentEvent> {
   // Initialize currentEvent with default values in a closure
   private currentEvent: EventState = {
     event: DEFAULT_EVENT_TYPE,

--- a/packages/eventstream/test/serverSentEventTransformStream.test.ts
+++ b/packages/eventstream/test/serverSentEventTransformStream.test.ts
@@ -13,10 +13,10 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import {
-  ServerSentEventField,
+  ServerSentEventFields,
   ServerSentEventTransformer,
   ServerSentEventTransformStream,
-} from '../src/serverSentEventTransformStream';
+} from '../src';
 
 describe('serverSentEventTransformStream.ts', () => {
   describe('ServerSentEventTransformStream', () => {
@@ -30,10 +30,10 @@ describe('serverSentEventTransformStream.ts', () => {
 
   describe('ServerSentEventField', () => {
     it('should define ServerSentEventField enum values', () => {
-      expect(ServerSentEventField.ID).toBe('id');
-      expect(ServerSentEventField.RETRY).toBe('retry');
-      expect(ServerSentEventField.EVENT).toBe('event');
-      expect(ServerSentEventField.DATA).toBe('data');
+      expect(ServerSentEventFields.ID).toBe('id');
+      expect(ServerSentEventFields.RETRY).toBe('retry');
+      expect(ServerSentEventFields.EVENT).toBe('event');
+      expect(ServerSentEventFields.DATA).toBe('data');
     });
   });
 

--- a/packages/fetcher/src/fetchRequest.ts
+++ b/packages/fetcher/src/fetchRequest.ts
@@ -44,11 +44,11 @@ export enum HttpMethod {
   OPTIONS = 'OPTIONS',
 }
 
-export const ContentTypeHeader = 'Content-Type';
+export const CONTENT_TYPE_HEADER = 'Content-Type';
 
-export enum ContentTypeValues {
-  APPLICATION_JSON = 'application/json',
-  TEXT_EVENT_STREAM = 'text/event-stream',
+export class ContentTypeValues {
+  static readonly APPLICATION_JSON = 'application/json';
+  static readonly TEXT_EVENT_STREAM = 'text/event-stream';
 }
 
 /**
@@ -58,7 +58,7 @@ export enum ContentTypeValues {
  * Allows for additional custom headers through index signature.
  */
 export interface RequestHeaders {
-  [ContentTypeHeader]?: string;
+  [CONTENT_TYPE_HEADER]?: string;
   Accept?: string;
   Authorization?: string;
 


### PR DESCRIPTION
- Replace CoSecHeaders enum with static readonly class
- Replace ResponseCodes enum with static readonly class
- Replace ServerSentEventField enum with static readonly class
- Update related imports and usages across multiple files