### PR TITLE
refactor(fetcher): improve result extraction and rename methods

### DIFF
--- a/packages/fetcher/src/fetchExchange.ts
+++ b/packages/fetcher/src/fetchExchange.ts
@@ -260,16 +260,26 @@ export class FetchExchange
   }
 
   /**
+   * Extracts the result by applying the result extractor to the exchange.
+   * The result is cached after the first computation to avoid repeated computations.
+   *
+   * @returns The extracted result
+   */
+  extractResult<R>(): R {
+    if (this.cachedExtractedResult !== undefined) {
+      return this.cachedExtractedResult;
+    }
+    this.cachedExtractedResult = this.resultExtractor(this);
+    return this.cachedExtractedResult;
+  }
+
+  /**
    * Gets the extracted result by applying the result extractor to the exchange.
    * The result is cached after the first computation.
    *
    * @returns The extracted result or null if extraction failed
    */
   typedExtractedResult<R = any>(): R | Promise<R> {
-    if (this.cachedExtractedResult !== undefined) {
-      return this.cachedExtractedResult;
-    }
-    this.cachedExtractedResult = this.resultExtractor(this);
-    return this.cachedExtractedResult;
+    return this.extractResult<R>();
   }
 }

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -140,7 +140,7 @@ export class Fetcher
       attributes,
     });
     await this.interceptors.exchange(exchange);
-    return exchange.typedExtractedResult();
+    return exchange.extractResult();
   }
 
   /**


### PR DESCRIPTION
- Rename `typedExtractedResult` to `extractResult` for clarity
- Add a new `typedExtractedResult` method that calls `extractResult`
- Update method documentation to better reflect functionality