### PR TITLE
feat(cosec): add option to ignore refresh token for specific requests

### DIFF
--- a/packages/cosec/src/cosecRequestInterceptor.ts
+++ b/packages/cosec/src/cosecRequestInterceptor.ts
@@ -31,6 +31,8 @@ export const COSEC_REQUEST_INTERCEPTOR_NAME = 'CoSecRequestInterceptor';
 export const COSEC_REQUEST_INTERCEPTOR_ORDER =
   REQUEST_BODY_INTERCEPTOR_ORDER + 1000;
 
+export const IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY = 'Ignore-Refresh-Token';
+
 /**
  * Interceptor that automatically adds CoSec authentication headers to requests.
  *
@@ -108,7 +110,7 @@ export class CoSecRequestInterceptor implements RequestInterceptor {
     }
 
     // Refresh token if needed and refreshable
-    if (currentToken.isRefreshNeeded && currentToken.isRefreshable) {
+    if (!exchange.attributes[IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY] && currentToken.isRefreshNeeded && currentToken.isRefreshable) {
       await this.options.tokenManager.refresh();
     }
 

--- a/packages/cosec/test/cosecRequestInterceptor.test.ts
+++ b/packages/cosec/test/cosecRequestInterceptor.test.ts
@@ -69,6 +69,7 @@ describe('CoSecRequestInterceptor', () => {
     // Create mock exchange
     mockExchange = {
       request: {},
+      attributes: {},
       ensureRequestHeaders: vi.fn().mockReturnValue({}),
     } as unknown as FetchExchange;
   });
@@ -101,8 +102,12 @@ describe('CoSecRequestInterceptor', () => {
       access: {
         token: 'mock-access-token',
       },
-      isRefreshNeeded: false,
-      isRefreshable: true,
+      get isRefreshNeeded() {
+        return false;
+      },
+      get isRefreshable() {
+        return true;
+      },
     };
 
     // Mock tokenManager.currentToken getter
@@ -130,8 +135,12 @@ describe('CoSecRequestInterceptor', () => {
       access: {
         token: 'mock-access-token',
       },
-      isRefreshNeeded: false,
-      isRefreshable: true,
+      get isRefreshNeeded() {
+        return false;
+      },
+      get isRefreshable() {
+        return true;
+      },
     };
 
     // Mock tokenManager.currentToken getter
@@ -153,16 +162,24 @@ describe('CoSecRequestInterceptor', () => {
       access: {
         token: 'new-access-token',
       },
-      isRefreshNeeded: true,
-      isRefreshable: true,
+      get isRefreshNeeded() {
+        return true;
+      },
+      get isRefreshable() {
+        return true;
+      },
     };
 
     const refreshedToken = {
       access: {
         token: 'refreshed-access-token',
       },
-      isRefreshNeeded: false,
-      isRefreshable: true,
+      get isRefreshNeeded() {
+        return false;
+      },
+      get isRefreshable() {
+        return true;
+      },
     };
 
     // Mock tokenManager.currentToken getter to return different values


### PR DESCRIPTION
- Introduce IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY to control token refresh behavior
- Update cosecRequestInterceptor to check for the ignore attribute before refreshing tokens
- Add corresponding test cases to verify the new functionality