### PR TITLE
build(vite): remove bundle analyzer from vite configurations

### DIFF
--- a/packages/cosec/vite.config.ts
+++ b/packages/cosec/vite.config.ts
@@ -13,7 +13,6 @@
 
 import { defineConfig } from 'vite';
 import dts from 'unplugin-dts/vite';
-import analyzer from 'vite-bundle-analyzer';
 
 export default defineConfig({
   build: {
@@ -37,7 +36,6 @@ export default defineConfig({
     dts({
       outDirs: 'dist',
       tsconfigPath: './tsconfig.json',
-    }),
-    analyzer(),
+    })
   ],
 });

--- a/packages/decorator/vite.config.ts
+++ b/packages/decorator/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import dts from 'unplugin-dts/vite';
-import analyzer from 'vite-bundle-analyzer';
 
 export default defineConfig({
   build: {
@@ -29,7 +28,6 @@ export default defineConfig({
     dts({
       outDirs: 'dist',
       tsconfigPath: './tsconfig.json',
-    }),
-    analyzer(),
+    })
   ],
 });

--- a/packages/eventstream/vite.config.ts
+++ b/packages/eventstream/vite.config.ts
@@ -13,7 +13,6 @@
 
 import { defineConfig } from 'vite';
 import dts from 'unplugin-dts/vite';
-import analyzer from 'vite-bundle-analyzer';
 
 export default defineConfig({
   build: {
@@ -36,7 +35,6 @@ export default defineConfig({
     dts({
       outDirs: 'dist',
       tsconfigPath: './tsconfig.json',
-    }),
-    analyzer(),
+    })
   ],
 });

--- a/packages/fetcher/vite.config.ts
+++ b/packages/fetcher/vite.config.ts
@@ -13,7 +13,6 @@
 
 import { defineConfig } from 'vite';
 import dts from 'unplugin-dts/vite';
-import analyzer from 'vite-bundle-analyzer';
 
 export default defineConfig({
   build: {
@@ -34,7 +33,6 @@ export default defineConfig({
     dts({
       outDirs: 'dist',
       tsconfigPath: './tsconfig.json',
-    }),
-    analyzer(),
+    })
   ],
 });

--- a/packages/wow/vite.config.ts
+++ b/packages/wow/vite.config.ts
@@ -13,7 +13,6 @@
 
 import { defineConfig } from 'vite';
 import dts from 'unplugin-dts/vite';
-import analyzer from 'vite-bundle-analyzer';
 
 export default defineConfig({
   build: {
@@ -43,6 +42,5 @@ export default defineConfig({
       outDirs: 'dist',
       tsconfigPath: './tsconfig.json',
     }),
-    analyzer(),
   ],
 });


### PR DESCRIPTION
- Removed `vite-bundle-analyzer` import and configuration from multiple packages
- This change affects `cosec`, `decorator`, `eventstream`, `fetcher`, and `wow` packages