### PR TITLE
feat(wow): implement EventStreamQueryClient and refactor query clients

### DIFF
--- a/integration-test/test/wow/eventStreamQueryClient.test.ts
+++ b/integration-test/test/wow/eventStreamQueryClient.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { ExchangeError, Fetcher, FetchExchange, HttpMethod, URL_RESOLVE_INTERCEPTOR_ORDER } from '@ahoo-wang/fetcher';
+import { idGenerator } from '@ahoo-wang/fetcher-cosec';
+import {
+  all,
+  CommandHeaders,
+  CommandHttpClient,
+  CommandHttpRequest,
+  CommandStage, ErrorCodes, id, ListQuery, PagedQuery, SingleQuery,
+  EventStreamQueryClient, MaterializedSnapshot, DomainEventStream,
+} from '@ahoo-wang/fetcher-wow';
+import { describe, expect, it } from 'vitest';
+
+const wowFetcher = new Fetcher({
+  baseURL: 'http://localhost:8080/',
+});
+const ownerId = idGenerator.generateId();
+wowFetcher.interceptors.request.use({
+  name: 'AppendOwnerId',
+  order: URL_RESOLVE_INTERCEPTOR_ORDER - 1,
+  intercept(exchange: FetchExchange) {
+    exchange.request.urlParams = {
+      path: {
+        ...exchange.request.urlParams?.path,
+        ownerId,
+      },
+      query: exchange.request.urlParams?.query,
+    };
+  },
+});
+
+const commandHttpClient = new CommandHttpClient(wowFetcher);
+const aggregateBasePath = 'owner/{ownerId}/cart';
+const cartQueryClient = new EventStreamQueryClient({
+  fetcher: wowFetcher,
+  basePath: aggregateBasePath,
+});
+const command: CommandHttpRequest = {
+  path: `${aggregateBasePath}/add_cart_item`,
+  method: HttpMethod.POST,
+  headers: {
+    [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT,
+  },
+  body: {
+    productId: 'productId',
+    quantity: 1,
+  },
+};
+const commandResult = await commandHttpClient.send(command);
+expect(commandResult.errorCode).toBe(ErrorCodes.SUCCEEDED);
+
+
+function expectDomainEventStreamToBeDefined(domainEventStream: Partial<DomainEventStream>) {
+  expect(domainEventStream.contextName).toBeDefined();
+  expect(domainEventStream.aggregateName).toBeDefined();
+  expect(domainEventStream.header).toBeDefined();
+  expect(domainEventStream.id).toBeDefined();
+  expect(domainEventStream.aggregateId).toBeDefined();
+  expect(domainEventStream.tenantId).toBeDefined();
+  expect(domainEventStream.ownerId).toBeDefined();
+  expect(domainEventStream.commandId).toBeDefined();
+  expect(domainEventStream.requestId).toBeDefined();
+  expect(domainEventStream.version).toBeDefined();
+  expect(domainEventStream.body).toBeDefined();
+  expect(domainEventStream.createTime).toBeDefined;
+  for (const domainEvent of domainEventStream.body!) {
+    expect(domainEvent.id).toBeDefined();
+    expect(domainEvent.name).toBeDefined();
+    expect(domainEvent.revision).toBeDefined();
+    expect(domainEvent.bodyType).toBeDefined();
+    expect(domainEvent.body).toBeDefined();
+  }
+}
+
+describe('EventStreamQueryClient Integration Test', () => {
+
+  it('should count', async () => {
+    const count = await cartQueryClient.count(all());
+    expect(count).greaterThanOrEqual(1);
+  });
+
+  it('should list', async () => {
+    const listQuery: ListQuery = {
+      condition: all(),
+    };
+    const list = await cartQueryClient.list(listQuery);
+    for (const domainEventStream of list) {
+      expectDomainEventStreamToBeDefined(domainEventStream);
+    }
+  });
+
+  it('should list stream', async () => {
+    const listQuery: ListQuery = {
+      condition: all(),
+    };
+    const listStream = await cartQueryClient.listStream(listQuery);
+    for await (const event of listStream) {
+      const domainEventStream = event.data;
+      expectDomainEventStreamToBeDefined(domainEventStream);
+    }
+  });
+
+
+  it('should paged', async () => {
+    const pagedQuery: PagedQuery = {
+      condition: all(),
+    };
+    const paged = await cartQueryClient.paged(pagedQuery);
+    expect(paged.total).greaterThanOrEqual(1);
+    expect(paged.list.length).greaterThanOrEqual(1);
+    for (const domainEventStream of paged.list) {
+      expectDomainEventStreamToBeDefined(domainEventStream);
+    }
+  });
+
+});

--- a/integration-test/test/wow/snapshotQueryClient.test.ts
+++ b/integration-test/test/wow/snapshotQueryClient.test.ts
@@ -101,7 +101,7 @@ function expectSnapshotToBeDefined(snapshot: Partial<MaterializedSnapshot<CartSt
   expectCartState(snapshot.state);
 }
 
-describe('CommandHttpClient Integration Test', () => {
+describe('SnapshotQueryClient Integration Test', () => {
 
   it('should count', async () => {
     const count = await cartQueryClient.count(all());

--- a/packages/wow/src/query/event/domainEventStream.ts
+++ b/packages/wow/src/query/event/domainEventStream.ts
@@ -34,7 +34,7 @@ export interface DomainEvent<BODY>
   revision: string;
 }
 
-export interface DomainEventStreamHeaders {
+export interface DomainEventStreamHeader {
   command_operator?: string;
   command_wait_endpoint?: string;
   command_wait_stage?: CommandStage;
@@ -55,7 +55,7 @@ export interface DomainEventStream
     RequestId,
     Version,
     BodyCapable<DomainEvent<any>[]> {
-  headers: DomainEventStreamHeaders;
+  header: DomainEventStreamHeader;
 }
 
 /**
@@ -66,8 +66,8 @@ export interface DomainEventStream
  * The fields include headers, identifiers, command information, versioning, body content, and creation time.
  */
 export class DomainEventStreamMetadataFields {
-  static readonly HEADERS = 'headers';
-  static readonly COMMAND_OPERATOR = `${DomainEventStreamMetadataFields.HEADERS}.command_operator`;
+  static readonly HEADER = 'header';
+  static readonly COMMAND_OPERATOR = `${DomainEventStreamMetadataFields.HEADER}.command_operator`;
   static readonly AGGREGATE_ID = 'aggregateId';
   static readonly TENANT_ID = 'tenantId';
   static readonly OWNER_ID = 'ownerId';

--- a/packages/wow/src/query/event/eventStreamQueryClient.ts
+++ b/packages/wow/src/query/event/eventStreamQueryClient.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EventStreamQueryApi, EventStreamQueryEndpointPaths } from './eventStreamQueryApi';
+import { Condition } from '../condition';
+import { ListQuery, PagedList, PagedQuery } from '../queryable';
+import { DomainEventStream } from './domainEventStream';
+import { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
+import { QueryClient } from '../queryApi';
+import { ClientOptions } from '../../types';
+import { ContentTypeValues } from '@ahoo-wang/fetcher';
+import { ResultExtractors } from '@ahoo-wang/fetcher-decorator';
+
+export class EventStreamQueryClient extends QueryClient implements EventStreamQueryApi {
+  constructor(options: ClientOptions) {
+    super(options);
+  }
+
+  count(condition: Condition): Promise<number> {
+    return this.query(EventStreamQueryEndpointPaths.COUNT, condition);
+  }
+
+  list(listQuery: ListQuery): Promise<Partial<DomainEventStream>[]> {
+    return this.query(EventStreamQueryEndpointPaths.LIST, listQuery);
+  }
+
+  listStream(listQuery: ListQuery): Promise<ReadableStream<JsonServerSentEvent<Partial<DomainEventStream>>>> {
+    return this.query(EventStreamQueryEndpointPaths.LIST, listQuery, ContentTypeValues.TEXT_EVENT_STREAM, ResultExtractors.JsonEventStream);
+  }
+
+  paged(pagedQuery: PagedQuery): Promise<PagedList<Partial<DomainEventStream>>> {
+    return this.query(EventStreamQueryEndpointPaths.PAGED, pagedQuery);
+  }
+}

--- a/packages/wow/src/query/event/index.ts
+++ b/packages/wow/src/query/event/index.ts
@@ -13,3 +13,4 @@
 
 export * from './domainEventStream';
 export * from './eventStreamQueryApi';
+export * from './eventStreamQueryClient';

--- a/packages/wow/src/query/snapshot/snapshotQueryClient.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryClient.ts
@@ -16,61 +16,24 @@ import { Condition } from '../condition';
 import { ListQuery, PagedList, PagedQuery, SingleQuery } from '../queryable';
 import { MaterializedSnapshot } from './snapshot';
 import { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
-import { combineURLs, ContentTypeValues, Fetcher, HttpMethod } from '@ahoo-wang/fetcher';
-import { ResultExtractor, ResultExtractors } from '@ahoo-wang/fetcher-decorator';
+import { ContentTypeValues } from '@ahoo-wang/fetcher';
+import { ResultExtractors } from '@ahoo-wang/fetcher-decorator';
 import '@ahoo-wang/fetcher-eventstream';
-
-/**
- * Configuration options for the SnapshotQueryClient.
- */
-export interface SnapshotQueryOptions {
-  /**
-   * The fetcher instance used to make HTTP requests.
-   */
-  fetcher: Fetcher;
-  /**
-   * The base URL path for all snapshot query endpoints.
-   */
-  basePath: string;
-}
+import { ClientOptions } from '../../types';
+import { QueryClient } from '../queryApi';
 
 /**
  * A client for querying snapshot data through HTTP endpoints.
  * Provides methods for various query operations such as counting, listing, paging, and retrieving single snapshots.
  * @template S The type of the snapshot state
  */
-export class SnapshotQueryClient<S> implements SnapshotQueryApi<S> {
+export class SnapshotQueryClient<S> extends QueryClient implements SnapshotQueryApi<S> {
   /**
    * Creates a new SnapshotQueryClient instance.
    * @param options - The configuration options for the client
    */
-  constructor(private options: SnapshotQueryOptions) {
-  }
-
-  /**
-   * Performs a generic query operation by sending a request to the specified path.
-   * @template R The return type of the query
-   * @param path - The endpoint path to query
-   * @param query - The query parameters to send
-   * @param accept - The content type to accept from the server
-   * @param extractor - Function to extract the result from the response, defaults to JSON extractor
-   * @returns A promise that resolves to the query result
-   */
-  private async query<R>(path: string,
-                         query: Condition | ListQuery | PagedQuery | SingleQuery,
-                         accept: string = ContentTypeValues.APPLICATION_JSON,
-                         extractor: ResultExtractor = ResultExtractors.Json): Promise<R> {
-    const url = combineURLs(this.options.basePath, path);
-    const request = {
-      url: url,
-      method: HttpMethod.POST,
-      headers: {
-        Accept: accept,
-      },
-      body: query,
-    };
-    const exchange = await this.options.fetcher.request(request);
-    return extractor(exchange);
+  constructor(options: ClientOptions) {
+    super(options);
   }
 
   /**

--- a/packages/wow/src/types/client.ts
+++ b/packages/wow/src/types/client.ts
@@ -11,10 +11,19 @@
  * limitations under the License.
  */
 
-export * from './client';
-export * from './common';
-export * from './error';
-export * from './function';
-export * from './messaging';
-export * from './modeling';
-export * from './naming';
+
+import { Fetcher } from '@ahoo-wang/fetcher';
+
+/**
+ * Configuration options for the Client.
+ */
+export interface ClientOptions {
+  /**
+   * The fetcher instance used to make HTTP requests.
+   */
+  fetcher: Fetcher;
+  /**
+   * The base URL path for all endpoints.
+   */
+  basePath: string;
+}

--- a/packages/wow/test/query/event/domainEventStream.test.ts
+++ b/packages/wow/test/query/event/domainEventStream.test.ts
@@ -83,7 +83,7 @@ describe('DomainEventStream', () => {
       requestId: 'request-id-1',
       version: 1,
       body: events,
-      headers: {
+      header: {
         remote_ip: '127.0.0.1',
       },
     };
@@ -99,15 +99,15 @@ describe('DomainEventStream', () => {
     expect(stream.requestId).toBe('request-id-1');
     expect(stream.version).toBe(1);
     expect(stream.body).toHaveLength(2);
-    expect(stream.headers.remote_ip).toBe('127.0.0.1');
+    expect(stream.header.remote_ip).toBe('127.0.0.1');
   });
 });
 
 describe('DomainEventStreamMetadataFields', () => {
   it('should have correct field values', () => {
-    expect(DomainEventStreamMetadataFields.HEADERS).toBe('headers');
+    expect(DomainEventStreamMetadataFields.HEADER).toBe('header');
     expect(DomainEventStreamMetadataFields.COMMAND_OPERATOR).toBe(
-      'headers.command_operator',
+      'header.command_operator',
     );
     expect(DomainEventStreamMetadataFields.AGGREGATE_ID).toBe('aggregateId');
     expect(DomainEventStreamMetadataFields.TENANT_ID).toBe('tenantId');

--- a/packages/wow/vitest.config.ts
+++ b/packages/wow/vitest.config.ts
@@ -23,8 +23,12 @@ export default mergeConfig(
           ...configDefaults.exclude,
           // use integration-test, see integration-test/test/wow/commandHttpClient.test.ts
           'src/command/commandHttpClient.ts',
+          // use integration-test
+          'src/query/queryApi.ts',
           // use integration-test, see integration-test/test/wow/snapshotQueryClient.test.ts
           'src/query/snapshot/snapshotQueryClient.ts',
+          // use integration-test, see integration-test/test/wow/eventStreamQueryClient.test.ts
+          'src/query/event/eventStreamQueryClient.ts',
         ],
       },
     },


### PR DESCRIPTION
- Add EventStreamQueryClient for querying event streams
- Refactor SnapshotQueryClient to use new QueryClient base class
- Update integration tests for new and modified query clients
- Rename DomainEventStreamHeaders to DomainEventStreamHeader
- Move common query logic to QueryClient class