### PR TITLE
refactor(wow): replace ResultExtractors with JsonEventStreamResultExtractor

### DIFF
--- a/packages/wow/package.json
+++ b/packages/wow/package.json
@@ -46,8 +46,7 @@
   },
   "dependencies": {
     "@ahoo-wang/fetcher": "workspace:*",
-    "@ahoo-wang/fetcher-eventstream": "workspace:*",
-    "@ahoo-wang/fetcher-decorator": "workspace:*"
+    "@ahoo-wang/fetcher-eventstream": "workspace:*"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",

--- a/packages/wow/src/command/commandClient.ts
+++ b/packages/wow/src/command/commandClient.ts
@@ -17,8 +17,8 @@ import {
   type CommandResult,
   type CommandResultEventStream,
 } from './commandResult';
-import { combineURLs, ContentTypeValues, ResultExtractor } from '@ahoo-wang/fetcher';
-import { ResultExtractors } from '@ahoo-wang/fetcher-decorator';
+import { combineURLs, ContentTypeValues, ResultExtractor, ResultExtractors } from '@ahoo-wang/fetcher';
+import { JsonEventStreamResultExtractor } from '@ahoo-wang/fetcher-eventstream';
 
 /**
  * Command Client for sending commands to the server.
@@ -151,7 +151,7 @@ export class CommandClient {
     return this.sendCommand(
       path,
       commandHttpRequest,
-      ResultExtractors.JsonEventStream,
+      JsonEventStreamResultExtractor,
     );
   }
 }

--- a/packages/wow/src/query/event/eventStreamQueryClient.ts
+++ b/packages/wow/src/query/event/eventStreamQueryClient.ts
@@ -18,11 +18,10 @@ import {
 import type { Condition } from '../condition';
 import type { ListQuery, PagedList, PagedQuery } from '../queryable';
 import type { DomainEventStream } from './domainEventStream';
-import type { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
+import { JsonEventStreamResultExtractor, JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
 import { QueryClient } from '../queryApi';
 import type { ClientOptions } from '../../types';
 import { ContentTypeValues } from '@ahoo-wang/fetcher';
-import { ResultExtractors } from '@ahoo-wang/fetcher-decorator';
 
 /**
  * Client for querying event streams through HTTP endpoints.
@@ -140,7 +139,7 @@ export class EventStreamQueryClient
       EventStreamQueryEndpointPaths.LIST,
       listQuery,
       ContentTypeValues.TEXT_EVENT_STREAM,
-      ResultExtractors.JsonEventStream,
+      JsonEventStreamResultExtractor,
     );
   }
 

--- a/packages/wow/src/query/queryApi.ts
+++ b/packages/wow/src/query/queryApi.ts
@@ -20,10 +20,7 @@ import type {
 import type { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
 import type { Condition } from './condition';
 import type { ClientOptions } from '../types';
-import { combineURLs, ContentTypeValues, HttpMethod, ResultExtractor } from '@ahoo-wang/fetcher';
-import {
-  ResultExtractors,
-} from '@ahoo-wang/fetcher-decorator';
+import { combineURLs, ContentTypeValues, HttpMethod, ResultExtractor, ResultExtractors } from '@ahoo-wang/fetcher';
 
 /**
  * Interface for generic query API operations.

--- a/packages/wow/src/query/snapshot/snapshotQueryClient.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryClient.ts
@@ -23,9 +23,8 @@ import type {
   SingleQuery,
 } from '../queryable';
 import type { MaterializedSnapshot } from './snapshot';
-import type { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
+import { JsonEventStreamResultExtractor, JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
 import { ContentTypeValues } from '@ahoo-wang/fetcher';
-import { ResultExtractors } from '@ahoo-wang/fetcher-decorator';
 import '@ahoo-wang/fetcher-eventstream';
 import type { ClientOptions } from '../../types';
 import { QueryClient } from '../queryApi';
@@ -183,7 +182,7 @@ export class SnapshotQueryClient<S>
       SnapshotQueryEndpointPaths.LIST,
       listQuery,
       ContentTypeValues.TEXT_EVENT_STREAM,
-      ResultExtractors.JsonEventStream,
+      JsonEventStreamResultExtractor,
     );
   }
 
@@ -235,7 +234,7 @@ export class SnapshotQueryClient<S>
       SnapshotQueryEndpointPaths.LIST_STATE,
       listQuery,
       ContentTypeValues.TEXT_EVENT_STREAM,
-      ResultExtractors.JsonEventStream,
+      JsonEventStreamResultExtractor,
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,9 +223,6 @@ importers:
       '@ahoo-wang/fetcher':
         specifier: workspace:*
         version: link:../fetcher
-      '@ahoo-wang/fetcher-decorator':
-        specifier: workspace:*
-        version: link:../decorator
       '@ahoo-wang/fetcher-eventstream':
         specifier: workspace:*
         version: link:../eventstream


### PR DESCRIPTION


- Update command and query clients to use JsonEventStreamResultExtractor instead of ResultExtractors.JsonEventStream
- Remove unused import of ResultExtractors from fetcher-decorator
- Update package.json to remove dependency on fetcher-decorator