### PR TITLE
feat(core): add domain event stream and snapshot metadata fields

### DIFF
--- a/packages/wow/src/query/event/domainEventStream.ts
+++ b/packages/wow/src/query/event/domainEventStream.ts
@@ -58,6 +58,37 @@ export interface DomainEventStream
   headers: DomainEventStreamHeaders;
 }
 
+/**
+ * Provides field names for domain event stream metadata.
+ *
+ * This class contains static readonly properties that define the field names used in domain event stream metadata.
+ * These field names are used to access and manipulate domain event stream data in a consistent manner.
+ * The fields include headers, identifiers, command information, versioning, body content, and creation time.
+ */
+export class DomainEventStreamMetadataFields {
+  static readonly HEADERS = 'headers';
+  static readonly COMMAND_OPERATOR = `${DomainEventStreamMetadataFields.HEADERS}.command_operator`;
+  static readonly AGGREGATE_ID = 'aggregateId';
+  static readonly TENANT_ID = 'tenantId';
+  static readonly OWNER_ID = 'ownerId';
+  static readonly COMMAND_ID = 'commandId';
+  static readonly REQUEST_ID = 'requestId';
+  static readonly VERSION = 'version';
+  static readonly BODY = 'body';
+  static readonly BODY_ID = `${DomainEventStreamMetadataFields.BODY}.id`;
+  static readonly BODY_NAME = `${DomainEventStreamMetadataFields.BODY}.name`;
+  static readonly BODY_TYPE = `${DomainEventStreamMetadataFields.BODY}.bodyType`;
+  static readonly BODY_REVISION = `${DomainEventStreamMetadataFields.BODY}.revision`;
+  static readonly BODY_BODY = `${DomainEventStreamMetadataFields.BODY}.body`;
+  static readonly CREATE_TIME = 'createTime';
+}
+
+/**
+ * Represents a readable stream of domain event streams.
+ *
+ * This type defines a ReadableStream that emits JsonServerSentEvent objects containing DomainEventStream data.
+ * It is used for streaming domain events in a server-sent event format.
+ */
 export type ReadableDomainEventStream = ReadableStream<
   JsonServerSentEvent<DomainEventStream>
 >;

--- a/packages/wow/src/query/snapshot/snapshot.ts
+++ b/packages/wow/src/query/snapshot/snapshot.ts
@@ -85,13 +85,14 @@ export interface SmallMaterializedSnapshot<S>
  */
 export class SnapshotMetadataFields {
   static readonly VERSION = 'version';
-  /**
-   * The aggregate ID of the snapshot.
-   */
-  static readonly FIRST_OPERATOR = 'firstOperator';
-  static readonly OPERATOR = 'operator';
+  static readonly TENANT_ID = 'tenantId';
+  static readonly OWNER_ID = 'ownerId';
+  static readonly EVENT_ID = 'eventId';
   static readonly FIRST_EVENT_TIME = 'firstEventTime';
   static readonly EVENT_TIME = 'eventTime';
+  static readonly FIRST_OPERATOR = 'firstOperator';
+  static readonly OPERATOR = 'operator';
   static readonly SNAPSHOT_TIME = 'snapshotTime';
+  static readonly DELETED = 'deleted';
   static readonly STATE = 'state';
 }

