### PR TITLE
refactor(storage): change StorageListener type to use StorageEventInit

### DIFF
--- a/packages/cosec/src/storage/browserListenableStorage.ts
+++ b/packages/cosec/src/storage/browserListenableStorage.ts
@@ -39,7 +39,7 @@ export class BrowserListenableStorage implements ListenableStorage {
    * @returns A function that can be called to remove the listener
    */
   addListener(listener: StorageListener): RemoveStorageListener {
-    const wrapper: StorageListener = (event: StorageEvent) => {
+    const wrapper: StorageListener = (event: StorageEventInit) => {
       if (event.storageArea === this.storage) {
         listener(event);
       }

--- a/packages/cosec/src/storage/inMemoryListenableStorage.ts
+++ b/packages/cosec/src/storage/inMemoryListenableStorage.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { ListenableStorage, RemoveStorageListener, STORAGE_EVENT_TYPE, StorageListener } from './listenableStorage';
+import { ListenableStorage, RemoveStorageListener, StorageListener } from './listenableStorage';
 import { isBrowser } from '../env';
 
 /**
@@ -104,10 +104,9 @@ export class InMemoryListenableStorage implements ListenableStorage {
       eventInit.url = eventInit.url || window.location.href;
     }
     eventInit.storageArea = this;
-    const event = new StorageEvent(STORAGE_EVENT_TYPE, eventInit);
     this.listeners.forEach(listener => {
       try {
-        listener(event);
+        listener(eventInit);
       } catch (error) {
         console.error('Error in storage change listener:', error);
       }

--- a/packages/cosec/src/storage/listenableStorage.ts
+++ b/packages/cosec/src/storage/listenableStorage.ts
@@ -23,7 +23,7 @@ export const STORAGE_EVENT_TYPE = 'storage';
 /**
  * A function that handles storage change events.
  */
-export type StorageListener = (event: StorageEvent) => void;
+export type StorageListener = (event: StorageEventInit) => void;
 
 /**
  * A function that removes a storage listener when called.


### PR DESCRIPTION
- Update StorageListener type to expect StorageEventInit instead of StorageEvent
- Modify listener calls in browserListenableStorage and inMemoryListenableStorage
- Remove unnecessary StorageEvent import in inMemoryListenableStorage