### PR TITLE
refactor(decorator): move ResultExtractorCapable to @ahoo-wang/fetcher

### DIFF
--- a/packages/decorator/src/apiDecorator.ts
+++ b/packages/decorator/src/apiDecorator.ts
@@ -16,13 +16,13 @@ import {
   Fetcher,
   type RequestHeaders,
   type RequestHeadersCapable,
+  type ResultExtractorCapable,
   type TimeoutCapable,
 } from '@ahoo-wang/fetcher';
 import { ENDPOINT_METADATA_KEY } from './endpointDecorator';
 import { RequestExecutor } from './requestExecutor';
 import { PARAMETER_METADATA_KEY } from './parameterDecorator';
 import 'reflect-metadata';
-import { type ResultExtractorCapable } from './resultExtractor';
 import { type FetcherCapable } from './fetcherCapable';
 import { FunctionMetadata } from './functionMetadata';
 

--- a/packages/decorator/src/endpointDecorator.ts
+++ b/packages/decorator/src/endpointDecorator.ts
@@ -1,7 +1,6 @@
-import { HttpMethod } from '@ahoo-wang/fetcher';
+import { HttpMethod, type ResultExtractorCapable } from '@ahoo-wang/fetcher';
 import { type ApiMetadata } from './apiDecorator';
 import 'reflect-metadata';
-import { type ResultExtractorCapable } from './resultExtractor';
 
 export interface PathCapable {
   /**

--- a/packages/decorator/src/resultExtractor.ts
+++ b/packages/decorator/src/resultExtractor.ts
@@ -15,21 +15,12 @@ import {
   ExchangeResultExtractor,
   JsonResultExtractor,
   ResponseResultExtractor,
-  ResultExtractor,
   TextResultExtractor,
 } from '@ahoo-wang/fetcher';
 import {
   EventStreamResultExtractor,
   JsonEventStreamResultExtractor,
 } from '@ahoo-wang/fetcher-eventstream';
-
-/**
- * Interface with result extractor capability
- * Defines an optional resultExtractor property
- */
-export interface ResultExtractorCapable {
-  resultExtractor?: ResultExtractor<any>;
-}
 
 /**
  * ResultExtractors is an object that maps result extractor names to their corresponding

--- a/packages/fetcher/src/resultExtractor.ts
+++ b/packages/fetcher/src/resultExtractor.ts
@@ -25,6 +25,14 @@ export interface ResultExtractor<R> {
 }
 
 /**
+ * Interface with result extractor capability
+ * Defines an optional resultExtractor property
+ */
+export interface ResultExtractorCapable {
+  resultExtractor?: ResultExtractor<any>;
+}
+
+/**
  * Returns the original FetchExchange object.
  * @param exchange - The FetchExchange object to return
  * @returns The same FetchExchange object that was passed in


### PR DESCRIPTION
- Move ResultExtractorCapable interface from decorator package to fetcher package
- Update import statements in apiDecorator.ts, endpointDecorator.ts, and resultExtractor.ts
- Remove redundant ResultExtractorCapable interface definition from resultExtractor.ts