### PR TITLE
feat(wow): allow empty condition in OR condition Creators

### DIFF
--- a/packages/wow/src/query/condition.ts
+++ b/packages/wow/src/query/condition.ts
@@ -22,8 +22,7 @@ import { Operator } from './operator';
 export function isValidateCondition(
   condition: Condition | undefined | null,
 ): condition is Condition {
-  const typeDetect = (param: unknown) => Object.prototype.toString.call(param);
-  if (typeDetect(condition) === '[object Object]') {
+  if (condition) {
     return true;
   }
   return false;

--- a/packages/wow/src/query/condition.ts
+++ b/packages/wow/src/query/condition.ts
@@ -221,11 +221,16 @@ export function and(
  * @param conditions - Conditions to combine with OR
  * @returns A condition with OR operator
  */
-export function or(...conditions: Condition[]): Condition {
-  if (conditions.length === 0) {
+export function or(
+  ...conditions: Array<Condition | undefined | null>
+): Condition {
+  const validateConditions = conditions?.filter(condition =>
+    isValidateCondition(condition),
+  );
+  if (validateConditions.length === 0) {
     return all();
   }
-  return { operator: Operator.OR, children: conditions };
+  return { operator: Operator.OR, children: validateConditions };
 }
 
 /**

--- a/packages/wow/src/query/condition.ts
+++ b/packages/wow/src/query/condition.ts
@@ -14,6 +14,21 @@
 import { Operator } from './operator';
 
 /**
+ * Helper function to detect condition is validate or not
+ *
+ * @param condition - Condition
+ * @returns If condition is validate return true, otherwise return false
+ */
+export function isValidateCondition(
+  condition: Condition | undefined | null,
+): condition is Condition {
+  const typeDetect = (param: unknown) => Object.prototype.toString.call(param);
+  if (typeDetect(condition) === '[object Object]') {
+    return true;
+  }
+  return false;
+}
+/**
  * Condition option keys enumeration
  *
  * Defines standard option keys used in query conditions for special handling.
@@ -175,16 +190,21 @@ export enum DeletionState {
  *                   If multiple, combines them into an AND condition with flattening optimization.
  * @returns A condition with AND operator or an optimized condition based on the input
  */
-export function and(...conditions: Condition[]): Condition {
+export function and(
+  ...conditions: Array<Condition | undefined | null>
+): Condition {
   if (conditions.length === 0) {
     return all();
   }
   if (conditions.length === 1) {
-    return conditions[0];
+    return isValidateCondition(conditions[0]) ? conditions[0] : all();
   }
   const andChildren: Condition[] = [];
   conditions.forEach(condition => {
-    if (condition.operator === Operator.ALL) {
+    if (
+      condition?.operator === Operator.ALL ||
+      !isValidateCondition(condition)
+    ) {
       return;
     }
     if (condition.operator === Operator.AND && condition.children) {

--- a/packages/wow/test/query/condition.test.ts
+++ b/packages/wow/test/query/condition.test.ts
@@ -220,6 +220,25 @@ describe('Condition', () => {
         });
       });
 
+      it('should create OR condition with undefined and null condition', () => {
+        const condition1: Condition = {
+          field: 'name',
+          operator: Operator.EQ,
+          value: 'test',
+        };
+        const condition2: Condition = {
+          field: 'age',
+          operator: Operator.GT,
+          value: 18,
+        };
+        const result = or(condition1, undefined, condition2, null);
+
+        expect(result).toEqual({
+          operator: Operator.OR,
+          children: [condition1, condition2],
+        });
+      });
+
       it('should create OR condition with no arguments and return ALL condition', () => {
         const result = or();
         expect(result).toEqual({

--- a/packages/wow/test/query/condition.test.ts
+++ b/packages/wow/test/query/condition.test.ts
@@ -150,6 +150,25 @@ describe('Condition', () => {
         });
       });
 
+      it('should create AND condition with undefined and null condition', () => {
+        const condition1: Condition = {
+          field: 'name',
+          operator: Operator.EQ,
+          value: 'test',
+        };
+        const condition2: Condition = {
+          field: 'age',
+          operator: Operator.GT,
+          value: 18,
+        };
+        const result = and(condition1, undefined, condition2, null);
+
+        expect(result).toEqual({
+          operator: Operator.AND,
+          children: [condition1, condition2],
+        });
+      });
+
       it('should create AND condition with no arguments and return ALL condition', () => {
         const result = and();
         expect(result).toEqual({


### PR DESCRIPTION
There is OR condition creators in packages/wow/src/query/condition.ts
They did not filter empty conditions, we should ensure each of condition from arguments is a validate condition