### PR TITLE
feat(wow): allow empty condition in AND and OR Creators

### DIFF
--- a/packages/wow/src/query/condition.ts
+++ b/packages/wow/src/query/condition.ts
@@ -175,15 +175,20 @@ export enum DeletionState {
  *                   If multiple, combines them into an AND condition with flattening optimization.
  * @returns A condition with AND operator or an optimized condition based on the input
  */
-export function and(...conditions: Condition[]): Condition {
-  if (conditions.length === 0) {
+export function and(
+  ...conditions: Array<Condition | undefined | null>
+): Condition {
+  const validateConditions = conditions?.filter(
+    condition => condition !== undefined && condition !== null,
+  ) as Condition[];
+  if (validateConditions.length === 0) {
     return all();
   }
-  if (conditions.length === 1) {
-    return conditions[0];
+  if (validateConditions.length === 1) {
+    return validateConditions[0];
   }
   const andChildren: Condition[] = [];
-  conditions.forEach(condition => {
+  validateConditions.forEach(condition => {
     if (condition.operator === Operator.ALL) {
       return;
     }
@@ -202,11 +207,16 @@ export function and(...conditions: Condition[]): Condition {
  * @param conditions - Conditions to combine with OR
  * @returns A condition with OR operator
  */
-export function or(...conditions: Condition[]): Condition {
-  if (conditions.length === 0) {
+export function or(
+  ...conditions: Array<Condition | undefined | null>
+): Condition {
+  const validateConditions = conditions?.filter(
+    condition => condition !== undefined && condition !== null,
+  ) as Condition[];
+  if (validateConditions.length === 0) {
     return all();
   }
-  return { operator: Operator.OR, children: conditions };
+  return { operator: Operator.OR, children: validateConditions };
 }
 
 /**

--- a/packages/wow/test/query/condition.test.ts
+++ b/packages/wow/test/query/condition.test.ts
@@ -150,6 +150,25 @@ describe('Condition', () => {
         });
       });
 
+      it('should create AND condition with undefined and null condition', () => {
+        const condition1: Condition = {
+          field: 'name',
+          operator: Operator.EQ,
+          value: 'test',
+        };
+        const condition2: Condition = {
+          field: 'age',
+          operator: Operator.GT,
+          value: 18,
+        };
+        const result = and(condition1, condition2);
+
+        expect(result).toEqual({
+          operator: Operator.AND,
+          children: [condition1, undefined, condition2, null],
+        });
+      });
+
       it('should create AND condition with no arguments and return ALL condition', () => {
         const result = and();
         expect(result).toEqual({
@@ -198,6 +217,25 @@ describe('Condition', () => {
         expect(result).toEqual({
           operator: Operator.OR,
           children: [condition1, condition2],
+        });
+      });
+
+      it('should create OR condition with undefined and null condition', () => {
+        const condition1: Condition = {
+          field: 'name',
+          operator: Operator.EQ,
+          value: 'test',
+        };
+        const condition2: Condition = {
+          field: 'age',
+          operator: Operator.GT,
+          value: 18,
+        };
+        const result = or(condition1, condition2);
+
+        expect(result).toEqual({
+          operator: Operator.OR,
+          children: [condition1, undefined, condition2, null],
         });
       });
 


### PR DESCRIPTION
There are two condition creators in packages/wow/src/query/condition.ts
They did not filter empty conditions, we should ensure each of condition from arguments is a validate condition