### PR TITLE
refactor(react): improve variable naming in useKeyStorage

### DIFF
--- a/packages/react/src/storage/useKeyStorage.ts
+++ b/packages/react/src/storage/useKeyStorage.ts
@@ -33,7 +33,7 @@ export function useKeyStorage<T>(
     () => keyStorage.get(),
     [keyStorage],
   );
-  const store = useSyncExternalStore(
+  const value = useSyncExternalStore(
     subscribe,
     getSnapshot,
     getSnapshot,
@@ -42,5 +42,5 @@ export function useKeyStorage<T>(
     (value: T) => keyStorage.set(value),
     [keyStorage],
   );
-  return [store, setValue];
+  return [value, setValue];
 }


### PR DESCRIPTION
- Rename 'store' to 'value' to better reflect the data it holds
- This change enhances code readability and maintainability