### PR TITLE
feat(query): add listQuery factory function and update related tests

### DIFF
--- a/packages/wow/src/query/queryable.ts
+++ b/packages/wow/src/query/queryable.ts
@@ -13,7 +13,7 @@
 
 import { all, type ConditionCapable } from './condition';
 import { type  SortCapable } from './sort';
-import { type  Pagination } from './pagination';
+import { DEFAULT_PAGINATION, type  Pagination } from './pagination';
 import { type  ProjectionCapable } from './projection';
 
 /**
@@ -60,6 +60,34 @@ export function singleQuery({ condition = all(), projection, sort }: Partial<Sin
  */
 export interface ListQuery extends Queryable {
   limit?: number;
+}
+
+/**
+ * Creates a ListQuery object with the provided parameters.
+ *
+ * This function is a factory for creating ListQuery objects, which represent
+ * queries that return a list of results. It provides default values for optional
+ * properties while allowing customization of condition, projection, sort criteria,
+ * and result limit.
+ *
+ * @param condition - The query condition. Defaults to an 'all' condition that matches everything.
+ * @param projection - The field projection specification. Optional.
+ * @param sort - The sort criteria. Optional.
+ * @param limit - The maximum number of results to return. Defaults to DEFAULT_PAGINATION.size.
+ * @returns A ListQuery object with the specified parameters
+ */
+export function listQuery({
+                            condition = all(),
+                            projection,
+                            sort,
+                            limit = DEFAULT_PAGINATION.size,
+                          }: Partial<ListQuery>): ListQuery {
+  return {
+    condition,
+    projection,
+    sort,
+    limit,
+  };
 }
 
 /**

--- a/packages/wow/test/query/queryable.test.ts
+++ b/packages/wow/test/query/queryable.test.ts
@@ -12,10 +12,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { all, asc, eq } from '../../src';
-import { singleQuery } from '../../src';
-import { FieldSort } from '../../src';
+import { all, asc, eq, FieldSort } from '../../src';
+import { singleQuery, listQuery } from '../../src';
 import { Projection } from '../../src';
+import { DEFAULT_PAGINATION } from '../../src';
 
 describe('queryable', () => {
   describe('singleQuery', () => {
@@ -67,6 +67,75 @@ describe('queryable', () => {
         condition,
         projection,
         sort,
+      });
+    });
+  });
+
+  describe('listQuery', () => {
+    it('should create a ListQuery with default values when no parameters are provided', () => {
+      const result = listQuery({} as any);
+
+      expect(result).toEqual({
+        condition: all(),
+        limit: DEFAULT_PAGINATION.size,
+      });
+    });
+
+    it('should create a ListQuery with provided condition', () => {
+      const condition = eq('name', 'test');
+      const result = listQuery({ condition });
+
+      expect(result).toEqual({
+        condition,
+        limit: DEFAULT_PAGINATION.size,
+      });
+    });
+
+    it('should create a ListQuery with provided projection', () => {
+      const projection: Projection = { include: ['field1', 'field2'] };
+      const result = listQuery({ projection });
+
+      expect(result).toEqual({
+        condition: all(),
+        projection,
+        limit: DEFAULT_PAGINATION.size,
+      });
+    });
+
+    it('should create a ListQuery with provided sort', () => {
+      const sort: FieldSort[] = [asc('name')];
+      const result = listQuery({ sort });
+
+      expect(result).toEqual({
+        condition: all(),
+        sort,
+        limit: DEFAULT_PAGINATION.size,
+      });
+    });
+
+    it('should create a ListQuery with provided limit', () => {
+      const limit = 10;
+      const result = listQuery({ limit });
+
+      expect(result).toEqual({
+        condition: all(),
+        limit,
+      });
+    });
+
+    it('should create a ListQuery with all provided parameters', () => {
+      const condition = eq('name', 'test');
+      const projection: Projection = { include: ['field1', 'field2'] };
+      const sort: FieldSort[] = [asc('name')];
+      const limit = 10;
+
+      const result = listQuery({ condition, projection, sort, limit });
+
+      expect(result).toEqual({
+        condition,
+        projection,
+        sort,
+        limit,
       });
     });
   });


### PR DESCRIPTION
- Implement listQuery factory function for creating ListQuery objects
- Add default pagination size constant
- Update import statements to include new and existing components
- Add comprehensive unit tests for listQuery functionality