### PR TITLE
fix(cosec/jwtToken): Allow payload to be null and handle invalid tokens

### DIFF
--- a/packages/cosec/src/jwtToken.ts
+++ b/packages/cosec/src/jwtToken.ts
@@ -22,7 +22,7 @@ import { Serializer } from '@ahoo-wang/fetcher-storage';
  */
 export interface IJwtToken<Payload extends JwtPayload> extends EarlyPeriodCapable {
   readonly token: string;
-  readonly payload: Payload;
+  readonly payload: Payload | null;
 
   isExpired: boolean;
 }
@@ -32,7 +32,7 @@ export interface IJwtToken<Payload extends JwtPayload> extends EarlyPeriodCapabl
  * @template Payload The type of the JWT payload
  */
 export class JwtToken<Payload extends JwtPayload> implements IJwtToken<Payload> {
-  public readonly payload: Payload;
+  public readonly payload: Payload | null;
 
   /**
    * Creates a new JwtToken instance
@@ -41,7 +41,7 @@ export class JwtToken<Payload extends JwtPayload> implements IJwtToken<Payload> 
     public readonly token: string,
     public readonly earlyPeriod: number = 0,
   ) {
-    this.payload = parseJwtPayload(token) as Payload;
+    this.payload = parseJwtPayload<Payload>(token);
   }
 
   /**
@@ -49,6 +49,9 @@ export class JwtToken<Payload extends JwtPayload> implements IJwtToken<Payload> 
    * @returns true if the token is expired, false otherwise
    */
   get isExpired(): boolean {
+    if (!this.payload) {
+      return true;
+    }
     return isTokenExpired(this.payload, this.earlyPeriod);
   }
 }


### PR DESCRIPTION
- Modified the `payload` property in `IJwtToken` and `JwtToken` to be of type `Payload | null`.