### PR TITLE
feat(fetcher): improve timeout handling and support existing signals

### DIFF
--- a/packages/fetcher/src/timeout.ts
+++ b/packages/fetcher/src/timeout.ts
@@ -89,15 +89,16 @@ export function resolveTimeout(
 }
 
 /**
- * HTTP request method with timeout control.
+ * Executes an HTTP request with optional timeout support.
  *
- * Uses Promise.race to implement timeout control, initiating both
- * fetch request and timeout Promise simultaneously. When either Promise completes,
- * it returns the result or throws an exception.
+ * This function provides a wrapper around the native fetch API with added timeout functionality.
+ * If a timeout is specified, it will create an AbortController to cancel the request if it exceeds the timeout.
+ * If the request already has a signal, it will delegate to the native fetch API directly to avoid conflicts.
  *
- * @param request - The request initialization options
- * @returns Promise<Response> HTTP response Promise
- * @throws FetchTimeoutError Thrown when the request times out
+ * @param request - The request configuration including URL, method, headers, body, and optional timeout
+ * @returns Promise that resolves to the Response object
+ * @throws FetchTimeoutError if the request times out
+ * @throws TypeError for network errors
  *
  * @example
  * ```typescript
@@ -119,6 +120,12 @@ export async function timeoutFetch(request: FetchRequest): Promise<Response> {
   const url = request.url;
   const timeout = request.timeout;
   const requestInit = request as RequestInit;
+
+  // If the request already has a signal, delegate to native fetch to avoid conflicts
+  if (request.signal) {
+    return fetch(url, requestInit);
+  }
+  
   // Extract timeout from request
   if (!timeout) {
     return fetch(url, requestInit);

--- a/packages/fetcher/test/timeout.test.ts
+++ b/packages/fetcher/test/timeout.test.ts
@@ -93,6 +93,36 @@ describe('timeoutFetch', () => {
     globalThis.fetch = originalFetch;
   });
 
+  it('should delegate to fetch when request.signal is present', async () => {
+    // Set up mock fetch
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch as any;
+    const response = new Response('test');
+    mockFetch.mockResolvedValue(response);
+
+    // Create an AbortController to get a signal
+    const controller = new AbortController();
+
+    const request: FetchRequest = {
+      url: 'https://api.example.com/test',
+      method: 'GET',
+      signal: controller.signal,
+      timeout: 1000, // Even with timeout, should delegate because signal is present
+    };
+
+    const result = await timeoutFetch(request);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/test',
+      request,
+    );
+    expect(result).toBe(response);
+    // Should not have called abort on the controller
+    expect(controller.signal.aborted).toBe(false);
+
+    // Restore original fetch
+    globalThis.fetch = originalFetch;
+  });
+
   it('should resolve normally when request completes before timeout', async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
- Refactor timeoutFetch to handle optional timeout and existing AbortSignal
- Add support for delegating to native fetch when request.signal is present
- Update function documentation to reflect new behavior
- Add unit test for request.signal delegation