### PR TITLE
feat(fetcher): implement ResultExtractor and related tests

### DIFF
--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -132,7 +132,7 @@ export class Fetcher
    * @throws Error if an unhandled error occurs during request processing
    */
   // @ts-expect-error - Required to bypass type checking for resultExtractor default value assignment
-  async request<R = FetchExchange>(request: FetchRequest, resultExtractor: ResultExtractor<R> = ExchangeResultExtractor): Promise<R> {
+  async request<R = FetchExchange>(request: FetchRequest, resultExtractor: ResultExtractor<R> = ResultExtractors.Exchange): Promise<R> {
     // Merge default headers and request-level headers. defensive copy
     const mergedHeaders = {
       ...this.headers,

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -131,8 +131,8 @@ export class Fetcher
    * @returns Promise that resolves to the extracted result based on resultExtractor
    * @throws Error if an unhandled error occurs during request processing
    */
-  // @ts-ignore
-  async request<R = FetchExchange>(request: FetchRequest, resultExtractor: ResultExtractor<R> = ResultExtractors.Exchange): Promise<R> {
+  // @ts-expect-error - Required to bypass type checking for resultExtractor default value assignment
+  async request<R = FetchExchange>(request: FetchRequest, resultExtractor: ResultExtractor<R> = ExchangeResultExtractor): Promise<R> {
     // Merge default headers and request-level headers. defensive copy
     const mergedHeaders = {
       ...this.headers,

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -23,6 +23,7 @@ export * from './mergeRequest';
 export * from './namedFetcher';
 export * from './orderedCapable';
 export * from './requestBodyInterceptor';
+export * from './resultExtractor';
 export * from './timeout';
 export * from './types';
 export * from './urlBuilder';

--- a/packages/fetcher/src/resultExtractor.ts
+++ b/packages/fetcher/src/resultExtractor.ts
@@ -21,47 +21,48 @@ import { FetchExchange } from './fetchExchange';
  * @returns The extracted result of type R
  */
 export interface ResultExtractor<R> {
-  (exchange: FetchExchange): R;
+  (exchange: FetchExchange): R | Promise<R>;
 }
 
 /**
- * Collection of common result extractors.
- * Provides predefined functions for extracting different types of data from FetchExchange objects.
+ * Returns the original FetchExchange object.
+ * @param exchange - The FetchExchange object to return
+ * @returns The same FetchExchange object that was passed in
  */
-export namespace ResultExtractors {
-  /**
-   * Returns the original FetchExchange object.
-   * @param exchange - The FetchExchange object to return
-   * @returns The same FetchExchange object that was passed in
-   */
-  export const Exchange: ResultExtractor<FetchExchange> = (exchange: FetchExchange) => {
-    return exchange;
-  };
-  
-  /**
-   * Extracts the Response object from the exchange.
-   * @param exchange - The FetchExchange containing the response
-   * @returns The Response object from the exchange
-   */
-  export const Response: ResultExtractor<Response> = (exchange: FetchExchange) => {
-    return exchange.requiredResponse;
-  };
+export const ExchangeResultExtractor: ResultExtractor<FetchExchange> = (exchange: FetchExchange) => {
+  return exchange;
+};
 
-  /**
-   * Extracts and parses the response body as JSON.
-   * @param exchange - The FetchExchange containing the response with JSON data
-   * @returns A Promise that resolves to the parsed JSON data
-   */
-  export const Json: ResultExtractor<Promise<any>> = (exchange: FetchExchange) => {
-    return exchange.requiredResponse.json();
-  };
+/**
+ * Extracts the Response object from the exchange.
+ * @param exchange - The FetchExchange containing the response
+ * @returns The Response object from the exchange
+ */
+export const ResponseResultExtractor: ResultExtractor<Response> = (exchange: FetchExchange) => {
+  return exchange.requiredResponse;
+};
 
-  /**
-   * Extracts the response body as text.
-   * @param exchange - The FetchExchange containing the response with text data
-   * @returns A Promise that resolves to the response body as a string
-   */
-  export const Text: ResultExtractor<Promise<string>> = (exchange: FetchExchange) => {
-    return exchange.requiredResponse.text();
-  };
-}
+/**
+ * Extracts and parses the response body as JSON.
+ * @param exchange - The FetchExchange containing the response with JSON data
+ * @returns A Promise that resolves to the parsed JSON data
+ */
+export const JsonResultExtractor: ResultExtractor<Promise<any>> = (exchange: FetchExchange) => {
+  return exchange.requiredResponse.json();
+};
+
+/**
+ * Extracts the response body as text.
+ * @param exchange - The FetchExchange containing the response with text data
+ * @returns A Promise that resolves to the response body as a string
+ */
+export const TextResultExtractor: ResultExtractor<Promise<string>> = (exchange: FetchExchange) => {
+  return exchange.requiredResponse.text();
+};
+
+export const ResultExtractors = {
+  Exchange: ExchangeResultExtractor,
+  Response: ResponseResultExtractor,
+  Json: JsonResultExtractor,
+  Text: TextResultExtractor,
+};

--- a/packages/fetcher/src/resultExtractor.ts
+++ b/packages/fetcher/src/resultExtractor.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FetchExchange } from './fetchExchange';
+
+/**
+ * Function interface for extracting results from a FetchExchange.
+ * Defines how to transform a FetchExchange object into a specific result type.
+ * @template R - The type of result to extract
+ * @param exchange - The FetchExchange object containing request and response information
+ * @returns The extracted result of type R
+ */
+export interface ResultExtractor<R> {
+  (exchange: FetchExchange): R;
+}
+
+/**
+ * Collection of common result extractors.
+ * Provides predefined functions for extracting different types of data from FetchExchange objects.
+ */
+export namespace ResultExtractors {
+  /**
+   * Returns the original FetchExchange object.
+   * @param exchange - The FetchExchange object to return
+   * @returns The same FetchExchange object that was passed in
+   */
+  export const Exchange: ResultExtractor<FetchExchange> = (exchange: FetchExchange) => {
+    return exchange;
+  };
+  
+  /**
+   * Extracts the Response object from the exchange.
+   * @param exchange - The FetchExchange containing the response
+   * @returns The Response object from the exchange
+   */
+  export const Response: ResultExtractor<Response> = (exchange: FetchExchange) => {
+    return exchange.requiredResponse;
+  };
+
+  /**
+   * Extracts and parses the response body as JSON.
+   * @param exchange - The FetchExchange containing the response with JSON data
+   * @returns A Promise that resolves to the parsed JSON data
+   */
+  export const Json: ResultExtractor<Promise<any>> = (exchange: FetchExchange) => {
+    return exchange.requiredResponse.json();
+  };
+
+  /**
+   * Extracts the response body as text.
+   * @param exchange - The FetchExchange containing the response with text data
+   * @returns A Promise that resolves to the response body as a string
+   */
+  export const Text: ResultExtractor<Promise<string>> = (exchange: FetchExchange) => {
+    return exchange.requiredResponse.text();
+  };
+}

--- a/packages/fetcher/test/fetcher.test.ts
+++ b/packages/fetcher/test/fetcher.test.ts
@@ -14,8 +14,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_OPTIONS,
-  Fetcher,
-  FetchError,
+  Fetcher, FetcherError,
   FetchRequest,
   HttpMethod,
 } from '../src';
@@ -235,7 +234,7 @@ describe('Fetcher', () => {
     exchangeSpy.mockRestore();
   });
 
-  it('should throw FetchError when no response is returned', async () => {
+  it('should throw FetcherError when no response is returned', async () => {
     const fetcher = new Fetcher();
 
     // Mock the interceptors.exchange method to not set a response
@@ -245,7 +244,7 @@ describe('Fetcher', () => {
         return exchange;
       });
 
-    await expect(fetcher.get('/users')).rejects.toThrow(FetchError);
+    await expect(fetcher.get('/users')).rejects.toThrow(FetcherError);
 
     // Clean up spy
     exchangeSpy.mockRestore();

--- a/packages/fetcher/test/resultExtractor.test.ts
+++ b/packages/fetcher/test/resultExtractor.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { FetchExchange } from '../src';
-import { ResultExtractor, ResultExtractors } from '../src/resultExtractor';
+import { ResultExtractor, ResultExtractors } from '../src';
 import { Fetcher } from '../src';
 import { FetchRequest } from '../src';
 

--- a/packages/fetcher/test/resultExtractor.test.ts
+++ b/packages/fetcher/test/resultExtractor.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { FetchExchange } from '../src';
+import { ResultExtractor, ResultExtractors } from '../src/resultExtractor';
+import { Fetcher } from '../src';
+import { FetchRequest } from '../src';
+
+describe('ResultExtractor', () => {
+  const mockFetcher = {} as Fetcher;
+  const mockRequest = {} as FetchRequest;
+  const mockResponse = new Response(JSON.stringify({ data: 'test' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  it('should define ResultExtractor interface', () => {
+    // This test just verifies the interface is properly defined
+    const extractor: ResultExtractor<any> = (exchange: FetchExchange) => exchange;
+    expect(typeof extractor).toBe('function');
+  });
+});
+
+describe('ResultExtractors', () => {
+  const mockFetcher = {} as Fetcher;
+  const mockRequest = {} as FetchRequest;
+  const mockResponse = new Response(JSON.stringify({ data: 'test' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+  const exchange = new FetchExchange(mockFetcher, mockRequest, mockResponse);
+
+  it('should export Exchange result extractor', () => {
+    expect(ResultExtractors).toHaveProperty('Exchange');
+  });
+
+  it('should export Response result extractor', () => {
+    expect(ResultExtractors).toHaveProperty('Response');
+  });
+
+  it('should export Json result extractor', () => {
+    expect(ResultExtractors).toHaveProperty('Json');
+  });
+
+  it('should export Text result extractor', () => {
+    expect(ResultExtractors).toHaveProperty('Text');
+  });
+
+  it('Exchange extractor should return the original exchange', () => {
+    const result = ResultExtractors.Exchange(exchange);
+    expect(result).toBe(exchange);
+  });
+
+  it('Response extractor should return the response from exchange', () => {
+    const result = ResultExtractors.Response(exchange);
+    expect(result).toBe(mockResponse);
+  });
+
+  it('Json extractor should return a promise that resolves to parsed JSON', async () => {
+    const jsonSpy = vi.spyOn(mockResponse, 'json').mockResolvedValue({ data: 'test' });
+    const resultPromise = ResultExtractors.Json(exchange);
+    expect(resultPromise).toBeInstanceOf(Promise);
+
+    const result = await resultPromise;
+    expect(result).toEqual({ data: 'test' });
+    expect(jsonSpy).toHaveBeenCalled();
+  });
+
+  it('Text extractor should return a promise that resolves to response text', async () => {
+    const textSpy = vi.spyOn(mockResponse, 'text').mockResolvedValue('test text');
+    const resultPromise = ResultExtractors.Text(exchange);
+    expect(resultPromise).toBeInstanceOf(Promise);
+
+    const result = await resultPromise;
+    expect(result).toBe('test text');
+    expect(textSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- Add ResultExtractor interface for transforming FetchExchange into specific result types
- Implement common result extractors in ResultExtractors namespace:
  - Exchange: returns the original FetchExchange object
  - Response: extracts the Response object from the exchange
  - Json: parses the response body as JSON
  - Text: extracts the response body as text
- Create unit tests for ResultExtractor and ResultExtractors to ensure proper functionality