### PR TITLE
fix(cosec): use interceptor exchange method for retrying requests

### DIFF
--- a/packages/cosec/src/cosecResponseInterceptor.ts
+++ b/packages/cosec/src/cosecResponseInterceptor.ts
@@ -98,7 +98,7 @@ export class CoSecResponseInterceptor implements ResponseInterceptor {
       // Attempt to refresh the token
       await this.refresh(currentToken);
       // Retry the original request with the new token
-      await exchange.fetcher.request(exchange.request);
+      await exchange.fetcher.interceptors.exchange(exchange);
     } catch (error) {
       // If token refresh fails, clear stored tokens and re-throw the error
       this.options.tokenStorage.clear();

--- a/packages/cosec/test/cosecResponseInterceptor.test.ts
+++ b/packages/cosec/test/cosecResponseInterceptor.test.ts
@@ -172,6 +172,9 @@ describe('cosecResponseInterceptor.ts', () => {
       const interceptor = new CoSecResponseInterceptor(options);
 
       const mockFetcher = {
+        interceptors: {
+          exchange: vi.fn().mockResolvedValue(undefined),
+        },
         request: vi.fn().mockResolvedValue({}),
       } as unknown as Fetcher;
 
@@ -205,7 +208,7 @@ describe('cosecResponseInterceptor.ts', () => {
       });
 
       // Verify request was retried
-      expect(mockFetcher.request).toHaveBeenCalledWith(request);
+      expect(mockFetcher.interceptors.exchange).toHaveBeenCalledWith(exchange);
     });
 
     it('should clear token storage and re-throw error when token refresh fails', async () => {
@@ -229,7 +232,12 @@ describe('cosecResponseInterceptor.ts', () => {
 
       const interceptor = new CoSecResponseInterceptor(options);
 
-      const mockFetcher = {} as Fetcher;
+      const mockFetcher = {
+        interceptors: {
+          exchange: vi.fn().mockRejectedValue(new Error('Refresh failed')),
+        },
+      } as unknown as Fetcher;
+
       const request = { url: '/test' };
       const response = new Response('test', {
         status: ResponseCodes.UNAUTHORIZED,
@@ -288,6 +296,9 @@ describe('cosecResponseInterceptor.ts', () => {
       const interceptor = new CoSecResponseInterceptor(options);
 
       const mockFetcher = {
+        interceptors: {
+          exchange: vi.fn().mockResolvedValue(undefined),
+        },
         request: vi.fn().mockResolvedValue({}),
       } as unknown as Fetcher;
 
@@ -333,8 +344,9 @@ describe('cosecResponseInterceptor.ts', () => {
       });
 
       // Verify requests were retried
-      expect(mockFetcher.request).toHaveBeenCalledTimes(2);
-      expect(mockFetcher.request).toHaveBeenCalledWith(request);
+      expect(mockFetcher.interceptors.exchange).toHaveBeenCalledTimes(2);
+      expect(mockFetcher.interceptors.exchange).toHaveBeenCalledWith(exchange1);
+      expect(mockFetcher.interceptors.exchange).toHaveBeenCalledWith(exchange2);
     });
   });
 });


### PR DESCRIPTION
- Replace `exchange.fetcher.request` with `exchange.fetcher.interceptors.exchange` for retrying requests
- This change ensures that all interceptors are properly executed during the retry process