### PR TITLE
refactor(wow): add type parameter for partial resource type

### DIFF
--- a/packages/wow/src/command/commandClient.ts
+++ b/packages/wow/src/command/commandClient.ts
@@ -13,15 +13,9 @@
 
 import { ClientOptions } from '../types';
 import { CommandRequest } from './commandRequest';
-import { CommandResult } from './commandResult';
+import { CommandResult, CommandResultEventStream } from './commandResult';
 import { ResultExtractor, ResultExtractors } from '@ahoo-wang/fetcher-decorator';
 import { combineURLs, ContentTypeValues } from '@ahoo-wang/fetcher';
-
-/**
- * CommandResultEventStream represents a stream of command execution results.
- * It is a ReadableStream of JsonServerSentEvent containing CommandResult data.
- */
-export type CommandResultEventStream = ReadableStream<any>;
 
 /**
  * Command Client for sending commands to the server.

--- a/packages/wow/src/query/event/eventStreamQueryClient.ts
+++ b/packages/wow/src/query/event/eventStreamQueryClient.ts
@@ -77,7 +77,7 @@ export class EventStreamQueryClient
 
   /**
    * Counts the number of domain event streams that match the given condition.
-   * 
+   *
    * @param condition - The condition to filter event streams
    * @returns A promise that resolves to the count of matching event streams
    *
@@ -93,7 +93,7 @@ export class EventStreamQueryClient
 
   /**
    * Retrieves a list of domain event streams based on the provided query parameters.
-   * 
+   *
    * @param listQuery - The query parameters for listing event streams
    * @returns A promise that resolves to an array of partial domain event streams
    *
@@ -108,14 +108,14 @@ export class EventStreamQueryClient
    * }
    * ```
    */
