### PR TITLE
build(deps): switch to pnpm workspace catalog

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -51,9 +51,16 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "typescript": "^5.9.2",
-    "unplugin-dts": "1.0.0-beta.6",
-    "vite": "^7.1.3",
-    "vitest": "^3.0.5"
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
   },
   "packageManager": "pnpm@10.16.1",
   "devDependencies": {
-    "@eslint/js": "^9.35.0",
-    "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.35.0",
-    "globals": "^16.4.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "typescript-eslint": "^8.43.0",
-    "unplugin-dts": "1.0.0-beta.6",
-    "vite": "^7.1.5",
-    "vite-bundle-analyzer": "^1.2.3",
-    "vitest": "^3.2.4"
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:"
   }
 }

--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -51,12 +51,16 @@
     "nanoid": "^5.1.5"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.33.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "unplugin-dts": "1.0.0-beta.6",
-    "vite": "^7.1.3",
-    "vitest": "^3.2.4"
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:"
   }
 }

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -51,12 +51,16 @@
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.33.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "unplugin-dts": "1.0.0-beta.6",
-    "vite": "^7.1.3",
-    "vitest": "^3.2.4"
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:"
   }
 }

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -49,12 +49,16 @@
     "@ahoo-wang/fetcher": "workspace:*"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.33.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "unplugin-dts": "1.0.0-beta.6",
-    "vite": "^7.1.3",
-    "vitest": "^3.2.4"
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:"
   }
 }

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -49,12 +49,16 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.33.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "unplugin-dts": "1.0.0-beta.6",
-    "vite": "^7.1.3",
-    "vitest": "^3.2.4"
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,10 +53,20 @@
     "react-dom": ">=16.8.0"
   },
   "devDependencies": {
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "@vitest/coverage-v8": "^3.2.4",
     "jsdom": "^27.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -44,12 +44,16 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.33.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "unplugin-dts": "1.0.0-beta.6",
-    "vite": "^7.1.3",
-    "vitest": "^3.2.4"
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:"
   }
 }

--- a/packages/wow/package.json
+++ b/packages/wow/package.json
@@ -49,12 +49,16 @@
     "@ahoo-wang/fetcher-eventstream": "workspace:*"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^3.2.4",
-    "eslint": "^9.33.0",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "unplugin-dts": "1.0.0-beta.6",
-    "vite": "^7.1.3",
-    "vitest": "^3.2.4"
+    "vite": "catalog:",
+    "vite-bundle-analyzer": "catalog:",
+    "unplugin-dts": "catalog:",
+    "typescript": "catalog:",
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "globals": "catalog:",
+    "prettier": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,42 +4,78 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@eslint/js':
+      specifier: ^9.35.0
+      version: 9.35.0
+    '@vitest/coverage-v8':
+      specifier: ^3.2.4
+      version: 3.2.4
+    eslint:
+      specifier: ^9.35.0
+      version: 9.35.0
+    globals:
+      specifier: ^16.4.0
+      version: 16.4.0
+    prettier:
+      specifier: ^3.6.2
+      version: 3.6.2
+    typescript:
+      specifier: ^5.9.2
+      version: 5.9.2
+    typescript-eslint:
+      specifier: ^8.43.0
+      version: 8.43.0
+    unplugin-dts:
+      specifier: 1.0.0-beta.6
+      version: 1.0.0-beta.6
+    vite:
+      specifier: ^7.1.5
+      version: 7.1.5
+    vite-bundle-analyzer:
+      specifier: ^1.2.3
+      version: 1.2.3
+    vitest:
+      specifier: ^3.2.4
+      version: 3.2.4
+
 importers:
 
   .:
     devDependencies:
       '@eslint/js':
-        specifier: ^9.35.0
+        specifier: 'catalog:'
         version: 9.35.0
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
       eslint:
-        specifier: ^9.35.0
+        specifier: 'catalog:'
         version: 9.35.0
       globals:
-        specifier: ^16.4.0
+        specifier: 'catalog:'
         version: 16.4.0
       prettier:
-        specifier: ^3.6.2
+        specifier: 'catalog:'
         version: 3.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: 'catalog:'
         version: 5.9.2
       typescript-eslint:
