### PR TITLE
refactor(decorator): use requiredEventStream and requiredJsonEventStream

### DIFF
--- a/packages/decorator/src/resultExtractor.ts
+++ b/packages/decorator/src/resultExtractor.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { ExchangeError, FetchExchange } from '@ahoo-wang/fetcher';
+import { FetchExchange } from '@ahoo-wang/fetcher';
 import {
   JsonServerSentEventStream,
   ServerSentEventStream,
@@ -96,12 +96,7 @@ export const TextResultExtractor: ResultExtractor = (
 export const EventStreamResultExtractor: ResultExtractor = (
   exchange: FetchExchange,
 ) => {
-  // Check if response supports event stream, throw exception if not supported
-  if (!exchange.requiredResponse.eventStream) {
-    throw new ExchangeError(exchange, 'ServerSentEventStream is not supported');
-  }
-  // Return the event stream
-  return exchange.requiredResponse.eventStream()!;
+  return exchange.requiredResponse.requiredEventStream();
 };
 
 /**
@@ -114,15 +109,7 @@ export const EventStreamResultExtractor: ResultExtractor = (
 export const JsonEventStreamResultExtractor: ResultExtractor = (
   exchange: FetchExchange,
 ) => {
-  // Check if response supports event stream, throw exception if not supported
-  if (!exchange.requiredResponse.jsonEventStream) {
-    throw new ExchangeError(
-      exchange,
-      'JsonServerSentEventStream is not supported',
-    );
-  }
-  // Return the event stream
-  return exchange.requiredResponse.jsonEventStream()!;
+  return exchange.requiredResponse.requiredJsonEventStream();
 };
 
 /**

--- a/packages/decorator/test/resultExtractor.test.ts
+++ b/packages/decorator/test/resultExtractor.test.ts
@@ -86,12 +86,12 @@ describe('ResultExtractor', () => {
     it('should return ServerSentEventStream when response supports event stream', () => {
       const eventStreamResponse = new Response('');
 
-      // Mock the eventStream function on the response
+      // Mock the requiredEventStream function on the response
       const mockEventStream = {} as ServerSentEventStream;
-      Object.defineProperty(eventStreamResponse, 'eventStream', {
+      Object.defineProperty(eventStreamResponse, 'requiredEventStream', {
         configurable: true,
         enumerable: true,
-        get: () => () => mockEventStream,
+        value: () => mockEventStream,
       });
 
       const eventStreamExchange = new FetchExchange(
@@ -106,11 +106,13 @@ describe('ResultExtractor', () => {
 
     it('should throw ExchangeError when server does not support ServerSentEventStream', () => {
       const noEventStreamResponse = new Response('');
-      // Ensure there's no eventStream function
-      Object.defineProperty(noEventStreamResponse, 'eventStream', {
+      // Mock the requiredEventStream function to throw ExchangeError
+      Object.defineProperty(noEventStreamResponse, 'requiredEventStream', {
         configurable: true,
         enumerable: true,
-        get: () => undefined,
+        value: () => {
+          throw new ExchangeError(new FetchExchange({} as any, mockRequest, noEventStreamResponse), 'ServerSentEventStream is not supported');
+        },
       });
 
       const noEventStreamExchange = new FetchExchange(
@@ -129,12 +131,12 @@ describe('ResultExtractor', () => {
     it('should return JsonServerSentEventStream when response supports json event stream', () => {
       const jsonEventStreamResponse = new Response('');
 
-      // Mock the jsonEventStream function on the response
+      // Mock the requiredJsonEventStream function on the response
       const mockJsonEventStream = {} as JsonServerSentEventStream<any>;
-      Object.defineProperty(jsonEventStreamResponse, 'jsonEventStream', {
+      Object.defineProperty(jsonEventStreamResponse, 'requiredJsonEventStream', {
         configurable: true,
         enumerable: true,
-        get: () => () => mockJsonEventStream,
+        value: () => mockJsonEventStream,
       });
 
       const jsonEventStreamExchange = new FetchExchange(
@@ -149,11 +151,13 @@ describe('ResultExtractor', () => {
 
     it('should throw ExchangeError when server does not support JsonServerSentEventStream', () => {
       const noJsonEventStreamResponse = new Response('');
-      // Ensure there's no jsonEventStream function
-      Object.defineProperty(noJsonEventStreamResponse, 'jsonEventStream', {
+      // Mock the requiredJsonEventStream function to throw ExchangeError
+      Object.defineProperty(noJsonEventStreamResponse, 'requiredJsonEventStream', {
         configurable: true,
         enumerable: true,
-        get: () => undefined,
+        value: () => {
+          throw new ExchangeError(new FetchExchange({} as any, mockRequest, noJsonEventStreamResponse), 'JsonServerSentEventStream is not supported');
+        },
       });
 
       const noJsonEventStreamExchange = new FetchExchange(


### PR DESCRIPTION

- Replace exchange.requiredResponse.eventStream with requiredEventStream
- Replace exchange.requiredResponse.jsonEventStream with requiredJsonEventStream
- Update unit tests to use new requiredEventStream and requiredJsonEventStream methods
- Remove unnecessary ExchangeError import and usage