### PR TITLE
refactor(fetcher): move interpolateUrl to urls.ts and add extractPathParams

### DIFF
--- a/packages/fetcher/src/urlBuilder.ts
+++ b/packages/fetcher/src/urlBuilder.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { combineURLs } from './urls';
+import { combineURLs, interpolateUrl } from './urls';
 import { BaseURLCapable, FetchRequest } from './fetchRequest';
 
 /**
@@ -108,7 +108,7 @@ export class UrlBuilder implements BaseURLCapable {
     const path = params?.path;
     const query = params?.query;
     const combinedURL = combineURLs(this.baseURL, url);
-    let finalUrl = this.interpolateUrl(combinedURL, path);
+    let finalUrl = interpolateUrl(combinedURL, path);
     if (query) {
       const queryString = new URLSearchParams(query).toString();
       if (queryString) {
@@ -129,45 +129,6 @@ export class UrlBuilder implements BaseURLCapable {
    */
   resolveRequestUrl(request: FetchRequest): string {
     return this.build(request.url, request.urlParams);
-  }
-
-  /**
-   * Replaces placeholders in the URL with path parameters.
-   *
-   * @param url - Path string containing placeholders, e.g., "http://localhost/users/{id}/posts/{postId}"
-   * @param path - Path parameter object used to replace placeholders in the URL
-   * @returns Path string with placeholders replaced
-   * @throws Error when required path parameters are missing
-   *
-   * @example
-   * ```typescript
-   * const urlBuilder = new UrlBuilder('https://api.example.com');
-   * const result = urlBuilder.interpolateUrl('/users/{id}/posts/{postId}', {
-   *   path: { id: 123, postId: 456 }
-   * });
-   * // Result: https://api.example.com/users/123/posts/456
-   * ```
-   *
-   * @example
-   * ```typescript
-   * // Missing required parameter throws an error
-   * try {
-   *   urlBuilder.interpolateUrl('/users/{id}', { name: 'John' });
-   * } catch (error) {
-   *   console.error(error.message); // "Missing required path parameter: id"
-   * }
-   * ```
-   */
-  interpolateUrl(url: string, path?: Record<string, any> | null): string {
-    if (!path) return url;
-    return url.replace(/{([^}]+)}/g, (_, key) => {
-      const value = path[key];
-      // If path parameter is undefined, throw an error instead of preserving the placeholder
-      if (value === undefined) {
-        throw new Error(`Missing required path parameter: ${key}`);
-      }
-      return String(value);
-    });
   }
 }
 

--- a/packages/fetcher/src/urls.ts
+++ b/packages/fetcher/src/urls.ts
@@ -55,3 +55,85 @@ export function combineURLs(baseURL: string, relativeURL: string) {
     ? baseURL.replace(/\/?\/$/, '') + '/' + relativeURL.replace(/^\/+/, '')
     : baseURL;
 }
