### PR TITLE
refactor(fetcher): remove unnecessary default content type header

### DIFF
--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -62,7 +62,6 @@ export interface FetcherOptions
 }
 
 const DEFAULT_HEADERS: RequestHeaders = {
-  'Content-Type': ContentTypeValues.APPLICATION_JSON,
 };
 
 export const DEFAULT_OPTIONS: FetcherOptions = {

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -14,8 +14,8 @@
 import { UrlBuilder, type UrlBuilderCapable } from './urlBuilder';
 import { resolveTimeout, type TimeoutCapable } from './timeout';
 import { AttributesCapable, FetchExchange } from './fetchExchange';
-import type {
-  BaseURLCapable,
+import {
+  BaseURLCapable, CONTENT_TYPE_HEADER, ContentTypeValues,
   FetchRequest,
   FetchRequestInit,
   RequestHeaders,
@@ -62,6 +62,7 @@ export interface FetcherOptions
 }
 
 const DEFAULT_HEADERS: RequestHeaders = {
+  [CONTENT_TYPE_HEADER]: ContentTypeValues.APPLICATION_JSON,
 };
 
 export const DEFAULT_OPTIONS: FetcherOptions = {

--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -21,7 +21,7 @@ import type {
   RequestHeaders,
   RequestHeadersCapable,
 } from './fetchRequest';
-import { ContentTypeValues, HttpMethod } from './fetchRequest';
+import { HttpMethod } from './fetchRequest';
 import { InterceptorManager } from './interceptorManager';
 import { UrlTemplateStyle } from './urlTemplateResolver';
 import { ResultExtractorCapable, ResultExtractors } from './resultExtractor';
@@ -211,9 +211,11 @@ export class Fetcher
     request: FetchRequestInit = {},
     options?: RequestOptions,
   ): Promise<R> {
-    const fetchRequest = request as FetchRequest;
-    fetchRequest.url = url;
-    return this.request(fetchRequest, mergeRequestOptions(DEFAULT_FETCH_OPTIONS, options));
+    const mergedRequest: FetchRequest = {
+      ...request,
+      url,
+    };
+    return this.request(mergedRequest, mergeRequestOptions(DEFAULT_FETCH_OPTIONS, options));
   }
 
   /**

--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -13,7 +13,7 @@
 
 import { type RequestInterceptor } from './interceptor';
 import { FetchExchange } from './fetchExchange';
-import { ContentTypeValues } from './fetchRequest';
+import { CONTENT_TYPE_HEADER, ContentTypeValues } from './fetchRequest';
 import { URL_RESOLVE_INTERCEPTOR_ORDER } from './urlResolveInterceptor';
 
 /**
@@ -109,7 +109,7 @@ export class RequestBodyInterceptor implements RequestInterceptor {
     if (typeof request.body !== 'object') {
       return;
     }
-
+    const headers = exchange.ensureRequestHeaders();
     // Check if it's a supported type
     if (
       request.body instanceof ArrayBuffer ||
@@ -120,16 +120,18 @@ export class RequestBodyInterceptor implements RequestInterceptor {
       request.body instanceof FormData ||
       request.body instanceof ReadableStream
     ) {
+      if (headers[CONTENT_TYPE_HEADER]) {
+        delete headers[CONTENT_TYPE_HEADER];
+      }
       return;
     }
 
     // For plain objects, convert to JSON string
     // Also ensure Content-Type header is set to application/json
     exchange.request.body = JSON.stringify(request.body);
-    // Only set default Content-Type if not explicitly set
-    const headers = exchange.ensureRequestHeaders();
-    if (!headers['Content-Type']) {
-      headers['Content-Type'] = ContentTypeValues.APPLICATION_JSON;
+
+    if (!headers[CONTENT_TYPE_HEADER]) {
+      headers[CONTENT_TYPE_HEADER] = ContentTypeValues.APPLICATION_JSON;
     }
   }
 }

--- a/packages/fetcher/test/requestBodyInterceptor.test.ts
+++ b/packages/fetcher/test/requestBodyInterceptor.test.ts
@@ -13,9 +13,10 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  CONTENT_TYPE_HEADER,
   ContentTypeValues,
   Fetcher,
-  FetchExchange,
+  FetchExchange, FetchRequest,
   REQUEST_BODY_INTERCEPTOR_NAME,
   REQUEST_BODY_INTERCEPTOR_ORDER,
   RequestBodyInterceptor,
@@ -104,6 +105,23 @@ describe('RequestBodyInterceptor', () => {
     interceptor.intercept(exchange);
 
     expect(exchange.request.body).toBe(requestBody);
+  });
+
+  it('should request when body is FormData and delete Content-Type', () => {
+    const interceptor = new RequestBodyInterceptor();
+    const requestBody = new FormData();
+    requestBody.append('key', 'value');
+    const request: FetchRequest = {
+      url: '/test', body: requestBody, headers: {
+        [CONTENT_TYPE_HEADER]: ContentTypeValues.APPLICATION_JSON,
+      },
+    };
+    const exchange = new FetchExchange({ fetcher: mockFetcher, request });
+
+    interceptor.intercept(exchange);
+
+    expect(exchange.request.body).toBe(requestBody);
+    expect(exchange.ensureRequestHeaders()[CONTENT_TYPE_HEADER]).toBeUndefined();
   });
 
   it('should convert plain object to JSON string and set Content-Type header', () => {


### PR DESCRIPTION
- Remove 'Content-Type' from DEFAULT_HEADERS constant
- This change simplifies the default request headers configuration