-        specifier: ^8.43.0
+        specifier: 'catalog:'
         version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       unplugin-dts:
-        specifier: 1.0.0-beta.6
+        specifier: 'catalog:'
         version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
       vite:
-        specifier: ^7.1.5
+        specifier: 'catalog:'
         version: 7.1.5(@types/node@24.4.0)
       vite-bundle-analyzer:
-        specifier: ^1.2.3
+        specifier: 'catalog:'
         version: 1.2.3
       vitest:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
   integration-test:
@@ -60,20 +96,41 @@ importers:
         specifier: workspace:*
         version: link:../packages/wow
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.35.0
       '@types/node':
         specifier: ^24.3.0
         version: 24.4.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.35.0
+      globals:
+        specifier: 'catalog:'
+        version: 16.4.0
+      prettier:
+        specifier: 'catalog:'
+        version: 3.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: 'catalog:'
         version: 5.9.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       unplugin-dts:
-        specifier: 1.0.0-beta.6
+        specifier: 'catalog:'
         version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
       vite:
-        specifier: ^7.1.3
+        specifier: 'catalog:'
         version: 7.1.5(@types/node@24.4.0)
+      vite-bundle-analyzer:
+        specifier: 'catalog:'
+        version: 1.2.3
       vitest:
-        specifier: ^3.0.5
+        specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
   packages/cosec:
@@ -88,26 +145,38 @@ importers:
         specifier: ^5.1.5
         version: 5.1.5
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.35.0
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
       eslint:
-        specifier: ^9.33.0
+        specifier: 'catalog:'
         version: 9.35.0
+      globals:
+        specifier: 'catalog:'
+        version: 16.4.0
       prettier:
-        specifier: ^3.6.2
+        specifier: 'catalog:'
         version: 3.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: 'catalog:'
         version: 5.9.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       unplugin-dts:
-        specifier: 1.0.0-beta.6
+        specifier: 'catalog:'
         version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
       vite:
-        specifier: ^7.1.3
+        specifier: 'catalog:'
         version: 7.1.5(@types/node@24.4.0)
+      vite-bundle-analyzer:
+        specifier: 'catalog:'
+        version: 1.2.3
       vitest:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
   packages/decorator:
@@ -122,26 +191,38 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.35.0
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
       eslint:
-        specifier: ^9.33.0
+        specifier: 'catalog:'
         version: 9.35.0
+      globals:
+        specifier: 'catalog:'
+        version: 16.4.0
       prettier:
-        specifier: ^3.6.2
+        specifier: 'catalog:'
         version: 3.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: 'catalog:'
         version: 5.9.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       unplugin-dts:
-        specifier: 1.0.0-beta.6
+        specifier: 'catalog:'
         version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
       vite:
-        specifier: ^7.1.3
+        specifier: 'catalog:'
         version: 7.1.5(@types/node@24.4.0)
+      vite-bundle-analyzer:
+        specifier: 'catalog:'
+        version: 1.2.3
       vitest:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
   packages/eventstream:
@@ -150,50 +231,74 @@ importers:
         specifier: workspace:*
         version: link:../fetcher
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.35.0
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
       eslint:
-        specifier: ^9.33.0
+        specifier: 'catalog:'
         version: 9.35.0
+      globals:
+        specifier: 'catalog:'
+        version: 16.4.0
       prettier:
-        specifier: ^3.6.2
+        specifier: 'catalog:'
         version: 3.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: 'catalog:'
         version: 5.9.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       unplugin-dts:
-        specifier: 1.0.0-beta.6
+        specifier: 'catalog:'
         version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
       vite:
-        specifier: ^7.1.3
+        specifier: 'catalog:'
         version: 7.1.5(@types/node@24.4.0)
+      vite-bundle-analyzer:
+        specifier: 'catalog:'
+        version: 1.2.3
       vitest:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
   packages/fetcher:
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.35.0
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
       eslint:
-        specifier: ^9.33.0
+        specifier: 'catalog:'
         version: 9.35.0
+      globals:
+        specifier: 'catalog:'
+        version: 16.4.0
       prettier:
-        specifier: ^3.6.2
+        specifier: 'catalog:'
         version: 3.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: 'catalog:'
         version: 5.9.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       unplugin-dts:
-        specifier: 1.0.0-beta.6
+        specifier: 'catalog:'
         version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
       vite:
-        specifier: ^7.1.3
+        specifier: 'catalog:'
         version: 7.1.5(@types/node@24.4.0)
+      vite-bundle-analyzer:
+        specifier: 'catalog:'
+        version: 1.2.3
       vitest:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
   packages/react:
@@ -208,6 +313,9 @@ importers:
         specifier: ^17.6.0
         version: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.35.0
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.3.0(@testing-library/dom@9.3.4)(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -218,40 +326,79 @@ importers:
         specifier: ^18.0.0
         version: 18.3.7(@types/react@18.3.24)
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.35.0
+      globals:
+        specifier: 'catalog:'
+        version: 16.4.0
       jsdom:
         specifier: ^27.0.0
         version: 27.0.0(postcss@8.5.6)
+      prettier:
+        specifier: 'catalog:'
+        version: 3.6.2
       react:
         specifier: ^18.0.0
         version: 18.3.1
       react-dom:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
+      unplugin-dts:
+        specifier: 'catalog:'
+        version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
+      vite:
+        specifier: 'catalog:'
+        version: 7.1.5(@types/node@24.4.0)
+      vite-bundle-analyzer:
+        specifier: 'catalog:'
+        version: 1.2.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
   packages/storage:
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.35.0
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
       eslint:
-        specifier: ^9.33.0
+        specifier: 'catalog:'
         version: 9.35.0
+      globals:
+        specifier: 'catalog:'
+        version: 16.4.0
       prettier:
-        specifier: ^3.6.2
+        specifier: 'catalog:'
         version: 3.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: 'catalog:'
         version: 5.9.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       unplugin-dts:
-        specifier: 1.0.0-beta.6
+        specifier: 'catalog:'
         version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
       vite:
-        specifier: ^7.1.3
+        specifier: 'catalog:'
         version: 7.1.5(@types/node@24.4.0)
+      vite-bundle-analyzer:
+        specifier: 'catalog:'
+        version: 1.2.3
       vitest:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
   packages/wow:
@@ -263,26 +410,38 @@ importers:
         specifier: workspace:*
         version: link:../eventstream
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.35.0
       '@vitest/coverage-v8':
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6)))
       eslint:
-        specifier: ^9.33.0
+        specifier: 'catalog:'
         version: 9.35.0
+      globals:
+        specifier: 'catalog:'
+        version: 16.4.0
       prettier:
-        specifier: ^3.6.2
+        specifier: 'catalog:'
         version: 3.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: 'catalog:'
         version: 5.9.2
+      typescript-eslint:
+        specifier: 'catalog:'
+        version: 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       unplugin-dts:
-        specifier: 1.0.0-beta.6
+        specifier: 'catalog:'
         version: 1.0.0-beta.6(@microsoft/api-extractor@7.43.0(@types/node@24.4.0))(esbuild@0.25.9)(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.5(@types/node@24.4.0))
       vite:
-        specifier: ^7.1.3
+        specifier: 'catalog:'
         version: 7.1.5(@types/node@24.4.0)
+      vite-bundle-analyzer:
+        specifier: 'catalog:'
+        version: 1.2.3
       vitest:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(jsdom@27.0.0(postcss@8.5.6))
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,15 @@
 packages:
   - 'packages/*'
   - 'integration-test'
+catalog:
+  "vite": "^7.1.5"
+  "vite-bundle-analyzer": "^1.2.3"
+  "unplugin-dts": "1.0.0-beta.6"
+  "eslint": "^9.35.0"
+  "@eslint/js": "^9.35.0"
+  "typescript-eslint": "^8.43.0"
+  "vitest": "^3.2.4"
+  "@vitest/coverage-v8": "^3.2.4"
+  "globals": "^16.4.0"
+  "prettier": "^3.6.2"
+  "typescript": "^5.9.2"


### PR DESCRIPTION
- Replace individual package dependencies with centralized workspace catalog
- Update dependency specifiers to use 'catalog:' instead of specific versions
- Remove redundant dependencies from package.json files
- Update pnpm-lock.yaml to reflect new dependency structure