### PR TITLE
refactor(fetched): simplify result extraction API

### DIFF
--- a/packages/fetcher/src/fetchExchange.ts
+++ b/packages/fetcher/src/fetchExchange.ts
@@ -266,21 +266,11 @@ export class FetchExchange
    *
    * @returns The extracted result
    */
-  extractResult<R>(): R {
+  extractResult<R>(): R | Promise<R> {
     if (this.cachedExtractedResult !== undefined) {
       return this.cachedExtractedResult;
     }
     this.cachedExtractedResult = this.resultExtractor(this);
     return this.cachedExtractedResult;
-  }
-
-  /**
-   * Gets the extracted result by applying the result extractor to the exchange.
-   * The result is cached after the first computation.
-   *
-   * @returns The extracted result or null if extraction failed
-   */
-  typedExtractedResult<R = any>(): R | Promise<R> {
-    return this.extractResult<R>();
   }
 }

--- a/packages/fetcher/test/fetchExchange.test.ts
+++ b/packages/fetcher/test/fetchExchange.test.ts
@@ -219,11 +219,11 @@ describe('FetchExchange', () => {
     });
 
     // First call
-    const result1 = exchange.typedExtractedResult();
+    const result1 = exchange.extractResult();
     expect(result1).toBe(exchange);
 
     // Second call should return cached result
-    const result2 = exchange.typedExtractedResult();
+    const result2 = exchange.extractResult();
     expect(result2).toBe(result1);
     expect(result2).toBe(exchange);
   });
@@ -241,7 +241,7 @@ describe('FetchExchange', () => {
     });
 
     // This would normally be a Promise, but for testing purposes we're checking the function was called
-    const result = exchange.typedExtractedResult();
+    const result = exchange.extractResult();
     expect(result).toBeInstanceOf(Promise);
   });
 });


### PR DESCRIPTION
- Remove redundant typedExtractedResult() method
- Update extractResult() to return R | Promise<R>
- Adjust tests to use extractResult() directly