+
+
+/**
+ * Regular expression pattern to match path parameters in the format {paramName}
+ *
+ * This regex is used to identify and extract path parameters from URL patterns.
+ * It matches any text enclosed in curly braces {} and captures the content inside.
+ *
+ * Example matches:
+ * - {id} -> captures "id"
+ * - {userId} -> captures "userId"
+ * - {category-name} -> captures "category-name"
+ */
+const PATH_PARAM_REGEX = /{([^}]+)}/g;
+
+/**
+ * Extracts path parameters from a URL string.
+ *
+ * @param url - The URL string to extract path parameters from
+ * @returns An array of path parameter names without the curly braces, or an empty array if no matches found
+ *
+ * @example
+ * ```typescript
+ * extractPathParams('/users/{id}/posts/{postId}');
+ * // Returns: ['id', 'postId']
+ *
+ * extractPathParams('https://api.example.com/{resource}/{id}');
+ * // Returns: ['resource', 'id']
+ *
+ * extractPathParams('/users/profile');
+ * // Returns: []
+ * ```
+ */
+export function extractPathParams(url: string): string[] {
+  // Extract all path parameter matches using regex
+  const matches = url.match(PATH_PARAM_REGEX);
+  if (!matches) {
+    return [];
+  }
+  // Remove the curly braces from each matched parameter and return as array
+  return matches.map(match => match.slice(1, -1));
+}
+
+/**
+ * Replaces placeholders in the URL with path parameters.
+ *
+ * @param url - Path string containing placeholders, e.g., "http://localhost/users/{id}/posts/{postId}"
+ * @param path - Path parameter object used to replace placeholders in the URL
+ * @returns Path string with placeholders replaced
+ * @throws Error when required path parameters are missing
+ *
+ * @example
+ * ```typescript
+ * const urlBuilder = new UrlBuilder('https://api.example.com');
+ * const result = urlBuilder.interpolateUrl('/users/{id}/posts/{postId}', {
+ *   path: { id: 123, postId: 456 }
+ * });
+ * // Result: https://api.example.com/users/123/posts/456
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Missing required parameter throws an error
+ * try {
+ *   urlBuilder.interpolateUrl('/users/{id}', { name: 'John' });
+ * } catch (error) {
+ *   console.error(error.message); // "Missing required path parameter: id"
+ * }
+ * ```
+ */
+export function interpolateUrl(url: string, path?: Record<string, any> | null): string {
+  if (!path) return url;
+  return url.replace(PATH_PARAM_REGEX, (_, key) => {
+    const value = path[key];
+    // If path parameter is undefined, throw an error instead of preserving the placeholder
+    if (value === undefined) {
+      throw new Error(`Missing required path parameter: ${key}`);
+    }
+    return String(value);
+  });
+}
+

--- a/packages/fetcher/test/urlBuilder.test.ts
+++ b/packages/fetcher/test/urlBuilder.test.ts
@@ -158,69 +158,6 @@ describe('UrlBuilder', () => {
     });
   });
 
