### PR TITLE
fix(query): handle edge case for empty arguments in and(), or(), nor()

### DIFF
--- a/packages/wow/src/query/condition.ts
+++ b/packages/wow/src/query/condition.ts
@@ -170,6 +170,9 @@ export enum DeletionState {
  * @returns A condition with AND operator
  */
 export function and(...conditions: Condition[]): Condition {
+  if (conditions.length === 0) {
+    return all();
+  }
   return { operator: Operator.AND, children: conditions };
 }
 
@@ -180,6 +183,9 @@ export function and(...conditions: Condition[]): Condition {
  * @returns A condition with OR operator
  */
 export function or(...conditions: Condition[]): Condition {
+  if (conditions.length === 0) {
+    return all();
+  }
   return { operator: Operator.OR, children: conditions };
 }
 
@@ -190,6 +196,9 @@ export function or(...conditions: Condition[]): Condition {
  * @returns A condition with NOR operator
  */
 export function nor(...conditions: Condition[]): Condition {
+  if (conditions.length === 0) {
+    return all();
+  }
   return { operator: Operator.NOR, children: conditions };
 }
 

--- a/packages/wow/test/query/condition.test.ts
+++ b/packages/wow/test/query/condition.test.ts
@@ -150,6 +150,13 @@ describe('Condition', () => {
         });
       });
 
+      it('should create AND condition with no arguments and return ALL condition', () => {
+        const result = and();
+        expect(result).toEqual({
+          operator: Operator.ALL,
+        });
+      });
+
       it('should create OR condition', () => {
         const condition1: Condition = {
           field: 'name',
@@ -169,6 +176,13 @@ describe('Condition', () => {
         });
       });
 
+      it('should create OR condition with no arguments and return ALL condition', () => {
+        const result = or();
+        expect(result).toEqual({
+          operator: Operator.ALL,
+        });
+      });
+
       it('should create NOR condition', () => {
         const condition1: Condition = {
           field: 'name',
@@ -185,6 +199,13 @@ describe('Condition', () => {
         expect(result).toEqual({
           operator: Operator.NOR,
           children: [condition1, condition2],
+        });
+      });
+
+      it('should create NOR condition with no arguments and return ALL condition', () => {
+        const result = nor();
+        expect(result).toEqual({
+          operator: Operator.ALL,
         });
       });
     });


### PR DESCRIPTION
- Add condition to return ALL condition when no arguments are provided
- Update unit tests to cover this new edge case