### PR TITLE
refactor(deviceIdStorage): inherit from KeyStorage and use IdentitySerializer

### DIFF
--- a/packages/cosec/src/deviceIdStorage.ts
+++ b/packages/cosec/src/deviceIdStorage.ts
@@ -12,41 +12,21 @@
  */
 
 import { idGenerator } from './idGenerator';
-import { createListenableStorage } from './storage';
+import { createListenableStorage, KeyStorage } from './storage';
+import { IdentitySerializer } from './serializer';
 
 export const DEFAULT_COSEC_DEVICE_ID_KEY = 'cosec-device-id';
 
 /**
  * Storage class for managing device identifiers.
  */
-export class DeviceIdStorage {
-  private readonly deviceIdKey: string;
-  private storage: Storage;
-
-  constructor(
-    deviceIdKey: string = DEFAULT_COSEC_DEVICE_ID_KEY,
-    storage: Storage = createListenableStorage(),
-  ) {
-    this.deviceIdKey = deviceIdKey;
-    this.storage = storage;
-  }
-
-  /**
-   * Get the current device ID.
-   *
-   * @returns The current device ID or null if not set
-   */
-  get(): string | null {
-    return this.storage.getItem(this.deviceIdKey);
-  }
-
-  /**
-   * Set a device ID.
-   *
-   * @param deviceId - The device ID to set
-   */
-  set(deviceId: string): void {
-    this.storage.setItem(this.deviceIdKey, deviceId);
+export class DeviceIdStorage extends KeyStorage<string> {
+  constructor(key: string = DEFAULT_COSEC_DEVICE_ID_KEY) {
+    super({
+      key,
+      serializer: new IdentitySerializer<string>(),
+      storage: createListenableStorage(),
+    });
   }
 
   /**
@@ -75,10 +55,4 @@ export class DeviceIdStorage {
     return deviceId;
   }
 
-  /**
-   * Clear the stored device ID.
-   */
-  clear(): void {
-    this.storage.removeItem(this.deviceIdKey);
-  }
 }

--- a/packages/cosec/test/deviceIdStorage.test.ts
+++ b/packages/cosec/test/deviceIdStorage.test.ts
@@ -13,8 +13,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import {
-  DEFAULT_COSEC_DEVICE_ID_KEY,
-  DeviceIdStorage, InMemoryListenableStorage,
+  DeviceIdStorage,
 } from '../src';
 
 describe('deviceIdStorage.ts', () => {
@@ -26,21 +25,20 @@ describe('deviceIdStorage.ts', () => {
 
     it('should create DeviceIdStorage with custom parameters', () => {
       const customKey = 'custom-device-id-key';
-      const customStorage = new InMemoryListenableStorage();
-      const storage = new DeviceIdStorage(customKey, customStorage);
+      const storage = new DeviceIdStorage(customKey);
 
       expect(storage).toBeInstanceOf(DeviceIdStorage);
     });
 
     it('should get null when no device ID is set', () => {
-      const storage = new DeviceIdStorage('test-key', new InMemoryListenableStorage());
+      const storage = new DeviceIdStorage('test-key');
       const result = storage.get();
 
       expect(result).toBeNull();
     });
 
     it('should set and get device ID', () => {
-      const storage = new DeviceIdStorage('test-key', new InMemoryListenableStorage());
+      const storage = new DeviceIdStorage('test-key');
       const deviceId = 'test-device-id';
 
       storage.set(deviceId);
@@ -50,7 +48,7 @@ describe('deviceIdStorage.ts', () => {
     });
 
     it('should generate device ID', () => {
-      const storage = new DeviceIdStorage('test-key', new InMemoryListenableStorage());
+      const storage = new DeviceIdStorage('test-key');
       const deviceId = storage.generateDeviceId();
 
       expect(deviceId).toBeDefined();
@@ -59,7 +57,7 @@ describe('deviceIdStorage.ts', () => {
     });
 
     it('should get existing device ID when available', () => {
-      const storage = new DeviceIdStorage('test-key', new InMemoryListenableStorage());
+      const storage = new DeviceIdStorage('test-key');
       const deviceId = 'existing-device-id';
 
       storage.set(deviceId);
@@ -69,7 +67,7 @@ describe('deviceIdStorage.ts', () => {
     });
 
     it('should generate and store new device ID when none exists', () => {
-      const storage = new DeviceIdStorage('test-key', new InMemoryListenableStorage());
+      const storage = new DeviceIdStorage('test-key');
       const result = storage.getOrCreate();
 
       expect(result).toBeDefined();
@@ -81,30 +79,15 @@ describe('deviceIdStorage.ts', () => {
       expect(stored).toBe(result);
     });
 
-    it('should clear stored device ID', () => {
-      const storage = new DeviceIdStorage('test-key', new InMemoryListenableStorage());
+    it('should remove stored device ID', () => {
+      const storage = new DeviceIdStorage('test-key');
       const deviceId = 'test-device-id';
 
       storage.set(deviceId);
-      storage.clear();
+      storage.remove();
       const result = storage.get();
 
       expect(result).toBeNull();
-    });
-
-    it('should use default key when none provided', () => {
-      const mockStorage = {
-        getItem: vi.fn().mockReturnValue(null),
-        setItem: vi.fn(),
-        removeItem: vi.fn(),
-      } as unknown as Storage;
-
-      const storage = new DeviceIdStorage(undefined, mockStorage);
-      storage.get();
-
-      expect(mockStorage.getItem).toHaveBeenCalledWith(
-        DEFAULT_COSEC_DEVICE_ID_KEY,
-      );
     });
   });
 });


### PR DESCRIPTION


- DeviceIdStorage now extends KeyStorage<string>
- Uses IdentitySerializer for string serialization
- Storage key is now configurable upon instantiation
- Removed unnecessary methods and simplified existing ones
- Updated tests to reflect new implementation