### PR TITLE
feat(fetcher): add URL template style configuration

### DIFF
--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -24,6 +24,7 @@ import {
   RequestHeadersCapable,
 } from './fetchRequest';
 import { InterceptorManager } from './interceptorManager';
+import { UrlTemplateStyle } from './urlTemplateResolver';
 
 /**
  * Configuration options for the Fetcher client.
@@ -45,6 +46,7 @@ export interface FetcherOptions
   extends BaseURLCapable,
     RequestHeadersCapable,
     TimeoutCapable {
+  urlTemplateStyle?: UrlTemplateStyle;
   interceptors?: InterceptorManager;
 }
 
@@ -92,7 +94,7 @@ export class Fetcher
    * @param options - Configuration options for the Fetcher instance
    */
   constructor(options: FetcherOptions = DEFAULT_OPTIONS) {
-    this.urlBuilder = new UrlBuilder(options.baseURL);
+    this.urlBuilder = new UrlBuilder(options.baseURL, options.urlTemplateStyle);
     this.headers = options.headers ?? DEFAULT_HEADERS;
     this.timeout = options.timeout;
     this.interceptors = options.interceptors ?? new InterceptorManager();

--- a/packages/fetcher/src/urlBuilder.ts
+++ b/packages/fetcher/src/urlBuilder.ts
@@ -13,7 +13,12 @@
 
 import { combineURLs } from './urls';
 import { BaseURLCapable, FetchRequest } from './fetchRequest';
-import { uriTemplateResolver, UrlTemplateResolver } from './urlTemplateResolver';
+import {
+  getUrlTemplateResolver,
+  uriTemplateResolver,
+  UrlTemplateResolver,
+  UrlTemplateStyle,
+} from './urlTemplateResolver';
 
 /**
  * Container for URL parameters including path and query parameters.
@@ -78,16 +83,22 @@ export class UrlBuilder implements BaseURLCapable {
    * Initializes a new UrlBuilder instance.
    *
    * @param baseURL - Base URL that all constructed URLs will be based on
-   *
-   * @param urlTemplateResolver
+   * @param urlTemplateStyle - Optional style configuration for URL template resolution.
+   *                           Determines how path parameters are parsed and resolved.
+   *                           Defaults to UriTemplate style if not specified.
+   * 
    * @example
    * ```typescript
+   * // Create a URL builder with default URI template style
    * const urlBuilder = new UrlBuilder('https://api.example.com');
+   *
+   * // Create a URL builder with Express-style template resolution
+   * const expressUrlBuilder = new UrlBuilder('https://api.example.com', UrlTemplateStyle.Express);
    * ```
    */
-  constructor(baseURL: string, urlTemplateResolver: UrlTemplateResolver = uriTemplateResolver) {
+  constructor(baseURL: string, urlTemplateStyle?: UrlTemplateStyle) {
     this.baseURL = baseURL;
-    this.urlTemplateResolver = urlTemplateResolver;
+    this.urlTemplateResolver = getUrlTemplateResolver(urlTemplateStyle);
   }
 
   /**

--- a/packages/fetcher/src/urlBuilder.ts
+++ b/packages/fetcher/src/urlBuilder.ts
@@ -15,7 +15,6 @@ import { combineURLs } from './urls';
 import { BaseURLCapable, FetchRequest } from './fetchRequest';
 import {
   getUrlTemplateResolver,
-  uriTemplateResolver,
   UrlTemplateResolver,
   UrlTemplateStyle,
 } from './urlTemplateResolver';


### PR DESCRIPTION
- Introduce `urlTemplateStyle` option in `FetcherOptions`
- Update `UrlBuilder` to support different URL template styles
- Add `UrlTemplateStyle` enum and `getUrlTemplateResolver` function
- Enable customization of path parameter parsing and resolution