### PR TITLE
refactor(query): rename sort functions to asc and desc

### DIFF
--- a/packages/wow/src/query/sort.ts
+++ b/packages/wow/src/query/sort.ts
@@ -29,7 +29,7 @@ export interface Sort {
  * @param field - The field to sort by
  * @returns A Sort object with the specified field and ascending direction
  */
-export function sort(field: string): Sort {
+export function asc(field: string): Sort {
   return {
     field,
     direction: SortDirection.ASC,
@@ -41,7 +41,7 @@ export function sort(field: string): Sort {
  * @param field - The field to sort by
  * @returns A Sort object with the specified field and descending direction
  */
-export function sortDesc(field: string): Sort {
+export function desc(field: string): Sort {
   return {
     field,
     direction: SortDirection.DESC,

--- a/packages/wow/test/query/sort.test.ts
+++ b/packages/wow/test/query/sort.test.ts
@@ -12,12 +12,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { sort, sortDesc, SortDirection } from '../../src';
+import { asc, desc, SortDirection } from '../../src';
 
 describe('sort', () => {
   it('should create a sort object with ascending direction', () => {
     const field = 'testField';
-    const result = sort(field);
+    const result = asc(field);
 
     expect(result).toEqual({
       field,
@@ -27,7 +27,7 @@ describe('sort', () => {
 
   it('should create a sort object with descending direction', () => {
     const field = 'testField';
-    const result = sortDesc(field);
+    const result = desc(field);
 
     expect(result).toEqual({
       field,


### PR DESCRIPTION
- Rename sort() function to asc() for ascending sort
- Rename sortDesc() function to desc() for descending sort
- Update related test cases