### PR TITLE
refactor(fetcherCapable): update getFetcher to use fetcherRegistrar default

### DIFF
--- a/packages/fetcher/src/fetcherCapable.ts
+++ b/packages/fetcher/src/fetcherCapable.ts
@@ -13,7 +13,6 @@
 
 import { Fetcher } from './fetcher';
 import { fetcherRegistrar } from './fetcherRegistrar';
-import { fetcher as defaultNamedFetcher } from './namedFetcher';
 
 /**
  * Interface that defines a capability for objects that can have a fetcher.
@@ -35,10 +34,10 @@ export interface FetcherCapable {
  * @param defaultFetcher - The default Fetcher to use when fetcher is not provided, defaults to defaultNamedFetcher
  * @returns A Fetcher instance if found, otherwise returns the default Fetcher
  */
-export function getFetcher(fetcher?: string | Fetcher, defaultFetcher: Fetcher = defaultNamedFetcher): Fetcher {
-  // Return undefined if no fetcher is provided
+export function getFetcher(fetcher?: string | Fetcher, defaultFetcher?: Fetcher): Fetcher {
+  // Return default fetcher if no fetcher is provided
   if (!fetcher) {
-    return defaultFetcher;
+    return defaultFetcher ?? fetcherRegistrar.default;
   }
 
   // Return the fetcher directly if it's already a Fetcher instance,

--- a/packages/fetcher/test/fetcherCapable.test.ts
+++ b/packages/fetcher/test/fetcherCapable.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { Fetcher } from '../src';
+import { DEFAULT_FETCHER_NAME, Fetcher } from '../src';
 import { fetcherRegistrar } from '../src';
 import { getFetcher, type FetcherCapable } from '../src';
 import { NamedFetcher } from '../src';
@@ -20,10 +20,11 @@ import { NamedFetcher } from '../src';
 describe('fetcherCapable', () => {
   let mockFetcher: Fetcher;
   let testFetcher: NamedFetcher;
-
+  let defaultFetcher: Fetcher;
   beforeEach(() => {
     mockFetcher = new Fetcher({ baseURL: 'https://api.example.com' });
     testFetcher = new NamedFetcher('test-fetcher', { baseURL: 'https://test.api.com' });
+    defaultFetcher = new NamedFetcher(DEFAULT_FETCHER_NAME);
   });
 
   afterEach(() => {
@@ -47,11 +48,13 @@ describe('fetcherCapable', () => {
     it('should return default fetcher when no fetcher provided', () => {
       const result = getFetcher();
       expect(result).toBeInstanceOf(NamedFetcher);
+      expect(result).toBe(defaultFetcher);
     });
 
     it('should return default fetcher when fetcher is undefined', () => {
       const result = getFetcher(undefined);
       expect(result).toBeInstanceOf(NamedFetcher);
+      expect(result).toBe(defaultFetcher);
     });
 
     it('should return provided Fetcher instance directly', () => {


### PR DESCRIPTION


- Removed unused import `defaultNamedFetcher`.
- Updated the `getFetcher` function to use `fetcherRegistrar.default` as the fallback when no fetcher is provided.
- Added a new test case to ensure the default fetcher is returned when no fetcher is provided.This change simplifies the logic and ensures that the default fetcher is consistently managed by the `fetcherRegistrar`.