--- a/packages/wow/test/index.test.ts
+++ b/packages/wow/test/index.test.ts
@@ -14,8 +14,8 @@
 import { describe, expect, it } from 'vitest';
 
 describe('Index', () => {
-  it('should compile without errors', () => {
-    // This test ensures that the main index can be imported without compilation errors
-    expect(true).toBe(true);
+  it('should export modules', async () => {
+    const mod = await import('../src/index');
+    expect(mod).toBeDefined();
   });
 });

--- a/packages/wow/test/query/event/domainEventStream.test.ts
+++ b/packages/wow/test/query/event/domainEventStream.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DomainEvent,
+  DomainEventStream,
+  DomainEventStreamMetadataFields,
+} from '../../../src';
+
+interface TestEventBody {
+  message: string;
+  count: number;
+}
+
+describe('DomainEvent', () => {
+  it('should create a domain event with required properties', () => {
+    const event: DomainEvent<TestEventBody> = {
+      id: 'event-id-1',
+      name: 'TestEvent',
+      body: {
+        message: 'test message',
+        count: 42,
+      },
+      bodyType: 'TestEventBody',
+      revision: '1.0',
+    };
+
+    expect(event).toBeDefined();
+    expect(event.id).toBe('event-id-1');
+    expect(event.name).toBe('TestEvent');
+    expect(event.body.message).toBe('test message');
+    expect(event.body.count).toBe(42);
+    expect(event.bodyType).toBe('TestEventBody');
+    expect(event.revision).toBe('1.0');
+  });
+});
+
+describe('DomainEventStream', () => {
+  it('should create a domain event stream with required properties', () => {
+    const events: DomainEvent<TestEventBody>[] = [
+      {
+        id: 'event-id-1',
+        name: 'TestEvent',
+        body: {
+          message: 'test message 1',
+          count: 1,
+        },
+        bodyType: 'TestEventBody',
+        revision: '1.0',
+      },
+      {
+        id: 'event-id-2',
+        name: 'TestEvent',
+        body: {
+          message: 'test message 2',
+          count: 2,
+        },
+        bodyType: 'TestEventBody',
+        revision: '1.0',
+      },
+    ];
+
+    const stream: DomainEventStream = {
+      id: 'stream-id-1',
+      contextName: 'context-name-1',
+      aggregateName: 'aggregate-name-1',
+      aggregateId: 'aggregate-id-1',
+      tenantId: 'tenant-id-1',
+      ownerId: 'owner-id-1',
+      commandId: 'command-id-1',
+      createTime: Date.now(),
+      requestId: 'request-id-1',
+      version: 1,
+      body: events,
+      headers: {
+        remote_ip: '127.0.0.1',
+      },
+    };
+
+    expect(stream).toBeDefined();
+    expect(stream.id).toBe('stream-id-1');
+    expect(stream.contextName).toBe('context-name-1');
+    expect(stream.aggregateName).toBe('aggregate-name-1');
+    expect(stream.aggregateId).toBe('aggregate-id-1');
+    expect(stream.tenantId).toBe('tenant-id-1');
+    expect(stream.ownerId).toBe('owner-id-1');
+    expect(stream.commandId).toBe('command-id-1');
+    expect(stream.requestId).toBe('request-id-1');
+    expect(stream.version).toBe(1);
+    expect(stream.body).toHaveLength(2);
+    expect(stream.headers.remote_ip).toBe('127.0.0.1');
+  });
+});
+
+describe('DomainEventStreamMetadataFields', () => {
+  it('should have correct field values', () => {
+    expect(DomainEventStreamMetadataFields.HEADERS).toBe('headers');
+    expect(DomainEventStreamMetadataFields.COMMAND_OPERATOR).toBe('headers.command_operator');
+    expect(DomainEventStreamMetadataFields.AGGREGATE_ID).toBe('aggregateId');
+    expect(DomainEventStreamMetadataFields.TENANT_ID).toBe('tenantId');
+    expect(DomainEventStreamMetadataFields.OWNER_ID).toBe('ownerId');
+    expect(DomainEventStreamMetadataFields.COMMAND_ID).toBe('commandId');
+    expect(DomainEventStreamMetadataFields.REQUEST_ID).toBe('requestId');
+    expect(DomainEventStreamMetadataFields.VERSION).toBe('version');
+    expect(DomainEventStreamMetadataFields.BODY).toBe('body');
+    expect(DomainEventStreamMetadataFields.BODY_ID).toBe('body.id');
+    expect(DomainEventStreamMetadataFields.BODY_NAME).toBe('body.name');
+    expect(DomainEventStreamMetadataFields.BODY_TYPE).toBe('body.bodyType');
+    expect(DomainEventStreamMetadataFields.BODY_REVISION).toBe('body.revision');
+    expect(DomainEventStreamMetadataFields.BODY_BODY).toBe('body.body');
+    expect(DomainEventStreamMetadataFields.CREATE_TIME).toBe('createTime');
+  });
+});

--- a/packages/wow/test/query/snapshot/snapshot.test.ts
+++ b/packages/wow/test/query/snapshot/snapshot.test.ts
@@ -79,11 +79,15 @@ describe('SmallMaterializedSnapshot', () => {
 describe('SnapshotMetadataFields', () => {
   it('should have correct field values', () => {
     expect(SnapshotMetadataFields.VERSION).toBe('version');
-    expect(SnapshotMetadataFields.FIRST_OPERATOR).toBe('firstOperator');
-    expect(SnapshotMetadataFields.OPERATOR).toBe('operator');
+    expect(SnapshotMetadataFields.TENANT_ID).toBe('tenantId');
+    expect(SnapshotMetadataFields.OWNER_ID).toBe('ownerId');
+    expect(SnapshotMetadataFields.EVENT_ID).toBe('eventId');
     expect(SnapshotMetadataFields.FIRST_EVENT_TIME).toBe('firstEventTime');
     expect(SnapshotMetadataFields.EVENT_TIME).toBe('eventTime');
+    expect(SnapshotMetadataFields.FIRST_OPERATOR).toBe('firstOperator');
+    expect(SnapshotMetadataFields.OPERATOR).toBe('operator');
     expect(SnapshotMetadataFields.SNAPSHOT_TIME).toBe('snapshotTime');
+    expect(SnapshotMetadataFields.DELETED).toBe('deleted');
     expect(SnapshotMetadataFields.STATE).toBe('state');
   });
 });


### PR DESCRIPTION
- Add DomainEventStreamMetadataFields class to provide field names for domain event stream metadata
- Update SnapshotMetadataFields class to include new fields
- Add unit tests for domain event stream and snapshot metadata fields
- Update index test to import modules