-  list(listQuery: ListQuery): Promise<Partial<DomainEventStream>[]> {
+  list<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(listQuery: ListQuery): Promise<T[]> {
     return this.query(EventStreamQueryEndpointPaths.LIST, listQuery);
   }
 
   /**
    * Retrieves a stream of domain event streams based on the provided query parameters.
    * Sets the Accept header to text/event-stream to indicate that the response should be streamed.
-   * 
+   *
    * @param listQuery - The query parameters for listing event streams
    * @returns A promise that resolves to a readable stream of JSON server-sent events containing partial domain event streams
    *
@@ -131,9 +131,9 @@ export class EventStreamQueryClient
    * }
    * ```
    */
-  listStream(
+  listStream<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(
     listQuery: ListQuery,
-  ): Promise<ReadableStream<JsonServerSentEvent<Partial<DomainEventStream>>>> {
+  ): Promise<ReadableStream<JsonServerSentEvent<T>>> {
     return this.query(
       EventStreamQueryEndpointPaths.LIST,
       listQuery,
@@ -144,7 +144,7 @@ export class EventStreamQueryClient
 
   /**
    * Retrieves a paged list of domain event streams based on the provided query parameters.
-   * 
+   *
    * @param pagedQuery - The query parameters for paging event streams
    * @returns A promise that resolves to a paged list of partial domain event streams
    *
@@ -162,9 +162,9 @@ export class EventStreamQueryClient
    * }
    * ```
    */
-  paged(
+  paged<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(
     pagedQuery: PagedQuery,
-  ): Promise<PagedList<Partial<DomainEventStream>>> {
+  ): Promise<PagedList<T>> {
     return this.query(EventStreamQueryEndpointPaths.PAGED, pagedQuery);
   }
 }

--- a/packages/wow/src/query/queryApi.ts
+++ b/packages/wow/src/query/queryApi.ts
@@ -36,30 +36,30 @@ export interface QueryApi<R> {
    * @param singleQuery - The query parameters for retrieving a single resource
    * @returns A promise that resolves to a partial resource
    */
-  single(singleQuery: SingleQuery): Promise<Partial<R>>;
+  single<T extends Partial<R> = Partial<R>>(singleQuery: SingleQuery): Promise<T>;
 
   /**
    * Retrieves a list of resources based on the provided query parameters.
    * @param listQuery - The query parameters for listing resources
    * @returns A promise that resolves to an array of partial resources
    */
-  list(listQuery: ListQuery): Promise<Partial<R>[]>;
+  list<T extends Partial<R> = Partial<R>>(listQuery: ListQuery): Promise<T[]>;
 
   /**
    * Retrieves a stream of resources based on the provided query parameters.
    * @param listQuery - The query parameters for listing resources
    * @returns A promise that resolves to a readable stream of JSON server-sent events containing partial resources
    */
-  listStream(
+  listStream<T extends Partial<R> = Partial<R>>(
     listQuery: ListQuery,
-  ): Promise<ReadableStream<JsonServerSentEvent<Partial<R>>>>;
+  ): Promise<ReadableStream<JsonServerSentEvent<T>>>;
 
   /**
    * Retrieves a paged list of resources based on the provided query parameters.
    * @param pagedQuery - The query parameters for paging resources
    * @returns A promise that resolves to a paged list of partial resources
    */
-  paged(pagedQuery: PagedQuery): Promise<PagedList<Partial<R>>>;
+  paged<T extends Partial<R> = Partial<R>>(pagedQuery: PagedQuery): Promise<PagedList<T>>;
 
   /**
    * Counts the number of resources that match the given condition.

--- a/packages/wow/src/query/snapshot/snapshotQueryApi.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryApi.ts
@@ -28,30 +28,30 @@ export interface SnapshotQueryApi<S> extends QueryApi<MaterializedSnapshot<S>> {
    * @param singleQuery - The query parameters for retrieving a single snapshot state
    * @returns A promise that resolves to a partial snapshot state
    */
-  singleState(singleQuery: SingleQuery): Promise<Partial<S>>;
+  singleState<T extends Partial<S> = Partial<S>>(singleQuery: SingleQuery): Promise<T>;
 
   /**
    * Retrieves a list of snapshot states based on the provided query parameters.
    * @param listQuery - The query parameters for listing snapshot states
    * @returns A promise that resolves to an array of partial snapshot states
    */
-  listState(listQuery: ListQuery): Promise<Partial<S>[]>;
+  listState<T extends Partial<S> = Partial<S>>(listQuery: ListQuery): Promise<T[]>;
 
   /**
    * Retrieves a stream of snapshot states based on the provided query parameters.
    * @param listQuery - The query parameters for listing snapshot states
    * @returns A promise that resolves to a readable stream of JSON server-sent events containing partial snapshot states
    */
-  listStateStream(
+  listStateStream<T extends Partial<S> = Partial<S>>(
     listQuery: ListQuery,
-  ): Promise<ReadableStream<JsonServerSentEvent<Partial<S>>>>;
+  ): Promise<ReadableStream<JsonServerSentEvent<T>>>;
 
   /**
    * Retrieves a paged list of snapshot states based on the provided query parameters.
    * @param pagedQuery - The query parameters for paging snapshot states
    * @returns A promise that resolves to a paged list of partial snapshot states
    */
-  pagedState(pagedQuery: PagedQuery): Promise<PagedList<Partial<S>>>;
+  pagedState<T extends Partial<S> = Partial<S>>(pagedQuery: PagedQuery): Promise<PagedList<T>>;
 }
 
 /**

--- a/packages/wow/src/query/snapshot/snapshotQueryClient.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryClient.ts
@@ -96,7 +96,7 @@ import { QueryClient } from '../queryApi';
  * // Single snapshot state
  * const singleState = await snapshotQueryClient.singleState(singleQuery);
  * ```
- * 
+ *
  * @template S The type of the snapshot state
  */
 export class SnapshotQueryClient<S>
@@ -112,7 +112,7 @@ export class SnapshotQueryClient<S>
 
   /**
    * Counts the number of snapshots that match the given condition.
-   * 
+   *
    * @param condition - The condition to match snapshots against
    * @returns A promise that resolves to the count of matching snapshots
    *
@@ -128,7 +128,7 @@ export class SnapshotQueryClient<S>
 
   /**
    * Retrieves a list of materialized snapshots based on the provided query parameters.
-   * 
+   *
    * @param listQuery - The query parameters for listing snapshots
    * @returns A promise that resolves to an array of partial materialized snapshots
    *
@@ -143,13 +143,13 @@ export class SnapshotQueryClient<S>
    * }
    * ```
    */
-  list(listQuery: ListQuery): Promise<Partial<MaterializedSnapshot<S>>[]> {
+  list<T extends Partial<MaterializedSnapshot<S>> = Partial<MaterializedSnapshot<S>>>(listQuery: ListQuery): Promise<T[]> {
     return this.query(SnapshotQueryEndpointPaths.LIST, listQuery);
   }
 
   /**
    * Retrieves a stream of materialized snapshots based on the provided query parameters.
-   * 
+   *
    * @param listQuery - The query parameters for listing snapshots
    * @returns A promise that resolves to a readable stream of JSON server-sent events containing partial materialized snapshots
    *
@@ -165,10 +165,10 @@ export class SnapshotQueryClient<S>
    * }
    * ```
    */
-  listStream(
+  listStream<T extends Partial<MaterializedSnapshot<S>> = Partial<MaterializedSnapshot<S>>>(
     listQuery: ListQuery,
   ): Promise<
-    ReadableStream<JsonServerSentEvent<Partial<MaterializedSnapshot<S>>>>
+    ReadableStream<JsonServerSentEvent<T>>
   > {
     return this.query(
       SnapshotQueryEndpointPaths.LIST,
@@ -180,7 +180,7 @@ export class SnapshotQueryClient<S>
 
   /**
    * Retrieves a list of snapshot states based on the provided query parameters.
-   * 
+   *
    * @param listQuery - The query parameters for listing snapshot states
    * @returns A promise that resolves to an array of partial snapshot states
    *
@@ -195,13 +195,13 @@ export class SnapshotQueryClient<S>
    * }
    * ```
    */
-  listState(listQuery: ListQuery): Promise<Partial<S>[]> {
+  listState<T extends Partial<S> = Partial<S>>(listQuery: ListQuery): Promise<T[]> {
     return this.query(SnapshotQueryEndpointPaths.LIST_STATE, listQuery);
   }
 
   /**
    * Retrieves a stream of snapshot states based on the provided query parameters.
-   * 
+   *
    * @param listQuery - The query parameters for listing snapshot states
    * @returns A promise that resolves to a readable stream of JSON server-sent events containing partial snapshot states
    *
@@ -217,9 +217,9 @@ export class SnapshotQueryClient<S>
    * }
    * ```
    */
-  listStateStream(
+  listStateStream<T extends Partial<S> = Partial<S>>(
     listQuery: ListQuery,
-  ): Promise<ReadableStream<JsonServerSentEvent<Partial<S>>>> {
+  ): Promise<ReadableStream<JsonServerSentEvent<T>>> {
     return this.query(
       SnapshotQueryEndpointPaths.LIST_STATE,
       listQuery,
@@ -230,7 +230,7 @@ export class SnapshotQueryClient<S>
 
   /**
    * Retrieves a paged list of materialized snapshots based on the provided query parameters.
-   * 
+   *
    * @param pagedQuery - The query parameters for paging snapshots
    * @returns A promise that resolves to a paged list of partial materialized snapshots
    *
@@ -248,15 +248,15 @@ export class SnapshotQueryClient<S>
    * }
    * ```
    */
-  paged(
+  paged<T extends Partial<MaterializedSnapshot<S>> = Partial<MaterializedSnapshot<S>>>(
     pagedQuery: PagedQuery,
-  ): Promise<PagedList<Partial<MaterializedSnapshot<S>>>> {
+  ): Promise<PagedList<T>> {
     return this.query(SnapshotQueryEndpointPaths.PAGED, pagedQuery);
   }
 
   /**
    * Retrieves a paged list of snapshot states based on the provided query parameters.
-   * 
+   *
    * @param pagedQuery - The query parameters for paging snapshot states
    * @returns A promise that resolves to a paged list of partial snapshot states
    *
@@ -273,13 +273,13 @@ export class SnapshotQueryClient<S>
    * }
    * ```
    */
-  pagedState(pagedQuery: PagedQuery): Promise<PagedList<Partial<S>>> {
+  pagedState<T extends Partial<S> = Partial<S>>(pagedQuery: PagedQuery): Promise<PagedList<T>> {
     return this.query(SnapshotQueryEndpointPaths.PAGED_STATE, pagedQuery);
   }
 
   /**
    * Retrieves a single materialized snapshot based on the provided query parameters.
-   * 
+   *
    * @param singleQuery - The query parameters for retrieving a single snapshot
    * @returns A promise that resolves to a partial materialized snapshot
    *
@@ -292,13 +292,13 @@ export class SnapshotQueryClient<S>
    * console.log('Snapshot:', single);
    * ```
    */
-  single(singleQuery: SingleQuery): Promise<Partial<MaterializedSnapshot<S>>> {
+  single<T extends Partial<MaterializedSnapshot<S>> = Partial<MaterializedSnapshot<S>>>(singleQuery: SingleQuery): Promise<T> {
     return this.query(SnapshotQueryEndpointPaths.SINGLE, singleQuery);
   }
 
   /**
    * Retrieves a single snapshot state based on the provided query parameters.
-   * 
+   *
    * @param singleQuery - The query parameters for retrieving a single snapshot state
    * @returns A promise that resolves to a partial snapshot state
    *
@@ -311,7 +311,7 @@ export class SnapshotQueryClient<S>
    * console.log('State:', singleState);
    * ```
    */
-  singleState(singleQuery: SingleQuery): Promise<Partial<S>> {
+  singleState<T extends Partial<S> = Partial<S>>(singleQuery: SingleQuery): Promise<T> {
     return this.query(SnapshotQueryEndpointPaths.SINGLE_STATE, singleQuery);
   }
 }


### PR DESCRIPTION
- Add type parameter T to methods in QueryApi, SnapshotQueryApi, EventStreamQueryClient, and CommandClient
- Remove redundant type definitions and improve type inference
- Update method signatures to use the new type parameter for partial resource types