### PR TITLE
feat(fetcher): add mergeRecordToMap utility function

### DIFF
--- a/packages/fetcher/src/utils.ts
+++ b/packages/fetcher/src/utils.ts
@@ -61,3 +61,26 @@ export function mergeRecords<V>(
   // Merge both records, with second taking precedence
   return { ...first, ...second };
 }
+
+/**
+ * Merge a Record object or Map object into a target Map
+ * @param record - Source data, can be either Record<string, V> or Map<string, V> type
+ * @param map - Target Map object, if not provided a new Map will be created
+ * @returns The merged Map object
+ */
+export function mergeRecordToMap<V>(record: Record<string, V> | Map<string, V>, map?: Map<string, V>): Map<string, V> {
+  if (record instanceof Map) {
+    if (!map) {
+      return record;
+    }
+    for (const [key, value] of record) {
+      map.set(key, value);
+    }
+    return map;
+  }
+  map ??= new Map();
+  for (const [key, value] of Object.entries(record)) {
+    map.set(key, value);
+  }
+  return map;
+}

--- a/packages/fetcher/test/utils.test.ts
+++ b/packages/fetcher/test/utils.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { mergeRecords } from '../src';
+import { mergeRecords, mergeRecordToMap } from '../src';
 
 describe('utils', () => {
   describe('mergeRecords', () => {
@@ -71,6 +71,68 @@ describe('utils', () => {
         number: 100,
         boolean: true,
       });
+    });
+  });
+
+  describe('mergeRecordToMap', () => {
+    it('should merge Record to new Map when target map is not provided', () => {
+      const record = { a: 1, b: 2 };
+      const result = mergeRecordToMap(record);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(2);
+      expect(result.get('a')).toBe(1);
+      expect(result.get('b')).toBe(2);
+    });
+
+    it('should merge Record to existing Map', () => {
+      const record = { a: 1, b: 2 };
+      const targetMap = new Map([['c', 3]]);
+      const result = mergeRecordToMap(record, targetMap);
+
+      expect(result).toBe(targetMap);
+      expect(result.size).toBe(3);
+      expect(result.get('a')).toBe(1);
+      expect(result.get('b')).toBe(2);
+      expect(result.get('c')).toBe(3);
+    });
+
+    it('should merge Map to new Map when target map is not provided', () => {
+      const sourceMap = new Map([['a', 1], ['b', 2]]);
+      const result = mergeRecordToMap(sourceMap);
+
+      expect(result).toBe(sourceMap);
+      expect(result.size).toBe(2);
+      expect(result.get('a')).toBe(1);
+      expect(result.get('b')).toBe(2);
+    });
+
+    it('should merge Map to existing Map', () => {
+      const sourceMap = new Map([['a', 1], ['b', 2]]);
+      const targetMap = new Map([['c', 3]]);
+      const result = mergeRecordToMap(sourceMap, targetMap);
+
+      expect(result).toBe(targetMap);
+      expect(result.size).toBe(3);
+      expect(result.get('a')).toBe(1);
+      expect(result.get('b')).toBe(2);
+      expect(result.get('c')).toBe(3);
+    });
+
+    it('should create new Map when source is Record and target map is undefined', () => {
+      const record = { a: 1 };
+      const result = mergeRecordToMap(record, undefined);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(1);
+      expect(result.get('a')).toBe(1);
+    });
+
+    it('should return source Map when target map is not provided', () => {
+      const sourceMap = new Map([['a', 1]]);
+      const result = mergeRecordToMap(sourceMap);
+
+      expect(result).toBe(sourceMap);
     });
   });
 });


### PR DESCRIPTION
- Implement mergeRecordToMap function to merge Record or Map into a target Map
- Add comprehensive unit tests for mergeRecordToMap
- Update utils.ts to include the new function