### PR TITLE
feat(fetcher): add ensureRequestHeaders method to FetchExchange

### DIFF
--- a/packages/fetcher/src/fetchExchange.ts
+++ b/packages/fetcher/src/fetchExchange.ts
@@ -12,7 +12,7 @@
  */
 
 import { Fetcher } from './fetcher';
-import { FetchRequest } from './fetchRequest';
+import { FetchRequest, RequestHeaders } from './fetchRequest';
 import { ExchangeError } from './interceptorManager';
 
 /**
@@ -103,6 +103,22 @@ export class FetchExchange {
     this.request = request;
     this.response = response;
     this.error = error;
+  }
+
+  /**
+   * Ensures that request headers object exists, creating it if necessary.
+   *
+   * This method checks if the request headers object is present and initializes
+   * it as an empty object if it's missing. This guarantees that headers can
+   * be safely accessed and modified after calling this method.
+   *
+   * @returns The request headers object, guaranteed to be non-null
+   */
+  ensureRequestHeaders(): RequestHeaders {
+    if (!this.request.headers) {
+      this.request.headers = {};
+    }
+    return this.request.headers;
   }
 
   /**

--- a/packages/fetcher/test/fetchExchange.test.ts
+++ b/packages/fetcher/test/fetchExchange.test.ts
@@ -79,10 +79,42 @@ describe('FetchExchange', () => {
     expect(exchange.hasResponse()).toBe(true);
     expect(exchange.requiredResponse).toBe(mockResponse);
   });
+
   it('should throw an error when trying to access requiredResponse without a response', () => {
     expect(() => {
       const exchange = new FetchExchange(mockFetcher, mockRequest);
       exchange.requiredResponse;
     }).toThrowError(ExchangeError);
+  });
+
+  it('should create headers object when ensureRequestHeaders is called and headers is undefined', () => {
+    const request = { url: '/test' } as FetchRequest;
+    const exchange = new FetchExchange(mockFetcher, request);
+
+    // Verify headers is initially undefined
+    expect(exchange.request.headers).toBeUndefined();
+
+    // Call ensureRequestHeaders
+    const headers = exchange.ensureRequestHeaders();
+
+    // Verify headers is now an empty object
+    expect(headers).toEqual({});
+    expect(exchange.request.headers).toBe(headers);
+  });
+
+  it('should return existing headers object when ensureRequestHeaders is called and headers exists', () => {
+    const existingHeaders = { 'Content-Type': 'application/json' };
+    const request = { url: '/test', headers: existingHeaders } as FetchRequest;
+    const exchange = new FetchExchange(mockFetcher, request);
+
+    // Verify headers already exists
+    expect(exchange.request.headers).toBe(existingHeaders);
+
+    // Call ensureRequestHeaders
+    const headers = exchange.ensureRequestHeaders();
+
+    // Verify the same object is returned
+    expect(headers).toBe(existingHeaders);
+    expect(exchange.request.headers).toBe(existingHeaders);
   });
 });


### PR DESCRIPTION
- Implement ensureRequestHeaders method to guarantee request headers object exists
- Update tests to cover new functionality
- Add type import for RequestHeaders