-  describe('interpolateUrl', () => {
-    it('should return original URL when path is undefined', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      const url = urlBuilder.interpolateUrl('/users/{id}');
-      expect(url).toBe('/users/{id}');
-    });
-
-    it('should return original URL when path is null', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      const url = urlBuilder.interpolateUrl('/users/{id}', null);
-      expect(url).toBe('/users/{id}');
-    });
-
-    it('should replace single path parameter', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      const url = urlBuilder.interpolateUrl('/users/{id}', { id: 123 });
-      expect(url).toBe('/users/123');
-    });
-
-    it('should replace multiple path parameters', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      const url = urlBuilder.interpolateUrl('/users/{userId}/posts/{postId}', {
-        userId: 123,
-        postId: 456,
-      });
-      expect(url).toBe('/users/123/posts/456');
-    });
-
-    it('should throw error when required path parameter is missing', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      expect(() => urlBuilder.interpolateUrl('/users/{id}', {})).toThrow(
-        'Missing required path parameter: id',
-      );
-    });
-
-    it('should throw error when required path parameter is undefined', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      expect(() =>
-        urlBuilder.interpolateUrl('/users/{id}', { id: undefined }),
-      ).toThrow('Missing required path parameter: id');
-    });
-
-    it('should handle path parameter with special characters', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      const url = urlBuilder.interpolateUrl('/users/{id}', {
-        id: 'user@domain.com',
-      });
-      expect(url).toBe('/users/user@domain.com');
-    });
-
-    it('should handle URL without placeholders', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      const url = urlBuilder.interpolateUrl('/users/list', { id: 123 });
-      expect(url).toBe('/users/list');
-    });
-
-    it('should handle empty URL', () => {
-      const urlBuilder = new UrlBuilder('https://api.example.com');
-      const url = urlBuilder.interpolateUrl('', { id: 123 });
-      expect(url).toBe('');
-    });
-  });
-
   describe('resolveRequestUrl', () => {
     it('should resolve request URL with urlParams', () => {
       const urlBuilder = new UrlBuilder('https://api.example.com');

--- a/packages/fetcher/test/urls.test.ts
+++ b/packages/fetcher/test/urls.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isAbsoluteURL, combineURLs } from '../src';
+import { isAbsoluteURL, combineURLs, extractPathParams, interpolateUrl } from '../src';
 
 describe('urls.ts', () => {
   describe('isAbsoluteURL', () => {
@@ -59,6 +59,64 @@ describe('urls.ts', () => {
       expect(combineURLs('http://base.com', undefined as any)).toBe(
         'http://base.com',
       );
+    });
+  });
+
+  describe('extractPathParams', () => {
+    it('should return empty array when no path parameters exist', () => {
+      expect(extractPathParams('/users/profile')).toEqual([]);
+      expect(extractPathParams('https://api.example.com/users')).toEqual([]);
+    });
+
+    it('should return array with one parameter when URL contains one path parameter', () => {
+      expect(extractPathParams('/users/{id}')).toEqual(['id']);
+      expect(extractPathParams('https://api.example.com/users/{userId}')).toEqual(['userId']);
+    });
+
+    it('should return array with multiple parameters when URL contains multiple path parameters', () => {
+      expect(extractPathParams('/users/{id}/posts/{postId}')).toEqual(['id', 'postId']);
+      expect(extractPathParams('https://api.example.com/{resource}/{id}/details')).toEqual(['resource', 'id']);
+    });
+
+    it('should return empty array when URL is empty string', () => {
+      expect(extractPathParams('')).toEqual([]);
+    });
+
+    it('should extract parameters with special characters', () => {
+      expect(extractPathParams('/api/{version}/users/{user_id}/details')).toEqual(['version', 'user_id']);
+      expect(extractPathParams('/{category-name}/{sub-category}')).toEqual(['category-name', 'sub-category']);
+    });
+
+    it('should extract all parameters when URL contains only path parameters', () => {
+      expect(extractPathParams('{first}/{second}/{third}')).toEqual(['first', 'second', 'third']);
+    });
+  });
+
+  describe('interpolateUrl', () => {
+    it('should return original URL when path parameters are not provided', () => {
+      expect(interpolateUrl('/users/{id}/posts/{postId}')).toBe('/users/{id}/posts/{postId}');
+      expect(interpolateUrl('/users/{id}/posts/{postId}', null)).toBe('/users/{id}/posts/{postId}');
+      expect(interpolateUrl('/users/{id}/posts/{postId}', undefined)).toBe('/users/{id}/posts/{postId}');
+    });
+
+    it('should replace placeholders with provided values', () => {
+      expect(interpolateUrl('/users/{id}', { id: 123 })).toBe('/users/123');
+      expect(interpolateUrl('/users/{id}/posts/{postId}', { id: 123, postId: 456 })).toBe('/users/123/posts/456');
+      expect(interpolateUrl('https://api.example.com/{resource}/{id}', {
+        resource: 'users',
+        id: 123,
+      })).toBe('https://api.example.com/users/123');
+    });
+
+    it('should handle different data types for parameter values', () => {
+      expect(interpolateUrl('/items/{id}', { id: 'abc' })).toBe('/items/abc');
+      expect(interpolateUrl('/items/{flag}', { flag: true })).toBe('/items/true');
+      expect(interpolateUrl('/items/{count}', { count: 0 })).toBe('/items/0');
+    });
+
+    it('should throw error when required path parameter is missing', () => {
+      expect(() => interpolateUrl('/users/{id}', { name: 'John' })).toThrow('Missing required path parameter: id');
+      expect(() => interpolateUrl('/users/{id}/posts/{postId}', { id: 123 })).toThrow('Missing required path parameter: postId');
     });
   });
 });


### PR DESCRIPTION


- Move interpolateUrl function from UrlBuilder to urls.ts
- Add extractPathParams function to urls.ts
- Update related tests to use new functions
- Remove interpolateUrl from UrlBuilder class