### PR TITLE
refactor(wow): add type safety to CommandRequest

### DIFF
--- a/integration-test/test/wow/commandClient.test.ts
+++ b/integration-test/test/wow/commandClient.test.ts
@@ -73,8 +73,13 @@ function expectCommandResultToBeDefined(commandResult: CommandResult) {
   expect(commandResult.signalTime).toBeDefined();
 }
 
+interface AddCartItem {
+  productId: string;
+  quantity: number;
+}
+
 describe('CommandHttpClient Integration Test', () => {
-  const command: CommandRequest = {
+  const command: CommandRequest<AddCartItem> = {
     method: HttpMethod.POST,
     headers: {
       [CommandHttpHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT,

--- a/packages/wow/src/command/commandRequest.ts
+++ b/packages/wow/src/command/commandRequest.ts
@@ -155,11 +155,11 @@ export interface CommandUrlParams extends Omit<UrlParams, 'path' | 'query'> {
  * Extends RequestHeaders to provide type-safe access to command-related HTTP headers.
  * This interface includes only the essential command headers commonly used in HTTP requests.
  */
-export interface CommandRequest extends FetchRequestInit {
+export interface CommandRequest<C extends object = object> extends FetchRequestInit {
   urlParams?: CommandUrlParams;
   headers?: CommandRequestHeaders;
   /**
    * The body of the command request.
    */
-  body: any;
+  body: C;
 }


### PR DESCRIPTION
- Introduce AddCartItem interface for cart item addition
- Update CommandRequest to use a generic type for body
- Enhance type safety and reduce potential for runtime errors