### PR TITLE
refactor(storage): update isBrowser check and move to env module

### DIFF
--- a/packages/cosec/src/env.ts
+++ b/packages/cosec/src/env.ts
@@ -11,4 +11,6 @@
  * limitations under the License.
  */
 
-export const isBrowser = typeof window !== 'undefined';
+export function isBrowser(): boolean {
+  return typeof window !== 'undefined';
+}

--- a/packages/cosec/src/inMemoryStorage.ts
+++ b/packages/cosec/src/inMemoryStorage.ts
@@ -46,10 +46,10 @@ export class InMemoryStorage implements Storage {
   }
 }
 
-import { isBrowser } from './utils';
+import { isBrowser } from './env';
 
 export function getStorage(): Storage {
-  if (isBrowser && window.localStorage) {
+  if (isBrowser() && window.localStorage) {
     return window.localStorage;
   } else {
     // Use in-memory storage as fallback

--- a/packages/cosec/src/index.ts
+++ b/packages/cosec/src/index.ts
@@ -21,4 +21,4 @@ export * from './inMemoryStorage';
 export * from './tokenRefresher';
 export * from './tokenStorage';
 export * from './types';
-export * from './utils';
+export * from './env';

--- a/packages/cosec/src/storage/inMemoryListenableStorage.ts
+++ b/packages/cosec/src/storage/inMemoryListenableStorage.ts
@@ -12,6 +12,7 @@
  */
 
 import { ListenableStorage, RemoveStorageListener, STORAGE_EVENT_TYPE, StorageListener } from './listenableStorage';
+import { isBrowser } from '../env';
 
 /**
  * An in-memory implementation of ListenableStorage that works in any environment.
@@ -99,7 +100,7 @@ export class InMemoryListenableStorage implements ListenableStorage {
   private notifyListeners(
     eventInit: StorageEventInit,
   ): void {
-    if (window && window.location) {
+    if (isBrowser() && window.location) {
       eventInit.url = eventInit.url || window.location.href;
     }
     eventInit.storageArea = this;

--- a/packages/cosec/src/storage/listenableStorage.ts
+++ b/packages/cosec/src/storage/listenableStorage.ts
@@ -13,7 +13,7 @@
 
 import { InMemoryListenableStorage } from './inMemoryListenableStorage';
 import { BrowserListenableStorage } from './browserListenableStorage';
-import { isBrowser } from '../utils';
+import { isBrowser } from '../env';
 
 /**
  * The type of storage event used for listening to storage changes.
@@ -53,7 +53,7 @@ export interface ListenableStorage extends Storage, StorageListenable {
  * @returns A ListenableStorage instance suitable for the current environment
  */
 export const createListenableStorage = (): ListenableStorage => {
-  if (isBrowser) {
+  if (isBrowser()) {
     return new BrowserListenableStorage(window.localStorage);
   }
   return new InMemoryListenableStorage();

--- a/packages/cosec/test/env.test.ts
+++ b/packages/cosec/test/env.test.ts
@@ -11,25 +11,21 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { isBrowser } from '../src';
 
-describe('utils', () => {
-  it('should export isBrowser as false in Node.js environment', () => {
-    // In Node.js environment, window is undefined, so isBrowser should be false
-    expect(isBrowser).toBe(false);
-  });
-
-  it('should export isBrowser as true in browser environment', async () => {
+describe('env', () => {
+  it('should export isBrowser as true in browser environment', () => {
     // Mock window object to simulate browser environment
     const originalWindow = global.window;
     global.window = {} as any;
-
-    // Re-import the module to get the updated isBrowser value
-    vi.resetModules();
-    const utils = await import('../src/utils');
-    expect(utils.isBrowser).toBe(true);
+    expect(isBrowser()).toBe(true);
     // Restore original window
     global.window = originalWindow;
+  });
+
+  it('should have isBrowser as false in Node.js environment', () => {
+    // In Node.js environment, window is undefined
+    expect(isBrowser()).toBe(false);
   });
 });

--- a/packages/cosec/test/inMemoryStorage.test.ts
+++ b/packages/cosec/test/inMemoryStorage.test.ts
@@ -12,8 +12,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { getStorage, InMemoryStorage } from '../src/inMemoryStorage';
-import * as utils from '../src/utils';
+import { getStorage, InMemoryStorage } from '../src';
 
 describe('inMemoryStorage.ts', () => {
   describe('InMemoryStorage', () => {
@@ -139,10 +138,8 @@ describe('inMemoryStorage.ts', () => {
         key: vi.fn(),
         length: 0,
       };
-      
-      // Spy on isBrowser and make it return true
-      const isBrowserSpy = vi.spyOn(utils, 'isBrowser', 'get').mockReturnValue(true);
-      
+
+
       // Temporarily set window.localStorage
       const originalWindow = (globalThis as any).window;
       (globalThis as any).window = {
@@ -155,8 +152,6 @@ describe('inMemoryStorage.ts', () => {
       } finally {
         // Restore original window
         (globalThis as any).window = originalWindow;
-        // Restore spy
-        isBrowserSpy.mockRestore();
       }
     });
   });

--- a/packages/cosec/test/storage/listenableStorage.test.ts
+++ b/packages/cosec/test/storage/listenableStorage.test.ts
@@ -8,7 +8,6 @@ import {
 import {
   createListenableStorage,
 } from '../../src';
-import * as utils from '../../src/utils';
 
 describe('createListenableStorage', () => {
   // Mock window and localStorage for testing
@@ -73,8 +72,6 @@ describe('createListenableStorage', () => {
 
   it('should create BrowserListenableStorage when window is available', () => {
     // Spy on isBrowser and make it return true
-    const isBrowserSpy = vi.spyOn(utils, 'isBrowser', 'get').mockReturnValue(true);
-    
     // Temporarily set window
     const originalWindow = (global as any).window;
     (global as any).window = {
@@ -87,8 +84,6 @@ describe('createListenableStorage', () => {
     } finally {
       // Restore original window
       (global as any).window = originalWindow;
-      // Restore spy
-      isBrowserSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
- Update `isBrowser` check to use a function instead of a constant.
- Move `isBrowser` from `utils` to `env` module.
- Update import paths and usage in various files.
- Rename `utils.test.ts` to `env.test.ts` and update tests accordingly.

This change ensures that the `isBrowser` check is more flexible and can be used in different environments. It also organizes the code by moving environment-related checks to a dedicated `env` module.