### PR TITLE
fix(fetcher): handle falsy record in mergeRecordToMap

### DIFF
--- a/packages/fetcher/src/utils.ts
+++ b/packages/fetcher/src/utils.ts
@@ -68,7 +68,10 @@ export function mergeRecords<V>(
  * @param map - Target Map object, if not provided a new Map will be created
  * @returns The merged Map object
  */
-export function mergeRecordToMap<V>(record: Record<string, V> | Map<string, V>, map?: Map<string, V>): Map<string, V> {
+export function mergeRecordToMap<V>(record?: Record<string, V> | Map<string, V>, map?: Map<string, V>): Map<string, V> {
+  if (!record) {
+    return map ?? new Map();
+  }
   if (record instanceof Map) {
     if (!map) {
       return record;

--- a/packages/fetcher/test/utils.test.ts
+++ b/packages/fetcher/test/utils.test.ts
@@ -75,6 +75,20 @@ describe('utils', () => {
   });
 
   describe('mergeRecordToMap', () => {
+    it('should return new Map when record is falsy and target map is not provided', () => {
+      const result = mergeRecordToMap(undefined);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it('should return target map when record is falsy', () => {
+      const targetMap = new Map([['a', 1]]);
+      const result = mergeRecordToMap(undefined, targetMap);
+      expect(result).toBe(targetMap);
+      expect(result.size).toBe(1);
+      expect(result.get('a')).toBe(1);
+    });
+    
     it('should merge Record to new Map when target map is not provided', () => {
       const record = { a: 1, b: 2 };
       const result = mergeRecordToMap(record);


### PR DESCRIPTION
- Update mergeRecordToMap function to handle falsy record input
- Return new Map when record is falsy and no target map is provided
- Return target map when record is falsy
- Add corresponding test cases to cover new behavior