### PR TITLE
feat(openapi): add 'null' to SchemaType and make certain fields optional

### DIFF
--- a/packages/openapi/src/base-types.ts
+++ b/packages/openapi/src/base-types.ts
@@ -32,7 +32,7 @@ export type ParameterLocation = 'query' | 'header' | 'path' | 'cookie';
 /**
  * Primitive data types supported by JSON Schema
  */
-export type SchemaType = 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object';
+export type SchemaType = 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object' | 'null';
 
 /**
  * Additional external documentation

--- a/packages/openapi/src/info.ts
+++ b/packages/openapi/src/info.ts
@@ -50,10 +50,10 @@ export interface License {
  * @property version - The version of the OpenAPI document
  */
 export interface Info {
-  title: string;
+  title?: string;
   description?: string;
   termsOfService?: string;
   contact?: Contact;
   license?: License;
-  version: string;
+  version?: string;
 }

--- a/packages/openapi/src/responses.ts
+++ b/packages/openapi/src/responses.ts
@@ -51,7 +51,7 @@ export interface Link {
  * @property links - A map of operations links that can be followed from the response
  */
 export interface Response {
-  description: string;
+  description?: string;
   headers?: Record<string, Header | Reference>;
   content?: Record<string, MediaType>;
   links?: Record<string, Link | Reference>;

--- a/packages/openapi/src/schema.ts
+++ b/packages/openapi/src/schema.ts
@@ -49,6 +49,7 @@ export interface XML {
 /**
  * The Schema Object allows the definition of input and output data types
  *
+ * @property $schema - The URI of the JSON Schema dialect used for validation
  * @property title - The title of the schema
  * @property description - A description of the schema
  * @property type - The data type of the schema
@@ -58,6 +59,8 @@ export interface XML {
  * @property writeOnly - Relevant only for Schema "properties" definitions
  * @property deprecated - Specifies that a schema is deprecated
  * @property example - A free-form property to include an example of an instance for this schema
+ * @property const - A value that the schema must exactly match
+ * @property default - The default value for this schema
  * @property minimum - The minimum value of the range (for numeric types)
  * @property maximum - The maximum value of the range (for numeric types)
  * @property exclusiveMinimum - Whether the minimum value is excluded from the range
@@ -85,16 +88,19 @@ export interface XML {
  * @property externalDocs - Additional external documentation for this schema
  */
 export interface Schema {
+  $schema?: string;
   // General properties
   title?: string;
   description?: string;
-  type?: SchemaType;
+  type?: SchemaType | SchemaType[];
   format?: string;
   nullable?: boolean;
   readOnly?: boolean;
   writeOnly?: boolean;
   deprecated?: boolean;
   example?: any;
+  const?: any;
+  default?: any;
 
   // Numeric constraints
   minimum?: number;

--- a/packages/openapi/test/index.test.ts
+++ b/packages/openapi/test/index.test.ts
@@ -12,6 +12,8422 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { OpenAPI } from '../src';
+
+
+const openAPI: OpenAPI = {
+  'openapi': '3.1.0',
+  'info': {
+    'title': 'example-service',
+    'description': 'Wow Example Context',
+  },
+  'servers': [
+    {
+      'url': 'http://localhost:8080',
+      'description': 'Generated server url',
+    },
+  ],
+  'tags': [
+    {
+      'name': 'Actuator',
+      'description': 'Monitor and interact',
+      'externalDocs': {
+        'description': 'Spring Boot Actuator Web API Documentation',
+        'url': 'https://docs.spring.io/spring-boot/docs/current/actuator-api/html/',
+      },
+    },
+    {
+      'name': 'wow',
+      'description': 'Wow framework internal interface',
+    },
+    {
+      'name': 'example.order',
+    },
+    {
+      'name': 'example.cart',
+    },
+    {
+      'name': 'customer',
+    },
+  ],
+  'paths': {
+    '/command-proxy': {
+      'post': {
+        'tags': [
+          'command-proxy-controller',
+        ],
+        'operationId': 'send',
+        'requestBody': {
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/wow.apiclient.CommandRequest',
+              },
+            },
+          },
+          'required': true,
+        },
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              '*/*': {
+                'schema': {
+                  '$ref': '#/components/schemas/wow.command.CommandResult',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/{userId}/customize-send-cmd': {
+      'post': {
+        'tags': [
+          'cart-controller',
+        ],
+        'description': '自定义发送命令',
+        'operationId': 'customizeSendCmd',
+        'parameters': [
+          {
+            'name': 'userId',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              '*/*': {
+                'schema': {
+                  '$ref': '#/components/schemas/wow.command.CommandResult',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/{userId}/add-cart-item': {
+      'post': {
+        'tags': [
+          'cart-controller',
+        ],
+        'operationId': 'addCartItem',
+        'parameters': [
+          {
+            'name': 'userId',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'text/event-stream': {
+                'schema': {
+                  '$ref': '#/components/schemas/wow.command.CommandResultArray',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/order/{tenantId}/{orderId}': {
+      'get': {
+        'tags': [
+          'order-query-controller',
+        ],
+        'operationId': 'onQuery',
+        'parameters': [
+          {
+            'name': 'tenantId',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+          {
+            'name': 'orderId',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              '*/*': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderState',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/me': {
+      'get': {
+        'tags': [
+          'cart-controller',
+        ],
+        'operationId': 'me',
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              '*/*': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.cart.CartData',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/me/sync': {
+      'get': {
+        'tags': [
+          'cart-controller',
+        ],
+        'operationId': 'meSync',
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              '*/*': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.cart.CartData',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/actuator/health/{path}': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'health-path\'',
+        'operationId': 'health',
+        'parameters': [
+          {
+            'name': 'path',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'array',
+              'items': {
+                'type': 'string',
+              },
+            },
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+            },
+          },
+          '404': {
+            'description': 'Not Found',
+          },
+        },
+      },
+    },
+    '/actuator/health': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'health\'',
+        'operationId': 'health_1',
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/actuator/cosidStringGenerator/{name}': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'cosidStringGenerator-name\'',
+        'operationId': 'generateAsString',
+        'parameters': [
+          {
+            'name': 'name',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+            },
+          },
+          '404': {
+            'description': 'Not Found',
+          },
+        },
+      },
+    },
+    '/actuator/cosidStringGenerator': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'cosidStringGenerator\'',
+        'operationId': 'shareGenerateAsString',
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/actuator/cosidGenerator/{name}': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'cosidGenerator-name\'',
+        'operationId': 'generate',
+        'parameters': [
+          {
+            'name': 'name',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+            },
+          },
+          '404': {
+            'description': 'Not Found',
+          },
+        },
+      },
+    },
+    '/actuator/cosidGenerator': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'cosidGenerator\'',
+        'operationId': 'shareGenerate',
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/actuator/cosid/{name}': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'cosid-name\'',
+        'operationId': 'getStat',
+        'parameters': [
+          {
+            'name': 'name',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+            },
+          },
+          '404': {
+            'description': 'Not Found',
+          },
+        },
+      },
+      'delete': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'cosid-name\'',
+        'operationId': 'remove',
+        'parameters': [
+          {
+            'name': 'name',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+        ],
+        'responses': {
+          '204': {
+            'description': 'No Content',
+          },
+          '404': {
+            'description': 'Not Found',
+          },
+        },
+      },
+    },
+    '/actuator/cosid': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator web endpoint \'cosid\'',
+        'operationId': 'stat',
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/actuator': {
+      'get': {
+        'tags': [
+          'Actuator',
+        ],
+        'summary': 'Actuator root web endpoint',
+        'operationId': 'links',
+        'responses': {
+          '200': {
+            'description': 'OK',
+            'content': {
+              'application/vnd.spring-boot.actuator.v3+json': {
+                'schema': {
+                  'type': 'object',
+                  'additionalProperties': {
+                    '$ref': '#/components/schemas/example.StringLinkMap',
+                  },
+                },
+              },
+              'application/vnd.spring-boot.actuator.v2+json': {
+                'schema': {
+                  'type': 'object',
+                  'additionalProperties': {
+                    '$ref': '#/components/schemas/example.StringLinkMap',
+                  },
+                },
+              },
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                  'additionalProperties': {
+                    '$ref': '#/components/schemas/example.StringLinkMap',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/wow/command/wait': {
+      'summary': 'The receiving endpoint of the wait signal',
+      'description': '',
+      'post': {
+        'tags': [
+          'wow',
+        ],
+        'summary': 'The receiving endpoint of the wait signal',
+        'description': '',
+        'operationId': 'wow.command.wait',
+        'parameters': [],
+        'requestBody': {
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/wow.command.SimpleWaitSignal',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            'description': 'Ok',
+            'content': {},
+          },
+        },
+      },
+    },
+    '/wow/command/send': {
+      'summary': 'Unified Sending Endpoint For Command Messages',
+      'description': '',
+      'post': {
+        'tags': [
+          'wow',
+        ],
+        'summary': 'Unified Sending Endpoint For Command Messages',
+        'description': '',
+        'operationId': 'wow.command.send',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.Command-Type',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Tenant-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Owner-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Name',
+          },
+        ],
+        'requestBody': {
+          'description': 'Command Message Body',
+          'content': {
+            'application/json': {
+              'schema': {
+                'type': 'object',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/wow/metadata': {
+      'summary': 'Get Wow Metadata',
+      'description': '',
+      'get': {
+        'tags': [
+          'wow',
+        ],
+        'summary': 'Get Wow Metadata',
+        'description': '',
+        'operationId': 'wow.metadata.get',
+        'parameters': [],
+        'responses': {
+          '200': {
+            'description': 'The Wow Metadata.',
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/wow.configuration.WowMetadata',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/wow/id/global': {
+      'summary': 'Generate Global ID',
+      'description': '',
+      'get': {
+        'tags': [
+          'wow',
+        ],
+        'summary': 'Generate Global ID',
+        'description': '',
+        'operationId': 'wow.global_id.generate',
+        'parameters': [],
+        'responses': {
+          '200': {
+            'description': 'The generated global ID',
+            'content': {
+              'text/plain': {
+                'schema': {
+                  'type': 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/wow/bi/script': {
+      'summary': 'Generate BI Sync Script',
+      'description': '',
+      'get': {
+        'tags': [
+          'wow',
+        ],
+        'summary': 'Generate BI Sync Script',
+        'description': '',
+        'operationId': 'wow.bi_script.generate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.Wow-BI-Header-Sql-Type',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'The generated BI synchronization script.',
+            'content': {
+              'application/sql': {
+                'schema': {
+                  'type': 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}/address': {
+      'summary': '修改收货地址',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': '修改收货地址',
+        'description': '',
+        'operationId': 'example.order.change_address',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': '修改收货地址',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.order.ChangeAddress',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order': {
+      'summary': '下单',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': '下单',
+        'description': '',
+        'operationId': 'example.order.create_order',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': '下单',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.order.CreateOrder',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/{id}/pay': {
+      'summary': 'pay_order',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'pay_order',
+        'description': '',
+        'operationId': 'example.order.pay_order',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': 'pay_order',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.order.PayOrder',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/{id}/package': {
+      'summary': '发货',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': '发货',
+        'description': '',
+        'operationId': 'example.order.ship_order',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': '发货',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.order.ShipOrder',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}/package': {
+      'summary': '收货',
+      'description': '',
+      'patch': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': '收货',
+        'description': '',
+        'operationId': 'example.order.receipt_order',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': '收货',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.order.ReceiptOrder',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}': {
+      'summary': 'Delete aggregate',
+      'description': '',
+      'delete': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Delete aggregate',
+        'description': '',
+        'operationId': 'example.order.default_delete_aggregate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': 'Delete aggregate',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/wow.api.command.DefaultDeleteAggregate',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}/recover': {
+      'summary': 'Recover deleted aggregate',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Recover deleted aggregate',
+        'description': '',
+        'operationId': 'example.order.default_recover_aggregate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': 'Recover deleted aggregate',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/wow.api.command.DefaultRecoverAggregate',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/{id}/state/tracing': {
+      'summary': 'Get Aggregate Tracing',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Get Aggregate Tracing',
+        'description': '',
+        'operationId': 'example.order.tenant.aggregate_tracing.get',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'Get Aggregate Tracing',
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateStateEvent',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}/state': {
+      'summary': 'Load State Aggregate',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Load State Aggregate',
+        'description': '',
+        'operationId': 'example.order.tenant.aggregate.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'Load State Aggregate',
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderState',
+                },
+              },
+            },
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.BadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}/state/{version}': {
+      'summary': 'Load Versioned State Aggregate',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Load Versioned State Aggregate',
+        'description': '',
+        'operationId': 'example.order.tenant.versioned_aggregate.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.version',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'Load Versioned State Aggregate',
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderState',
+                },
+              },
+            },
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.BadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}/state/time/{createTime}': {
+      'summary': 'Load Time Based State Aggregate',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Load Time Based State Aggregate',
+        'description': '',
+        'operationId': 'example.order.tenant.time_based_aggregate.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.createTime',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'Load Time Based State Aggregate',
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderState',
+                },
+              },
+            },
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.BadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}/snapshot': {
+      'summary': 'Get Snapshot',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Get Snapshot',
+        'description': '',
+        'operationId': 'example.order.tenant.owner.snapshot.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+        ],
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStateSnapshot',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/{id}/snapshot': {
+      'summary': 'Regenerate Aggregate Snapshot',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Regenerate Aggregate Snapshot',
+        'description': '',
+        'operationId': 'example.order.tenant.snapshot.regenerate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+        ],
+        'responses': {
+          '200': {},
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/sales-order/snapshot/{afterId}/{limit}': {
+      'summary': 'Batch Regenerate Aggregate Snapshot',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Batch Regenerate Aggregate Snapshot',
+        'description': '',
+        'operationId': 'example.order.snapshot.batch_regenerate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.afterId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.limit',
+          },
+        ],
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.BatchResult',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+        },
+      },
+    },
+    '/sales-order/snapshot/count': {
+      'summary': 'Count Snapshot',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Count Snapshot',
+        'description': '',
+        'operationId': 'example.order.snapshot.count',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.TooManyRequests',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/snapshot/count': {
+      'summary': 'Count Snapshot Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Count Snapshot Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.snapshot.count',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.TooManyRequests',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/snapshot/count': {
+      'summary': 'Count Snapshot Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Count Snapshot Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.snapshot.count',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.TooManyRequests',
+          },
+        },
+      },
+    },
+    '/sales-order/snapshot/list': {
+      'summary': 'List Query Snapshot',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Snapshot',
+        'description': '',
+        'operationId': 'example.order.snapshot.list_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshot',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshotServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/snapshot/list': {
+      'summary': 'List Query Snapshot Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Snapshot Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.snapshot.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshot',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshotServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/snapshot/list': {
+      'summary': 'List Query Snapshot Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Snapshot Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.snapshot.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshot',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshotServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/sales-order/snapshot/list/state': {
+      'summary': 'List Query Snapshot State',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Snapshot State',
+        'description': '',
+        'operationId': 'example.order.snapshot_state.list_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderState',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/snapshot/list/state': {
+      'summary': 'List Query Snapshot State Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Snapshot State Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.snapshot_state.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderState',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/snapshot/list/state': {
+      'summary': 'List Query Snapshot State Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Snapshot State Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.snapshot_state.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderState',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.WowExampleOrderStateServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/sales-order/snapshot/paged': {
+      'summary': 'Paged Query Snapshot',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Snapshot',
+        'description': '',
+        'operationId': 'example.order.snapshot.paged_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshotPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/snapshot/paged': {
+      'summary': 'Paged Query Snapshot Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Snapshot Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.snapshot.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshotPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/snapshot/paged': {
+      'summary': 'Paged Query Snapshot Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Snapshot Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.snapshot.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshotPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/sales-order/snapshot/paged/state': {
+      'summary': 'Paged Query Snapshot State',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Snapshot State',
+        'description': '',
+        'operationId': 'example.order.snapshot_state.paged_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStatePagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/snapshot/paged/state': {
+      'summary': 'Paged Query Snapshot State Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Snapshot State Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.snapshot_state.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStatePagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/snapshot/paged/state': {
+      'summary': 'Paged Query Snapshot State Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Snapshot State Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.snapshot_state.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStatePagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/sales-order/snapshot/single': {
+      'summary': 'Single Snapshot',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Single Snapshot',
+        'description': '',
+        'operationId': 'example.order.snapshot.single',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshot',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/snapshot/single': {
+      'summary': 'Single Snapshot Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Single Snapshot Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.snapshot.single',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshot',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/snapshot/single': {
+      'summary': 'Single Snapshot Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Single Snapshot Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.snapshot.single',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshot',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/sales-order/snapshot/single/state': {
+      'summary': 'Single Snapshot State',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Single Snapshot State',
+        'description': '',
+        'operationId': 'example.order.snapshot_state.single',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderState',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/snapshot/single/state': {
+      'summary': 'Single Snapshot State Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Single Snapshot State Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.snapshot_state.single',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderState',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/snapshot/single/state': {
+      'summary': 'Single Snapshot State Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Single Snapshot State Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.snapshot_state.single',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.order.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.WowExampleOrderState',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/{id}/event/{headVersion}/{tailVersion}': {
+      'summary': 'Load Event Stream',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Load Event Stream',
+        'description': '',
+        'operationId': 'example.order.tenant.event_stream.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.headVersion',
+          },
+          {
+            '$ref': '#/components/parameters/wow.tailVersion',
+          },
+        ],
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStream',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStreamServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/sales-order/event/list': {
+      'summary': 'List Query Event Stream',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Event Stream',
+        'description': '',
+        'operationId': 'example.order.event.list_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStream',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStreamServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/event/list': {
+      'summary': 'List Query Event Stream Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Event Stream Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.event.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStream',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStreamServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/event/list': {
+      'summary': 'List Query Event Stream Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'List Query Event Stream Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.event.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStream',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStreamServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/sales-order/event/paged': {
+      'summary': 'Paged Query Event Stream',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Event Stream',
+        'description': '',
+        'operationId': 'example.order.event.paged_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStreamPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/event/paged': {
+      'summary': 'Paged Query Event Stream Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Event Stream Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.event.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStreamPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/event/paged': {
+      'summary': 'Paged Query Event Stream Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Paged Query Event Stream Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.event.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStreamPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/sales-order/event/count': {
+      'summary': 'Count Event Stream',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Count Event Stream',
+        'description': '',
+        'operationId': 'example.order.event.count',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/event/count': {
+      'summary': 'Count Event Stream Within Tenant',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Count Event Stream Within Tenant',
+        'description': '',
+        'operationId': 'example.order.tenant.event.count',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/sales-order/event/count': {
+      'summary': 'Count Event Stream Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Count Event Stream Within Owner',
+        'description': '',
+        'operationId': 'example.order.owner.event.count',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/sales-order/{id}/{version}/compensate': {
+      'summary': 'Event Compensate',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Event Compensate',
+        'description': '',
+        'operationId': 'example.order.tenant.compensate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.version',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.CompensationTarget',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CompensationTarget',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.BadRequest',
+          },
+        },
+      },
+    },
+    '/sales-order/state/{afterId}/{limit}': {
+      'summary': 'Resend State Event',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.order',
+        ],
+        'summary': 'Resend State Event',
+        'description': '',
+        'operationId': 'example.order.state_event.resend',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.afterId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.limit',
+          },
+        ],
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.BatchResult',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/view_cart': {
+      'summary': 'view_cart',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'view_cart',
+        'description': '',
+        'operationId': 'example.cart.view_cart',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': 'view_cart',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.cart.ViewCart',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/add_cart_item': {
+      'summary': '加入购物车',
+      'description': '加入购物车',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': '加入购物车',
+        'description': '加入购物车',
+        'operationId': 'example.cart.add_cart_item',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': '加入购物车',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.cart.AddCartItem',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/change_quantity': {
+      'summary': '变更购买数量',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': '变更购买数量',
+        'description': '',
+        'operationId': 'example.cart.change_quantity',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': '变更购买数量',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.cart.ChangeQuantity',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/remove_cart_item': {
+      'summary': '删除商品',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': '删除商品',
+        'description': '',
+        'operationId': 'example.cart.remove_cart_item',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': '删除商品',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.cart.RemoveCartItem',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/mounted_command': {
+      'summary': '挂载的命令',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': '挂载的命令',
+        'description': '',
+        'operationId': 'example.cart.mounted_command',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': '挂载的命令',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.cart.MountedCommand',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/tenant/{tenantId}/owner/{ownerId}/cart/{id}/{customerId}/{enum}': {
+      'summary': 'mock_variable_command',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'mock_variable_command',
+        'description': '',
+        'operationId': 'example.cart.mock_variable_command',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.tenantId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            'name': 'customerId',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'integer',
+              'format': 'int32',
+            },
+          },
+          {
+            'name': 'enum',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              '$ref': '#/components/schemas/example.cart.MockVariableCommand.MockEnum',
+            },
+          },
+          {
+            'name': 'id',
+            'in': 'path',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+          {
+            'name': 'headerEnumParameter',
+            'in': 'header',
+            'required': true,
+            'schema': {
+              '$ref': '#/components/schemas/example.cart.MockVariableCommand.MockEnum',
+            },
+          },
+          {
+            'name': 'headerParameter',
+            'in': 'header',
+            'required': true,
+            'schema': {
+              'type': 'string',
+            },
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': 'mock_variable_command',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/example.cart.MockVariableCommand',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart': {
+      'summary': 'Delete aggregate',
+      'description': '',
+      'delete': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Delete aggregate',
+        'description': '',
+        'operationId': 'example.cart.default_delete_aggregate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': 'Delete aggregate',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/wow.api.command.DefaultDeleteAggregate',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/recover': {
+      'summary': 'Recover deleted aggregate',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Recover deleted aggregate',
+        'description': '',
+        'operationId': 'example.cart.default_recover_aggregate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Timout',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Stage',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Context',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Processor',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Wait-Tail-Function',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Aggregate-Version',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Request-Id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Command-Local-First',
+          },
+          {
+            '$ref': '#/components/parameters/wow.Accept',
+          },
+        ],
+        'requestBody': {
+          'description': 'Recover deleted aggregate',
+          'content': {
+            'application/json': {
+              'schema': {
+                '$ref': '#/components/schemas/wow.api.command.DefaultRecoverAggregate',
+              },
+            },
+          },
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CommandOk',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.CommandBadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.CommandNotFound',
+          },
+          '409': {
+            '$ref': '#/components/responses/wow.CommandVersionConflict',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.CommandTooManyRequests',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.CommandRequestTimeout',
+          },
+          '410': {
+            '$ref': '#/components/responses/wow.CommandIllegalAccessDeletedAggregate',
+          },
+        },
+      },
+    },
+    '/cart/{id}/state/tracing': {
+      'summary': 'Get Aggregate Tracing',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Get Aggregate Tracing',
+        'description': '',
+        'operationId': 'example.cart.aggregate_tracing.get',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'Get Aggregate Tracing',
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartStateStateEvent',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/state': {
+      'summary': 'Load State Aggregate',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Load State Aggregate',
+        'description': '',
+        'operationId': 'example.cart.aggregate.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'Load State Aggregate',
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartState',
+                },
+              },
+            },
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.BadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/state/{version}': {
+      'summary': 'Load Versioned State Aggregate',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Load Versioned State Aggregate',
+        'description': '',
+        'operationId': 'example.cart.versioned_aggregate.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.version',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'Load Versioned State Aggregate',
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartState',
+                },
+              },
+            },
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.BadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/state/time/{createTime}': {
+      'summary': 'Load Time Based State Aggregate',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Load Time Based State Aggregate',
+        'description': '',
+        'operationId': 'example.cart.time_based_aggregate.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.createTime',
+          },
+        ],
+        'responses': {
+          '200': {
+            'description': 'Load Time Based State Aggregate',
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartState',
+                },
+              },
+            },
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.BadRequest',
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/snapshot': {
+      'summary': 'Get Snapshot',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Get Snapshot',
+        'description': '',
+        'operationId': 'example.cart.owner.snapshot.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartStateSnapshot',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/cart/{id}/snapshot': {
+      'summary': 'Regenerate Aggregate Snapshot',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Regenerate Aggregate Snapshot',
+        'description': '',
+        'operationId': 'example.cart.snapshot.regenerate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+        ],
+        'responses': {
+          '200': {},
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/cart/snapshot/{afterId}/{limit}': {
+      'summary': 'Batch Regenerate Aggregate Snapshot',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Batch Regenerate Aggregate Snapshot',
+        'description': '',
+        'operationId': 'example.cart.snapshot.batch_regenerate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.afterId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.limit',
+          },
+        ],
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.BatchResult',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+        },
+      },
+    },
+    '/cart/snapshot/count': {
+      'summary': 'Count Snapshot',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Count Snapshot',
+        'description': '',
+        'operationId': 'example.cart.snapshot.count',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.TooManyRequests',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/snapshot/count': {
+      'summary': 'Count Snapshot Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Count Snapshot Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.snapshot.count',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+          '429': {
+            '$ref': '#/components/responses/wow.TooManyRequests',
+          },
+        },
+      },
+    },
+    '/cart/snapshot/list': {
+      'summary': 'List Query Snapshot',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'List Query Snapshot',
+        'description': '',
+        'operationId': 'example.cart.snapshot.list_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartStateMaterializedSnapshot',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartStateMaterializedSnapshotServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/snapshot/list': {
+      'summary': 'List Query Snapshot Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'List Query Snapshot Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.snapshot.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartStateMaterializedSnapshot',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartStateMaterializedSnapshotServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/snapshot/list/state': {
+      'summary': 'List Query Snapshot State',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'List Query Snapshot State',
+        'description': '',
+        'operationId': 'example.cart.snapshot_state.list_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartState',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartStateServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/snapshot/list/state': {
+      'summary': 'List Query Snapshot State Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'List Query Snapshot State Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.snapshot_state.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartState',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartStateServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/snapshot/paged': {
+      'summary': 'Paged Query Snapshot',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Paged Query Snapshot',
+        'description': '',
+        'operationId': 'example.cart.snapshot.paged_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartStateMaterializedSnapshotPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/snapshot/paged': {
+      'summary': 'Paged Query Snapshot Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Paged Query Snapshot Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.snapshot.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartStateMaterializedSnapshotPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/snapshot/paged/state': {
+      'summary': 'Paged Query Snapshot State',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Paged Query Snapshot State',
+        'description': '',
+        'operationId': 'example.cart.snapshot_state.paged_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartStatePagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/snapshot/paged/state': {
+      'summary': 'Paged Query Snapshot State Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Paged Query Snapshot State Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.snapshot_state.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartStatePagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/snapshot/single': {
+      'summary': 'Single Snapshot',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Single Snapshot',
+        'description': '',
+        'operationId': 'example.cart.snapshot.single',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartStateMaterializedSnapshot',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/snapshot/single': {
+      'summary': 'Single Snapshot Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Single Snapshot Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.snapshot.single',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartStateMaterializedSnapshot',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/cart/snapshot/single/state': {
+      'summary': 'Single Snapshot State',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Single Snapshot State',
+        'description': '',
+        'operationId': 'example.cart.snapshot_state.single',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartState',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/snapshot/single/state': {
+      'summary': 'Single Snapshot State Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Single Snapshot State Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.snapshot_state.single',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/example.cart.SingleQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartState',
+                },
+              },
+            },
+          },
+          '404': {
+            '$ref': '#/components/responses/wow.NotFound',
+          },
+        },
+      },
+    },
+    '/cart/{id}/event/{headVersion}/{tailVersion}': {
+      'summary': 'Load Event Stream',
+      'description': '',
+      'get': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Load Event Stream',
+        'description': '',
+        'operationId': 'example.cart.event_stream.load',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.headVersion',
+          },
+          {
+            '$ref': '#/components/parameters/wow.tailVersion',
+          },
+        ],
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartAggregatedDomainEventStream',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartAggregatedDomainEventStreamServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/event/list': {
+      'summary': 'List Query Event Stream',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'List Query Event Stream',
+        'description': '',
+        'operationId': 'example.cart.event.list_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartAggregatedDomainEventStream',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartAggregatedDomainEventStreamServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/event/list': {
+      'summary': 'List Query Event Stream Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'List Query Event Stream Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.event.list_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.ListQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartAggregatedDomainEventStream',
+                  },
+                },
+              },
+              'text/event-stream': {
+                'schema': {
+                  'type': 'array',
+                  'items': {
+                    '$ref': '#/components/schemas/example.CartAggregatedDomainEventStreamServerSentEventNonNullData',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/event/paged': {
+      'summary': 'Paged Query Event Stream',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Paged Query Event Stream',
+        'description': '',
+        'operationId': 'example.cart.event.paged_query',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartAggregatedDomainEventStreamPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/event/paged': {
+      'summary': 'Paged Query Event Stream Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Paged Query Event Stream Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.event.paged_query',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.PagedQuery',
+        },
+        'responses': {
+          '200': {
+            'headers': {
+              'Wow-Error-Code': {
+                '$ref': '#/components/headers/wow.Wow-Error-Code',
+              },
+            },
+            'content': {
+              'application/json': {
+                'schema': {
+                  '$ref': '#/components/schemas/example.CartAggregatedDomainEventStreamPagedList',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/cart/event/count': {
+      'summary': 'Count Event Stream',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Count Event Stream',
+        'description': '',
+        'operationId': 'example.cart.event.count',
+        'parameters': [],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+        },
+      },
+    },
+    '/owner/{ownerId}/cart/event/count': {
+      'summary': 'Count Event Stream Within Owner',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Count Event Stream Within Owner',
+        'description': '',
+        'operationId': 'example.cart.owner.event.count',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.ownerId',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.CountQuery',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CountQuery',
+          },
+        },
+      },
+    },
+    '/cart/{id}/{version}/compensate': {
+      'summary': 'Event Compensate',
+      'description': '',
+      'put': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Event Compensate',
+        'description': '',
+        'operationId': 'example.cart.compensate',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.id',
+          },
+          {
+            '$ref': '#/components/parameters/wow.version',
+          },
+        ],
+        'requestBody': {
+          '$ref': '#/components/requestBodies/wow.CompensationTarget',
+        },
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.CompensationTarget',
+          },
+          '400': {
+            '$ref': '#/components/responses/wow.BadRequest',
+          },
+        },
+      },
+    },
+    '/cart/state/{afterId}/{limit}': {
+      'summary': 'Resend State Event',
+      'description': '',
+      'post': {
+        'tags': [
+          'example.cart',
+          'customer',
+        ],
+        'summary': 'Resend State Event',
+        'description': '',
+        'operationId': 'example.cart.state_event.resend',
+        'parameters': [
+          {
+            '$ref': '#/components/parameters/wow.afterId',
+          },
+          {
+            '$ref': '#/components/parameters/wow.limit',
+          },
+        ],
+        'responses': {
+          '200': {
+            '$ref': '#/components/responses/wow.BatchResult',
+          },
+          '408': {
+            '$ref': '#/components/responses/wow.RequestTimeout',
+          },
+        },
+      },
+    },
+  },
+  'components': {
+    'schemas': {
+      'wow.apiclient.CommandRequest': {
+        'type': 'object',
+        'properties': {
+          'aggregate': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'aggregateId': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'aggregateVersion': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+          'body': {},
+          'context': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'localFirst': {
+            'type': [
+              'boolean',
+              'null',
+            ],
+          },
+          'ownerId': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'requestId': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'serviceUri': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'tenantId': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'type': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'waitStrategy': {
+            '$ref': '#/components/schemas/wow.apiclient.CommandRequest.WaitStrategy',
+          },
+        },
+        'required': [
+          'body',
+        ],
+      },
+      'wow.command.CommandResult': {
+        'type': 'object',
+        'properties': {
+          'aggregateId': {
+            'type': 'string',
+          },
+          'aggregateName': {
+            'type': 'string',
+          },
+          'aggregateVersion': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+          'bindingErrors': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.BindingError',
+            },
+          },
+          'commandId': {
+            'type': 'string',
+          },
+          'contextName': {
+            'type': 'string',
+          },
+          'errorCode': {
+            'type': 'string',
+          },
+          'errorMsg': {
+            'type': 'string',
+          },
+          'function': {
+            '$ref': '#/components/schemas/wow.api.messaging.FunctionInfoData',
+          },
+          'id': {
+            'type': 'string',
+          },
+          'requestId': {
+            'type': 'string',
+          },
+          'result': {
+            '$ref': '#/components/schemas/example.StringObjectMap',
+          },
+          'signalTime': {
+            'type': 'integer',
+            'format': 'int64',
+          },
+          'stage': {
+            '$ref': '#/components/schemas/wow.command.CommandStage',
+          },
+          'tenantId': {
+            'type': 'string',
+          },
+          'waitCommandId': {
+            'type': 'string',
+          },
+          'succeeded': {
+            'type': 'boolean',
+            'readOnly': true,
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'commandId',
+          'contextName',
+          'function',
+          'id',
+          'requestId',
+          'stage',
+          'tenantId',
+          'waitCommandId',
+        ],
+      },
+      'wow.command.CommandResultArray': {
+        'type': 'array',
+        'items': {
+          '$ref': '#/components/schemas/wow.command.CommandResult',
+        },
+      },
+      'example.WowExampleOrderState': {
+        'type': 'object',
+        'properties': {
+          'address': {
+            '$ref': '#/components/schemas/example.order.ShippingAddress',
+            'readOnly': true,
+          },
+          'id': {
+            'type': 'string',
+          },
+          'items': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.order.OrderItem',
+              'readOnly': true,
+            },
+            'readOnly': true,
+          },
+          'paidAmount': {
+            'type': 'number',
+          },
+          'status': {
+            '$ref': '#/components/schemas/example.OrderStatus',
+          },
+          'totalAmount': {
+            'type': 'number',
+          },
+          'payable': {
+            'type': 'number',
+            'readOnly': true,
+          },
+        },
+        'required': [
+          'id',
+        ],
+      },
+      'example.cart.CartData': {
+        'type': 'object',
+        'properties': {
+          'items': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.cart.CartItem',
+            },
+          },
+        },
+        'required': [
+          'items',
+        ],
+      },
+      'example.ApiVersion': {
+        'type': 'string',
+        'enum': [
+          'V2',
+          'V3',
+        ],
+      },
+      'example.CartAggregatedCondition': {
+        'type': 'object',
+        'properties': {
+          'children': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/example.CartAggregatedCondition',
+            },
+          },
+          'field': {
+            '$ref': '#/components/schemas/example.CartAggregatedFields',
+          },
+          'operator': {
+            '$ref': '#/components/schemas/wow.api.query.Operator',
+            'default': 'ALL',
+          },
+          'options': {
+            '$ref': '#/components/schemas/example.StringObjectMap',
+            'default': '{}',
+          },
+          'value': {},
+        },
+      },
+      'example.CartAggregatedDomainEventStream': {
+        'type': 'object',
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'The ID of the domain event stream.',
+            'minLength': 1,
+          },
+          'contextName': {
+            'type': 'string',
+            'description': 'The name of the context to which the domain event stream belongs',
+            'minLength': 1,
+          },
+          'aggregateName': {
+            'type': 'string',
+            'description': 'The name of the aggregate to which the domain event stream belongs',
+            'minLength': 1,
+          },
+          'header': {
+            'type': 'object',
+            'additionalProperties': true,
+            'description': 'message header',
+            'properties': {
+              'user_agent': {
+                'type': 'string',
+                'description': 'user agent',
+              },
+              'remote_ip': {
+                'type': 'string',
+                'description': 'remote ip',
+              },
+              'trace_id': {
+                'type': 'string',
+                'description': 'trace id',
+              },
+              'command_operator': {
+                'type': 'string',
+                'description': 'command operator',
+              },
+              'local_first': {
+                'type': 'boolean',
+                'description': 'local first',
+              },
+              'command_wait_endpoint': {
+                'type': 'string',
+                'format': 'url',
+                'description': 'command wait endpoint',
+              },
+              'command_wait_stage': {
+                'type': 'string',
+                'default': 'PROCESSED',
+                'enum': [
+                  'SENT',
+                  'PROCESSED',
+                  'SNAPSHOT',
+                  'PROJECTED',
+                  'EVENT_HANDLED',
+                  'SAGA_HANDLED',
+                ],
+              },
+            },
+          },
+          'tenantId': {
+            'type': 'string',
+            'description': 'The tenant id of the aggregate',
+            'minLength': 1,
+          },
+          'aggregateId': {
+            'type': 'string',
+            'description': 'The id of the aggregate',
+            'minLength': 1,
+          },
+          'ownerId': {
+            'type': 'string',
+            'default': '',
+            'description': 'The owner ID of the aggregate resource',
+          },
+          'commandId': {
+            'type': 'string',
+            'description': 'The ID of the command message.',
+            'minLength': 1,
+          },
+          'requestId': {
+            'type': 'string',
+            'description': 'The request ID of the command message, which is used to check the idempotency of the command message',
+            'minLength': 1,
+          },
+          'version': {
+            'type': 'integer',
+            'format': 'int32',
+            'description': 'The version of the domain event stream',
+          },
+          'body': {
+            'type': 'array',
+            'description': 'A list of domain events for the domain event stream',
+            'items': {
+              'anyOf': [
+                {
+                  'type': 'object',
+                  'description': 'The body of the domain event',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The ID of the domain event.',
+                      'minLength': 1,
+                    },
+                    'name': {
+                      'type': 'string',
+                      'const': 'cart_item_added',
+                      'description': 'The name of the domain event',
+                      'minLength': 1,
+                    },
+                    'revision': {
+                      'type': 'string',
+                      'default': '0.0.1',
+                      'description': 'The revision number of the domain event',
+                    },
+                    'bodyType': {
+                      'type': 'string',
+                      'const': 'me.ahoo.wow.example.api.cart.CartItemAdded',
+                      'description': 'The fully qualified name of the domain event body',
+                    },
+                    'body': {
+                      '$ref': '#/components/schemas/example.cart.CartItemAdded',
+                    },
+                  },
+                  'required': [
+                    'body',
+                    'bodyType',
+                    'id',
+                    'name',
+                    'revision',
+                  ],
+                  'title': '商品已加入购物车',
+                },
+                {
+                  'type': 'object',
+                  'description': 'The body of the domain event',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The ID of the domain event.',
+                      'minLength': 1,
+                    },
+                    'name': {
+                      'type': 'string',
+                      'const': 'cart_item_removed',
+                      'description': 'The name of the domain event',
+                      'minLength': 1,
+                    },
+                    'revision': {
+                      'type': 'string',
+                      'default': '0.0.1',
+                      'description': 'The revision number of the domain event',
+                    },
+                    'bodyType': {
+                      'type': 'string',
+                      'const': 'me.ahoo.wow.example.api.cart.CartItemRemoved',
+                      'description': 'The fully qualified name of the domain event body',
+                    },
+                    'body': {
+                      '$ref': '#/components/schemas/example.cart.CartItemRemoved',
+                    },
+                  },
+                  'required': [
+                    'body',
+                    'bodyType',
+                    'id',
+                    'name',
+                    'revision',
+                  ],
+                  'title': 'cart_item_removed',
+                },
+                {
+                  'type': 'object',
+                  'description': 'The body of the domain event',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The ID of the domain event.',
+                      'minLength': 1,
+                    },
+                    'name': {
+                      'type': 'string',
+                      'const': 'cart_quantity_changed',
+                      'description': 'The name of the domain event',
+                      'minLength': 1,
+                    },
+                    'revision': {
+                      'type': 'string',
+                      'default': '0.0.1',
+                      'description': 'The revision number of the domain event',
+                    },
+                    'bodyType': {
+                      'type': 'string',
+                      'const': 'me.ahoo.wow.example.api.cart.CartQuantityChanged',
+                      'description': 'The fully qualified name of the domain event body',
+                    },
+                    'body': {
+                      '$ref': '#/components/schemas/example.cart.CartQuantityChanged',
+                    },
+                  },
+                  'required': [
+                    'body',
+                    'bodyType',
+                    'id',
+                    'name',
+                    'revision',
+                  ],
+                  'title': 'cart_quantity_changed',
+                },
+              ],
+            },
+            'minItems': 1,
+          },
+          'createTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The time when the domain event stream was created',
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'body',
+          'contextName',
+          'createTime',
+          'id',
+          'ownerId',
+          'tenantId',
+          'version',
+        ],
+      },
+      'example.CartAggregatedDomainEventStreamPagedList': {
+        'type': 'object',
+        'properties': {
+          'list': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.CartAggregatedDomainEventStream',
+            },
+          },
+          'total': {
+            'type': 'integer',
+            'format': 'int64',
+          },
+        },
+        'required': [
+          'list',
+          'total',
+        ],
+      },
+      'example.CartAggregatedDomainEventStreamServerSentEventNonNullData': {
+        'type': 'object',
+        'properties': {
+          'data': {
+            '$ref': '#/components/schemas/example.CartAggregatedDomainEventStream',
+          },
+          'event': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'id': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'retry': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'data',
+        ],
+      },
+      'example.CartAggregatedFields': {
+        'type': 'string',
+        'enum': [
+          '',
+          'aggregateId',
+          'tenantId',
+          'ownerId',
+          'version',
+          'eventId',
+          'firstOperator',
+          'operator',
+          'firstEventTime',
+          'eventTime',
+          'deleted',
+          'state',
+          'state.id',
+          'state.items',
+          'state.items.productId',
+          'state.items.quantity',
+        ],
+      },
+      'example.CartAggregatedListQuery': {
+        'type': 'object',
+        'properties': {
+          'condition': {
+            '$ref': '#/components/schemas/example.CartAggregatedCondition',
+          },
+          'limit': {
+            'type': 'integer',
+            'format': 'int32',
+            'default': '10',
+          },
+          'projection': {
+            '$ref': '#/components/schemas/wow.api.query.Projection',
+          },
+          'sort': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Sort',
+            },
+          },
+        },
+        'required': [
+          'condition',
+        ],
+      },
+      'example.CartAggregatedPagedQuery': {
+        'type': 'object',
+        'properties': {
+          'condition': {
+            '$ref': '#/components/schemas/example.CartAggregatedCondition',
+          },
+          'pagination': {
+            '$ref': '#/components/schemas/wow.api.query.Pagination',
+          },
+          'projection': {
+            '$ref': '#/components/schemas/wow.api.query.Projection',
+          },
+          'sort': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Sort',
+            },
+          },
+        },
+        'required': [
+          'condition',
+        ],
+      },
+      'example.CartAggregatedSingleQuery': {
+        'type': 'object',
+        'properties': {
+          'condition': {
+            '$ref': '#/components/schemas/example.CartAggregatedCondition',
+          },
+          'projection': {
+            '$ref': '#/components/schemas/wow.api.query.Projection',
+          },
+          'sort': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Sort',
+            },
+          },
+        },
+        'required': [
+          'condition',
+        ],
+      },
+      'example.CartState': {
+        'type': 'object',
+        'properties': {
+          'id': {
+            'type': 'string',
+          },
+          'items': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.cart.CartItem',
+            },
+          },
+        },
+        'required': [
+          'id',
+        ],
+      },
+      'example.CartStateMaterializedSnapshot': {
+        'type': 'object',
+        'properties': {
+          'aggregateId': {
+            'type': 'string',
+          },
+          'aggregateName': {
+            'type': 'string',
+          },
+          'contextName': {
+            'type': 'string',
+          },
+          'deleted': {
+            'type': 'boolean',
+            'description': 'Whether the aggregate is deleted.',
+          },
+          'eventId': {
+            'type': 'string',
+            'description': 'The event id of the aggregate.',
+          },
+          'eventTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The last event time of the aggregate, represented as a Unix timestamp in milliseconds.',
+          },
+          'firstEventTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The first event time of the aggregate, represented as a Unix timestamp in milliseconds.',
+          },
+          'firstOperator': {
+            'type': 'string',
+            'description': 'The first operator of the aggregate.',
+          },
+          'operator': {
+            'type': 'string',
+            'description': 'The last operator of the aggregate.',
+          },
+          'ownerId': {
+            'type': 'string',
+          },
+          'snapshotTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The snapshot time of the aggregate, represented as a Unix timestamp in milliseconds.',
+          },
+          'state': {
+            '$ref': '#/components/schemas/example.CartState',
+            'description': 'The state of the aggregate.',
+          },
+          'tenantId': {
+            'type': 'string',
+          },
+          'version': {
+            'type': 'integer',
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'contextName',
+          'deleted',
+          'eventId',
+          'eventTime',
+          'firstEventTime',
+          'firstOperator',
+          'operator',
+          'snapshotTime',
+          'state',
+          'tenantId',
+          'version',
+        ],
+      },
+      'example.CartStateMaterializedSnapshotPagedList': {
+        'type': 'object',
+        'properties': {
+          'list': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.CartStateMaterializedSnapshot',
+            },
+          },
+          'total': {
+            'type': 'integer',
+            'format': 'int64',
+          },
+        },
+        'required': [
+          'list',
+          'total',
+        ],
+      },
+      'example.CartStateMaterializedSnapshotServerSentEventNonNullData': {
+        'type': 'object',
+        'properties': {
+          'data': {
+            '$ref': '#/components/schemas/example.CartStateMaterializedSnapshot',
+          },
+          'event': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'id': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'retry': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'data',
+        ],
+      },
+      'example.CartStatePagedList': {
+        'type': 'object',
+        'properties': {
+          'list': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.CartState',
+            },
+          },
+          'total': {
+            'type': 'integer',
+            'format': 'int64',
+          },
+        },
+        'required': [
+          'list',
+          'total',
+        ],
+      },
+      'example.CartStateServerSentEventNonNullData': {
+        'type': 'object',
+        'properties': {
+          'data': {
+            '$ref': '#/components/schemas/example.CartState',
+          },
+          'event': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'id': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'retry': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'data',
+        ],
+      },
+      'example.CartStateSnapshot': {
+        'type': 'object',
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'properties': {
+          'contextName': {
+            'type': 'string',
+            'description': 'The name of the context to which the snapshot belongs',
+            'minLength': 1,
+          },
+          'aggregateName': {
+            'type': 'string',
+            'description': 'The name of the aggregate to which the snapshot belongs',
+            'minLength': 1,
+          },
+          'tenantId': {
+            'type': 'string',
+            'description': 'The tenant id of the aggregate',
+            'minLength': 1,
+          },
+          'aggregateId': {
+            'type': 'string',
+            'description': 'The id of the aggregate',
+            'minLength': 1,
+          },
+          'ownerId': {
+            'type': 'string',
+            'default': '',
+            'description': 'The owner ID of the aggregate resource',
+          },
+          'version': {
+            'type': 'integer',
+            'format': 'int32',
+            'description': 'The version of the snapshot',
+          },
+          'eventId': {
+            'type': 'string',
+            'description': 'The ID of the domain event stream.',
+            'minLength': 1,
+          },
+          'firstOperator': {
+            'type': 'string',
+            'description': 'The first person who operates the aggregate is the creator',
+          },
+          'operator': {
+            'type': 'string',
+            'description': 'The last person who operates the aggregate',
+          },
+          'firstEventTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The first event time of the aggregate, which is the time it was created',
+          },
+          'state': {
+            'type': 'object',
+            'description': 'The state data of the aggregate',
+            'properties': {
+              'id': {
+                'type': 'string',
+              },
+              'items': {
+                'type': 'array',
+                'items': {
+                  '$ref': '#/components/schemas/example.cart.CartItem',
+                },
+              },
+            },
+            'required': [
+              'id',
+            ],
+          },
+          'deleted': {
+            'type': 'boolean',
+            'description': 'Whether the aggregate has been deleted',
+          },
+          'snapshotTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The snapshot time of the aggregate',
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'contextName',
+          'deleted',
+          'eventId',
+          'firstEventTime',
+          'firstOperator',
+          'operator',
+          'ownerId',
+          'snapshotTime',
+          'state',
+          'tenantId',
+          'version',
+        ],
+      },
+      'example.CartStateStateEvent': {
+        'type': 'object',
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'The ID of the domain event stream.',
+            'minLength': 1,
+          },
+          'contextName': {
+            'type': 'string',
+            'description': 'The name of the context to which the domain event stream belongs',
+            'minLength': 1,
+          },
+          'aggregateName': {
+            'type': 'string',
+            'description': 'The name of the aggregate to which the domain event stream belongs',
+            'minLength': 1,
+          },
+          'header': {
+            'type': 'object',
+            'additionalProperties': true,
+            'description': 'message header',
+            'properties': {
+              'user_agent': {
+                'type': 'string',
+                'description': 'user agent',
+              },
+              'remote_ip': {
+                'type': 'string',
+                'description': 'remote ip',
+              },
+              'trace_id': {
+                'type': 'string',
+                'description': 'trace id',
+              },
+              'command_operator': {
+                'type': 'string',
+                'description': 'command operator',
+              },
+              'local_first': {
+                'type': 'boolean',
+                'description': 'local first',
+              },
+              'command_wait_endpoint': {
+                'type': 'string',
+                'format': 'url',
+                'description': 'command wait endpoint',
+              },
+              'command_wait_stage': {
+                'type': 'string',
+                'default': 'PROCESSED',
+                'enum': [
+                  'SENT',
+                  'PROCESSED',
+                  'SNAPSHOT',
+                  'PROJECTED',
+                  'EVENT_HANDLED',
+                  'SAGA_HANDLED',
+                ],
+              },
+            },
+          },
+          'tenantId': {
+            'type': 'string',
+            'description': 'The tenant id of the aggregate',
+            'minLength': 1,
+          },
+          'aggregateId': {
+            'type': 'string',
+            'description': 'The id of the aggregate',
+            'minLength': 1,
+          },
+          'ownerId': {
+            'type': 'string',
+            'default': '',
+            'description': 'The owner ID of the aggregate resource',
+          },
+          'commandId': {
+            'type': 'string',
+            'description': 'The ID of the command message.',
+            'minLength': 1,
+          },
+          'requestId': {
+            'type': 'string',
+            'description': 'The request ID of the command message, which is used to check the idempotency of the command message',
+            'minLength': 1,
+          },
+          'version': {
+            'type': 'integer',
+            'format': 'int32',
+            'description': 'The version of the domain event stream',
+          },
+          'body': {
+            'type': 'array',
+            'description': 'A list of domain events for the domain event stream',
+            'items': {
+              'type': 'object',
+              'description': 'The body of the domain event',
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'description': 'The ID of the domain event.',
+                  'minLength': 1,
+                },
+                'name': {
+                  'type': 'string',
+                  'description': 'The name of the domain event',
+                  'minLength': 1,
+                },
+                'revision': {
+                  'type': 'string',
+                  'description': 'The revision number of the domain event',
+                },
+                'bodyType': {
+                  'type': 'string',
+                  'description': 'The fully qualified name of the domain event body',
+                },
+                'body': {
+                  'type': 'object',
+                  'description': 'The message body of the domain event',
+                },
+              },
+              'required': [
+                'body',
+                'bodyType',
+                'id',
+                'name',
+                'revision',
+              ],
+            },
+            'minItems': 1,
+          },
+          'createTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The time when the domain event stream was created',
+          },
+          'firstOperator': {
+            'type': 'string',
+            'description': 'The first person who operates the aggregate is the creator',
+          },
+          'firstEventTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The first event time of the aggregate, which is the time it was created',
+          },
+          'state': {
+            'type': 'object',
+            'description': 'The state data of the aggregate',
+            'properties': {
+              'id': {
+                'type': 'string',
+              },
+              'items': {
+                'type': 'array',
+                'items': {
+                  '$ref': '#/components/schemas/example.cart.CartItem',
+                },
+              },
+            },
+            'required': [
+              'id',
+            ],
+          },
+          'deleted': {
+            'type': 'boolean',
+            'description': 'Whether the aggregate has been deleted',
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'body',
+          'contextName',
+          'createTime',
+          'deleted',
+          'firstEventTime',
+          'firstOperator',
+          'id',
+          'ownerId',
+          'state',
+          'tenantId',
+          'version',
+        ],
+      },
+      'example.Link': {
+        'type': 'object',
+        'properties': {
+          'href': {
+            'type': 'string',
+          },
+          'templated': {
+            'type': 'boolean',
+          },
+        },
+      },
+      'example.OrderAggregatedCondition': {
+        'type': 'object',
+        'properties': {
+          'children': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/example.OrderAggregatedCondition',
+            },
+          },
+          'field': {
+            '$ref': '#/components/schemas/example.OrderAggregatedFields',
+          },
+          'operator': {
+            '$ref': '#/components/schemas/wow.api.query.Operator',
+            'default': 'ALL',
+          },
+          'options': {
+            '$ref': '#/components/schemas/example.StringObjectMap',
+            'default': '{}',
+          },
+          'value': {},
+        },
+      },
+      'example.OrderAggregatedDomainEventStream': {
+        'type': 'object',
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'The ID of the domain event stream.',
+            'minLength': 1,
+          },
+          'contextName': {
+            'type': 'string',
+            'description': 'The name of the context to which the domain event stream belongs',
+            'minLength': 1,
+          },
+          'aggregateName': {
+            'type': 'string',
+            'description': 'The name of the aggregate to which the domain event stream belongs',
+            'minLength': 1,
+          },
+          'header': {
+            'type': 'object',
+            'additionalProperties': true,
+            'description': 'message header',
+            'properties': {
+              'user_agent': {
+                'type': 'string',
+                'description': 'user agent',
+              },
+              'remote_ip': {
+                'type': 'string',
+                'description': 'remote ip',
+              },
+              'trace_id': {
+                'type': 'string',
+                'description': 'trace id',
+              },
+              'command_operator': {
+                'type': 'string',
+                'description': 'command operator',
+              },
+              'local_first': {
+                'type': 'boolean',
+                'description': 'local first',
+              },
+              'command_wait_endpoint': {
+                'type': 'string',
+                'format': 'url',
+                'description': 'command wait endpoint',
+              },
+              'command_wait_stage': {
+                'type': 'string',
+                'default': 'PROCESSED',
+                'enum': [
+                  'SENT',
+                  'PROCESSED',
+                  'SNAPSHOT',
+                  'PROJECTED',
+                  'EVENT_HANDLED',
+                  'SAGA_HANDLED',
+                ],
+              },
+            },
+          },
+          'tenantId': {
+            'type': 'string',
+            'description': 'The tenant id of the aggregate',
+            'minLength': 1,
+          },
+          'aggregateId': {
+            'type': 'string',
+            'description': 'The id of the aggregate',
+            'minLength': 1,
+          },
+          'ownerId': {
+            'type': 'string',
+            'default': '',
+            'description': 'The owner ID of the aggregate resource',
+          },
+          'commandId': {
+            'type': 'string',
+            'description': 'The ID of the command message.',
+            'minLength': 1,
+          },
+          'requestId': {
+            'type': 'string',
+            'description': 'The request ID of the command message, which is used to check the idempotency of the command message',
+            'minLength': 1,
+          },
+          'version': {
+            'type': 'integer',
+            'format': 'int32',
+            'description': 'The version of the domain event stream',
+          },
+          'body': {
+            'type': 'array',
+            'description': 'A list of domain events for the domain event stream',
+            'items': {
+              'anyOf': [
+                {
+                  'type': 'object',
+                  'description': 'The body of the domain event',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The ID of the domain event.',
+                      'minLength': 1,
+                    },
+                    'name': {
+                      'type': 'string',
+                      'const': 'address_changed',
+                      'description': 'The name of the domain event',
+                      'minLength': 1,
+                    },
+                    'revision': {
+                      'type': 'string',
+                      'default': '0.0.1',
+                      'description': 'The revision number of the domain event',
+                    },
+                    'bodyType': {
+                      'type': 'string',
+                      'const': 'me.ahoo.wow.example.api.order.AddressChanged',
+                      'description': 'The fully qualified name of the domain event body',
+                    },
+                    'body': {
+                      '$ref': '#/components/schemas/example.order.AddressChanged',
+                    },
+                  },
+                  'required': [
+                    'body',
+                    'bodyType',
+                    'id',
+                    'name',
+                    'revision',
+                  ],
+                  'title': '收货地址已修改',
+                },
+                {
+                  'type': 'object',
+                  'description': 'The body of the domain event',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The ID of the domain event.',
+                      'minLength': 1,
+                    },
+                    'name': {
+                      'type': 'string',
+                      'const': 'order_created',
+                      'description': 'The name of the domain event',
+                      'minLength': 1,
+                    },
+                    'revision': {
+                      'type': 'string',
+                      'default': '0.0.1',
+                      'description': 'The revision number of the domain event',
+                    },
+                    'bodyType': {
+                      'type': 'string',
+                      'const': 'me.ahoo.wow.example.api.order.OrderCreated',
+                      'description': 'The fully qualified name of the domain event body',
+                    },
+                    'body': {
+                      '$ref': '#/components/schemas/example.order.OrderCreated',
+                    },
+                  },
+                  'required': [
+                    'body',
+                    'bodyType',
+                    'id',
+                    'name',
+                    'revision',
+                  ],
+                  'title': 'order_created',
+                },
+                {
+                  'type': 'object',
+                  'description': 'The body of the domain event',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The ID of the domain event.',
+                      'minLength': 1,
+                    },
+                    'name': {
+                      'type': 'string',
+                      'const': 'order_paid',
+                      'description': 'The name of the domain event',
+                      'minLength': 1,
+                    },
+                    'revision': {
+                      'type': 'string',
+                      'default': '0.0.1',
+                      'description': 'The revision number of the domain event',
+                    },
+                    'bodyType': {
+                      'type': 'string',
+                      'const': 'me.ahoo.wow.example.api.order.OrderPaid',
+                      'description': 'The fully qualified name of the domain event body',
+                    },
+                    'body': {
+                      '$ref': '#/components/schemas/example.order.OrderPaid',
+                    },
+                  },
+                  'required': [
+                    'body',
+                    'bodyType',
+                    'id',
+                    'name',
+                    'revision',
+                  ],
+                  'title': 'order_paid',
+                },
+                {
+                  'type': 'object',
+                  'description': 'The body of the domain event',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The ID of the domain event.',
+                      'minLength': 1,
+                    },
+                    'name': {
+                      'type': 'string',
+                      'const': 'order_received',
+                      'description': 'The name of the domain event',
+                      'minLength': 1,
+                    },
+                    'revision': {
+                      'type': 'string',
+                      'default': '0.0.1',
+                      'description': 'The revision number of the domain event',
+                    },
+                    'bodyType': {
+                      'type': 'string',
+                      'const': 'me.ahoo.wow.example.api.order.OrderReceived',
+                      'description': 'The fully qualified name of the domain event body',
+                    },
+                    'body': {
+                      '$ref': '#/components/schemas/example.order.OrderReceived',
+                    },
+                  },
+                  'required': [
+                    'body',
+                    'bodyType',
+                    'id',
+                    'name',
+                    'revision',
+                  ],
+                  'title': 'order_received',
+                },
+                {
+                  'type': 'object',
+                  'description': 'The body of the domain event',
+                  'properties': {
+                    'id': {
+                      'type': 'string',
+                      'description': 'The ID of the domain event.',
+                      'minLength': 1,
+                    },
+                    'name': {
+                      'type': 'string',
+                      'const': 'order_shipped',
+                      'description': 'The name of the domain event',
+                      'minLength': 1,
+                    },
+                    'revision': {
+                      'type': 'string',
+                      'default': '0.0.1',
+                      'description': 'The revision number of the domain event',
+                    },
+                    'bodyType': {
+                      'type': 'string',
+                      'const': 'me.ahoo.wow.example.api.order.OrderShipped',
+                      'description': 'The fully qualified name of the domain event body',
+                    },
+                    'body': {
+                      '$ref': '#/components/schemas/example.order.OrderShipped',
+                    },
+                  },
+                  'required': [
+                    'body',
+                    'bodyType',
+                    'id',
+                    'name',
+                    'revision',
+                  ],
+                  'title': 'order_shipped',
+                },
+              ],
+            },
+            'minItems': 1,
+          },
+          'createTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The time when the domain event stream was created',
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'body',
+          'contextName',
+          'createTime',
+          'id',
+          'ownerId',
+          'tenantId',
+          'version',
+        ],
+      },
+      'example.OrderAggregatedDomainEventStreamPagedList': {
+        'type': 'object',
+        'properties': {
+          'list': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStream',
+            },
+          },
+          'total': {
+            'type': 'integer',
+            'format': 'int64',
+          },
+        },
+        'required': [
+          'list',
+          'total',
+        ],
+      },
+      'example.OrderAggregatedDomainEventStreamServerSentEventNonNullData': {
+        'type': 'object',
+        'properties': {
+          'data': {
+            '$ref': '#/components/schemas/example.OrderAggregatedDomainEventStream',
+          },
+          'event': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'id': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'retry': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'data',
+        ],
+      },
+      'example.OrderAggregatedFields': {
+        'type': 'string',
+        'enum': [
+          '',
+          'aggregateId',
+          'tenantId',
+          'ownerId',
+          'version',
+          'eventId',
+          'firstOperator',
+          'operator',
+          'firstEventTime',
+          'eventTime',
+          'deleted',
+          'state',
+          'state.address',
+          'state.address.city',
+          'state.address.country',
+          'state.address.detail',
+          'state.address.district',
+          'state.address.province',
+          'state.id',
+          'state.items',
+          'state.items.id',
+          'state.items.price',
+          'state.items.productId',
+          'state.items.quantity',
+          'state.items.totalPrice',
+          'state.paidAmount',
+          'state.payable',
+          'state.status',
+          'state.totalAmount',
+        ],
+      },
+      'example.OrderAggregatedListQuery': {
+        'type': 'object',
+        'properties': {
+          'condition': {
+            '$ref': '#/components/schemas/example.OrderAggregatedCondition',
+          },
+          'limit': {
+            'type': 'integer',
+            'format': 'int32',
+            'default': '10',
+          },
+          'projection': {
+            '$ref': '#/components/schemas/wow.api.query.Projection',
+          },
+          'sort': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Sort',
+            },
+          },
+        },
+        'required': [
+          'condition',
+        ],
+      },
+      'example.OrderAggregatedPagedQuery': {
+        'type': 'object',
+        'properties': {
+          'condition': {
+            '$ref': '#/components/schemas/example.OrderAggregatedCondition',
+          },
+          'pagination': {
+            '$ref': '#/components/schemas/wow.api.query.Pagination',
+          },
+          'projection': {
+            '$ref': '#/components/schemas/wow.api.query.Projection',
+          },
+          'sort': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Sort',
+            },
+          },
+        },
+        'required': [
+          'condition',
+        ],
+      },
+      'example.OrderAggregatedSingleQuery': {
+        'type': 'object',
+        'properties': {
+          'condition': {
+            '$ref': '#/components/schemas/example.OrderAggregatedCondition',
+          },
+          'projection': {
+            '$ref': '#/components/schemas/wow.api.query.Projection',
+          },
+          'sort': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Sort',
+            },
+          },
+        },
+        'required': [
+          'condition',
+        ],
+      },
+      'example.OrderStatus': {
+        'type': 'string',
+        'enum': [
+          'CREATED',
+          'PAID',
+          'SHIPPED',
+          'RECEIVED',
+        ],
+      },
+      'example.SecurityContext': {
+        'type': 'object',
+      },
+      'example.StringLinkMap': {
+        'type': 'object',
+        'additionalProperties': {
+          '$ref': '#/components/schemas/example.Link',
+        },
+      },
+      'example.StringObjectMap': {
+        'type': 'object',
+      },
+      'example.WebServerNamespace': {
+        'type': 'object',
+        'properties': {
+          'value': {
+            'type': 'string',
+          },
+        },
+      },
+      'example.WowExampleOrderStateMaterializedSnapshot': {
+        'type': 'object',
+        'properties': {
+          'aggregateId': {
+            'type': 'string',
+          },
+          'aggregateName': {
+            'type': 'string',
+          },
+          'contextName': {
+            'type': 'string',
+          },
+          'deleted': {
+            'type': 'boolean',
+            'description': 'Whether the aggregate is deleted.',
+          },
+          'eventId': {
+            'type': 'string',
+            'description': 'The event id of the aggregate.',
+          },
+          'eventTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The last event time of the aggregate, represented as a Unix timestamp in milliseconds.',
+          },
+          'firstEventTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The first event time of the aggregate, represented as a Unix timestamp in milliseconds.',
+          },
+          'firstOperator': {
+            'type': 'string',
+            'description': 'The first operator of the aggregate.',
+          },
+          'operator': {
+            'type': 'string',
+            'description': 'The last operator of the aggregate.',
+          },
+          'ownerId': {
+            'type': 'string',
+          },
+          'snapshotTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The snapshot time of the aggregate, represented as a Unix timestamp in milliseconds.',
+          },
+          'state': {
+            '$ref': '#/components/schemas/example.WowExampleOrderState',
+            'description': 'The state of the aggregate.',
+          },
+          'tenantId': {
+            'type': 'string',
+          },
+          'version': {
+            'type': 'integer',
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'contextName',
+          'deleted',
+          'eventId',
+          'eventTime',
+          'firstEventTime',
+          'firstOperator',
+          'operator',
+          'snapshotTime',
+          'state',
+          'tenantId',
+          'version',
+        ],
+      },
+      'example.WowExampleOrderStateMaterializedSnapshotPagedList': {
+        'type': 'object',
+        'properties': {
+          'list': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshot',
+            },
+          },
+          'total': {
+            'type': 'integer',
+            'format': 'int64',
+          },
+        },
+        'required': [
+          'list',
+          'total',
+        ],
+      },
+      'example.WowExampleOrderStateMaterializedSnapshotServerSentEventNonNullData': {
+        'type': 'object',
+        'properties': {
+          'data': {
+            '$ref': '#/components/schemas/example.WowExampleOrderStateMaterializedSnapshot',
+          },
+          'event': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'id': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'retry': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'data',
+        ],
+      },
+      'example.WowExampleOrderStatePagedList': {
+        'type': 'object',
+        'properties': {
+          'list': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.WowExampleOrderState',
+            },
+          },
+          'total': {
+            'type': 'integer',
+            'format': 'int64',
+          },
+        },
+        'required': [
+          'list',
+          'total',
+        ],
+      },
+      'example.WowExampleOrderStateServerSentEventNonNullData': {
+        'type': 'object',
+        'properties': {
+          'data': {
+            '$ref': '#/components/schemas/example.WowExampleOrderState',
+          },
+          'event': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'id': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'retry': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'data',
+        ],
+      },
+      'example.WowExampleOrderStateSnapshot': {
+        'type': 'object',
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'properties': {
+          'contextName': {
+            'type': 'string',
+            'description': 'The name of the context to which the snapshot belongs',
+            'minLength': 1,
+          },
+          'aggregateName': {
+            'type': 'string',
+            'description': 'The name of the aggregate to which the snapshot belongs',
+            'minLength': 1,
+          },
+          'tenantId': {
+            'type': 'string',
+            'description': 'The tenant id of the aggregate',
+            'minLength': 1,
+          },
+          'aggregateId': {
+            'type': 'string',
+            'description': 'The id of the aggregate',
+            'minLength': 1,
+          },
+          'ownerId': {
+            'type': 'string',
+            'default': '',
+            'description': 'The owner ID of the aggregate resource',
+          },
+          'version': {
+            'type': 'integer',
+            'format': 'int32',
+            'description': 'The version of the snapshot',
+          },
+          'eventId': {
+            'type': 'string',
+            'description': 'The ID of the domain event stream.',
+            'minLength': 1,
+          },
+          'firstOperator': {
+            'type': 'string',
+            'description': 'The first person who operates the aggregate is the creator',
+          },
+          'operator': {
+            'type': 'string',
+            'description': 'The last person who operates the aggregate',
+          },
+          'firstEventTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The first event time of the aggregate, which is the time it was created',
+          },
+          'state': {
+            'type': 'object',
+            'description': 'The state data of the aggregate',
+            'properties': {
+              'address': {
+                '$ref': '#/components/schemas/example.order.ShippingAddress',
+                'readOnly': true,
+              },
+              'id': {
+                'type': 'string',
+              },
+              'items': {
+                'type': 'array',
+                'items': {
+                  '$ref': '#/components/schemas/example.order.OrderItem',
+                  'readOnly': true,
+                },
+                'readOnly': true,
+              },
+              'paidAmount': {
+                'type': 'number',
+              },
+              'status': {
+                '$ref': '#/components/schemas/example.OrderStatus',
+              },
+              'totalAmount': {
+                'type': 'number',
+              },
+            },
+            'required': [
+              'id',
+            ],
+          },
+          'deleted': {
+            'type': 'boolean',
+            'description': 'Whether the aggregate has been deleted',
+          },
+          'snapshotTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The snapshot time of the aggregate',
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'contextName',
+          'deleted',
+          'eventId',
+          'firstEventTime',
+          'firstOperator',
+          'operator',
+          'ownerId',
+          'snapshotTime',
+          'state',
+          'tenantId',
+          'version',
+        ],
+      },
+      'example.WowExampleOrderStateStateEvent': {
+        'type': 'object',
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'properties': {
+          'id': {
+            'type': 'string',
+            'description': 'The ID of the domain event stream.',
+            'minLength': 1,
+          },
+          'contextName': {
+            'type': 'string',
+            'description': 'The name of the context to which the domain event stream belongs',
+            'minLength': 1,
+          },
+          'aggregateName': {
+            'type': 'string',
+            'description': 'The name of the aggregate to which the domain event stream belongs',
+            'minLength': 1,
+          },
+          'header': {
+            'type': 'object',
+            'additionalProperties': true,
+            'description': 'message header',
+            'properties': {
+              'user_agent': {
+                'type': 'string',
+                'description': 'user agent',
+              },
+              'remote_ip': {
+                'type': 'string',
+                'description': 'remote ip',
+              },
+              'trace_id': {
+                'type': 'string',
+                'description': 'trace id',
+              },
+              'command_operator': {
+                'type': 'string',
+                'description': 'command operator',
+              },
+              'local_first': {
+                'type': 'boolean',
+                'description': 'local first',
+              },
+              'command_wait_endpoint': {
+                'type': 'string',
+                'format': 'url',
+                'description': 'command wait endpoint',
+              },
+              'command_wait_stage': {
+                'type': 'string',
+                'default': 'PROCESSED',
+                'enum': [
+                  'SENT',
+                  'PROCESSED',
+                  'SNAPSHOT',
+                  'PROJECTED',
+                  'EVENT_HANDLED',
+                  'SAGA_HANDLED',
+                ],
+              },
+            },
+          },
+          'tenantId': {
+            'type': 'string',
+            'description': 'The tenant id of the aggregate',
+            'minLength': 1,
+          },
+          'aggregateId': {
+            'type': 'string',
+            'description': 'The id of the aggregate',
+            'minLength': 1,
+          },
+          'ownerId': {
+            'type': 'string',
+            'default': '',
+            'description': 'The owner ID of the aggregate resource',
+          },
+          'commandId': {
+            'type': 'string',
+            'description': 'The ID of the command message.',
+            'minLength': 1,
+          },
+          'requestId': {
+            'type': 'string',
+            'description': 'The request ID of the command message, which is used to check the idempotency of the command message',
+            'minLength': 1,
+          },
+          'version': {
+            'type': 'integer',
+            'format': 'int32',
+            'description': 'The version of the domain event stream',
+          },
+          'body': {
+            'type': 'array',
+            'description': 'A list of domain events for the domain event stream',
+            'items': {
+              'type': 'object',
+              'description': 'The body of the domain event',
+              'properties': {
+                'id': {
+                  'type': 'string',
+                  'description': 'The ID of the domain event.',
+                  'minLength': 1,
+                },
+                'name': {
+                  'type': 'string',
+                  'description': 'The name of the domain event',
+                  'minLength': 1,
+                },
+                'revision': {
+                  'type': 'string',
+                  'description': 'The revision number of the domain event',
+                },
+                'bodyType': {
+                  'type': 'string',
+                  'description': 'The fully qualified name of the domain event body',
+                },
+                'body': {
+                  'type': 'object',
+                  'description': 'The message body of the domain event',
+                },
+              },
+              'required': [
+                'body',
+                'bodyType',
+                'id',
+                'name',
+                'revision',
+              ],
+            },
+            'minItems': 1,
+          },
+          'createTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The time when the domain event stream was created',
+          },
+          'firstOperator': {
+            'type': 'string',
+            'description': 'The first person who operates the aggregate is the creator',
+          },
+          'firstEventTime': {
+            'type': 'integer',
+            'format': 'int64',
+            'description': 'The first event time of the aggregate, which is the time it was created',
+          },
+          'state': {
+            'type': 'object',
+            'description': 'The state data of the aggregate',
+            'properties': {
+              'address': {
+                '$ref': '#/components/schemas/example.order.ShippingAddress',
+                'readOnly': true,
+              },
+              'id': {
+                'type': 'string',
+              },
+              'items': {
+                'type': 'array',
+                'items': {
+                  '$ref': '#/components/schemas/example.order.OrderItem',
+                  'readOnly': true,
+                },
+                'readOnly': true,
+              },
+              'paidAmount': {
+                'type': 'number',
+              },
+              'status': {
+                '$ref': '#/components/schemas/example.OrderStatus',
+              },
+              'totalAmount': {
+                'type': 'number',
+              },
+            },
+            'required': [
+              'id',
+            ],
+          },
+          'deleted': {
+            'type': 'boolean',
+            'description': 'Whether the aggregate has been deleted',
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'body',
+          'contextName',
+          'createTime',
+          'deleted',
+          'firstEventTime',
+          'firstOperator',
+          'id',
+          'ownerId',
+          'state',
+          'tenantId',
+          'version',
+        ],
+      },
+      'example.cart.AddCartItem': {
+        'type': 'object',
+        'properties': {
+          'productId': {
+            'type': 'string',
+            'minLength': 1,
+          },
+          'quantity': {
+            'type': 'integer',
+            'format': 'int32',
+            'exclusiveMinimum': 0,
+          },
+        },
+        'required': [
+          'productId',
+        ],
+      },
+      'example.cart.CartItem': {
+        'type': 'object',
+        'properties': {
+          'productId': {
+            'type': 'string',
+          },
+          'quantity': {
+            'type': 'integer',
+            'format': 'int32',
+          },
+        },
+        'required': [
+          'productId',
+        ],
+      },
+      'example.cart.CartItemAdded': {
+        'type': 'object',
+        'properties': {
+          'added': {
+            '$ref': '#/components/schemas/example.cart.CartItem',
+          },
+        },
+        'required': [
+          'added',
+        ],
+      },
+      'example.cart.CartItemRemoved': {
+        'type': 'object',
+        'properties': {
+          'productIds': {
+            'type': 'array',
+            'items': {
+              'type': 'string',
+            },
+          },
+        },
+        'required': [
+          'productIds',
+        ],
+      },
+      'example.cart.CartQuantityChanged': {
+        'type': 'object',
+        'properties': {
+          'changed': {
+            '$ref': '#/components/schemas/example.cart.CartItem',
+          },
+        },
+        'required': [
+          'changed',
+        ],
+      },
+      'example.cart.ChangeQuantity': {
+        'type': 'object',
+        'properties': {
+          'productId': {
+            'type': 'string',
+            'minLength': 1,
+          },
+          'quantity': {
+            'type': 'integer',
+            'format': 'int32',
+            'exclusiveMinimum': 0,
+          },
+        },
+        'required': [
+          'productId',
+          'quantity',
+        ],
+      },
+      'example.cart.MockVariableCommand': {
+        'type': 'object',
+      },
+      'example.cart.MockVariableCommand.MockEnum': {
+        'type': 'string',
+        'enum': [
+          'First',
+          'Second',
+          'Third',
+        ],
+      },
+      'example.cart.MountedCommand': {
+        'type': 'object',
+      },
+      'example.cart.RemoveCartItem': {
+        'type': 'object',
+        'properties': {
+          'productIds': {
+            'type': 'array',
+            'items': {
+              'type': 'string',
+            },
+            'minItems': 1,
+          },
+        },
+        'required': [
+          'productIds',
+        ],
+      },
+      'example.cart.ViewCart': {
+        'type': 'object',
+      },
+      'example.order.AddressChanged': {
+        'type': 'object',
+        'properties': {
+          'shippingAddress': {
+            '$ref': '#/components/schemas/example.order.ShippingAddress',
+          },
+        },
+        'required': [
+          'shippingAddress',
+        ],
+      },
+      'example.order.ChangeAddress': {
+        'type': 'object',
+        'properties': {
+          'shippingAddress': {
+            '$ref': '#/components/schemas/example.order.ShippingAddress',
+          },
+        },
+        'required': [
+          'shippingAddress',
+        ],
+      },
+      'example.order.CreateOrder': {
+        'type': 'object',
+        'properties': {
+          'address': {
+            '$ref': '#/components/schemas/example.order.ShippingAddress',
+          },
+          'fromCart': {
+            'type': 'boolean',
+          },
+          'items': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.order.CreateOrder.Item',
+            },
+            'minItems': 1,
+          },
+        },
+        'required': [
+          'address',
+          'fromCart',
+          'items',
+        ],
+      },
+      'example.order.CreateOrder.Item': {
+        'type': 'object',
+        'properties': {
+          'price': {
+            'type': 'number',
+            'exclusiveMinimum': 0,
+          },
+          'productId': {
+            'type': 'string',
+            'minLength': 1,
+          },
+          'quantity': {
+            'type': 'integer',
+            'format': 'int32',
+            'exclusiveMinimum': 0,
+          },
+        },
+        'required': [
+          'price',
+          'productId',
+          'quantity',
+        ],
+      },
+      'example.order.OrderCreated': {
+        'type': 'object',
+        'properties': {
+          'address': {
+            '$ref': '#/components/schemas/example.order.ShippingAddress',
+          },
+          'fromCart': {
+            'type': 'boolean',
+          },
+          'items': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/example.order.OrderItem',
+            },
+          },
+          'orderId': {
+            'type': 'string',
+          },
+        },
+        'required': [
+          'address',
+          'fromCart',
+          'items',
+          'orderId',
+        ],
+      },
+      'example.order.OrderItem': {
+        'type': 'object',
+        'properties': {
+          'id': {
+            'type': 'string',
+          },
+          'price': {
+            'type': 'number',
+          },
+          'productId': {
+            'type': 'string',
+          },
+          'quantity': {
+            'type': 'integer',
+            'format': 'int32',
+          },
+          'totalPrice': {
+            'type': 'number',
+            'readOnly': true,
+          },
+        },
+        'required': [
+          'id',
+          'price',
+          'productId',
+          'quantity',
+        ],
+      },
+      'example.order.OrderPaid': {
+        'type': 'object',
+        'properties': {
+          'amount': {
+            'type': 'number',
+          },
+          'paid': {
+            'type': 'boolean',
+          },
+        },
+        'required': [
+          'amount',
+          'paid',
+        ],
+      },
+      'example.order.OrderReceived': {
+        'type': 'object',
+      },
+      'example.order.OrderShipped': {
+        'type': 'object',
+      },
+      'example.order.PayOrder': {
+        'type': 'object',
+        'properties': {
+          'amount': {
+            'type': 'number',
+            'exclusiveMinimum': 0,
+          },
+          'paymentId': {
+            'type': 'string',
+            'minLength': 1,
+          },
+        },
+        'required': [
+          'amount',
+          'paymentId',
+        ],
+      },
+      'example.order.ReceiptOrder': {
+        'type': 'object',
+      },
+      'example.order.ShipOrder': {
+        'type': 'object',
+      },
+      'example.order.ShippingAddress': {
+        'type': 'object',
+        'properties': {
+          'city': {
+            'type': 'string',
+          },
+          'country': {
+            'type': 'string',
+            'minLength': 1,
+          },
+          'detail': {
+            'type': 'string',
+          },
+          'district': {
+            'type': 'string',
+          },
+          'province': {
+            'type': 'string',
+            'minLength': 1,
+          },
+        },
+        'required': [
+          'city',
+          'country',
+          'detail',
+          'district',
+          'province',
+        ],
+      },
+      'wow.MessageHeaderSqlType': {
+        'type': 'string',
+        'enum': [
+          'MAP',
+          'STRING',
+        ],
+      },
+      'wow.api.BindingError': {
+        'type': 'object',
+        'properties': {
+          'msg': {
+            'type': 'string',
+          },
+          'name': {
+            'type': 'string',
+          },
+        },
+        'required': [
+          'msg',
+          'name',
+        ],
+      },
+      'wow.api.DefaultErrorInfo': {
+        'type': 'object',
+        'properties': {
+          'bindingErrors': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.BindingError',
+            },
+          },
+          'errorCode': {
+            'type': 'string',
+          },
+          'errorMsg': {
+            'type': 'string',
+          },
+          'succeeded': {
+            'type': 'boolean',
+            'readOnly': true,
+          },
+        },
+        'required': [
+          'errorCode',
+        ],
+      },
+      'wow.api.command.DefaultDeleteAggregate': {
+        'type': 'object',
+      },
+      'wow.api.command.DefaultRecoverAggregate': {
+        'type': 'object',
+      },
+      'wow.api.messaging.FunctionInfoData': {
+        'type': 'object',
+        'properties': {
+          'contextName': {
+            'type': 'string',
+          },
+          'functionKind': {
+            '$ref': '#/components/schemas/wow.api.messaging.FunctionKind',
+          },
+          'name': {
+            'type': 'string',
+          },
+          'processorName': {
+            'type': 'string',
+          },
+        },
+        'required': [
+          'contextName',
+          'functionKind',
+          'name',
+          'processorName',
+        ],
+      },
+      'wow.api.messaging.FunctionKind': {
+        'type': 'string',
+        'enum': [
+          'COMMAND',
+          'SOURCING',
+          'EVENT',
+          'STATE_EVENT',
+          'ERROR',
+        ],
+      },
+      'wow.api.modeling.AggregateId': {
+        'type': 'object',
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'properties': {
+          'contextName': {
+            'type': 'string',
+            'description': 'aggregate context name',
+            'minLength': 1,
+          },
+          'aggregateName': {
+            'type': 'string',
+            'description': 'aggregate name',
+            'minLength': 1,
+          },
+          'tenantId': {
+            'type': 'string',
+            'default': '(0)',
+            'description': 'aggregate tenant id',
+            'minLength': 1,
+          },
+          'aggregateId': {
+            'type': 'string',
+            'description': 'aggregate id',
+            'minLength': 1,
+          },
+        },
+        'required': [
+          'aggregateId',
+          'aggregateName',
+          'contextName',
+          'tenantId',
+        ],
+      },
+      'wow.api.query.Condition': {
+        'type': 'object',
+        'properties': {
+          'children': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Condition',
+            },
+          },
+          'field': {
+            'type': 'string',
+          },
+          'operator': {
+            '$ref': '#/components/schemas/wow.api.query.Operator',
+            'default': 'ALL',
+          },
+          'options': {
+            '$ref': '#/components/schemas/example.StringObjectMap',
+            'default': '{}',
+          },
+          'value': {},
+        },
+      },
+      'wow.api.query.ListQuery': {
+        'type': 'object',
+        'properties': {
+          'condition': {
+            '$ref': '#/components/schemas/wow.api.query.Condition',
+          },
+          'limit': {
+            'type': 'integer',
+            'format': 'int32',
+            'default': '10',
+          },
+          'projection': {
+            '$ref': '#/components/schemas/wow.api.query.Projection',
+          },
+          'sort': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Sort',
+            },
+          },
+        },
+        'required': [
+          'condition',
+        ],
+      },
+      'wow.api.query.Operator': {
+        'type': 'string',
+        'enum': [
+          'AND',
+          'OR',
+          'NOR',
+          'ID',
+          'IDS',
+          'AGGREGATE_ID',
+          'AGGREGATE_IDS',
+          'TENANT_ID',
+          'OWNER_ID',
+          'DELETED',
+          'ALL',
+          'EQ',
+          'NE',
+          'GT',
+          'LT',
+          'GTE',
+          'LTE',
+          'CONTAINS',
+          'IN',
+          'NOT_IN',
+          'BETWEEN',
+          'ALL_IN',
+          'STARTS_WITH',
+          'ENDS_WITH',
+          'ELEM_MATCH',
+          'NULL',
+          'NOT_NULL',
+          'TRUE',
+          'FALSE',
+          'EXISTS',
+          'TODAY',
+          'BEFORE_TODAY',
+          'TOMORROW',
+          'THIS_WEEK',
+          'NEXT_WEEK',
+          'LAST_WEEK',
+          'THIS_MONTH',
+          'LAST_MONTH',
+          'RECENT_DAYS',
+          'EARLIER_DAYS',
+          'RAW',
+        ],
+      },
+      'wow.api.query.PagedQuery': {
+        'type': 'object',
+        'properties': {
+          'condition': {
+            '$ref': '#/components/schemas/wow.api.query.Condition',
+          },
+          'pagination': {
+            '$ref': '#/components/schemas/wow.api.query.Pagination',
+          },
+          'projection': {
+            '$ref': '#/components/schemas/wow.api.query.Projection',
+          },
+          'sort': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.query.Sort',
+            },
+          },
+        },
+        'required': [
+          'condition',
+        ],
+      },
+      'wow.api.query.Pagination': {
+        'type': 'object',
+        'properties': {
+          'index': {
+            'type': 'integer',
+            'format': 'int32',
+            'default': '1',
+          },
+          'size': {
+            'type': 'integer',
+            'format': 'int32',
+            'default': '10',
+          },
+        },
+        'required': [
+          'index',
+          'size',
+        ],
+      },
+      'wow.api.query.Projection': {
+        'type': 'object',
+        'properties': {
+          'exclude': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              'type': 'string',
+            },
+          },
+          'include': {
+            'type': 'array',
+            'default': '[]',
+            'items': {
+              'type': 'string',
+            },
+          },
+        },
+      },
+      'wow.api.query.Sort': {
+        'type': 'object',
+        'properties': {
+          'direction': {
+            '$ref': '#/components/schemas/wow.api.query.Sort.Direction',
+          },
+          'field': {
+            'type': 'string',
+          },
+        },
+        'required': [
+          'direction',
+          'field',
+        ],
+      },
+      'wow.api.query.Sort.Direction': {
+        'type': 'string',
+        'enum': [
+          'ASC',
+          'DESC',
+        ],
+      },
+      'wow.apiclient.CommandRequest.WaitStrategy': {
+        'type': 'object',
+        'properties': {
+          'waitContext': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'waitProcessor': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'waitStage': {
+            '$ref': '#/components/schemas/wow.command.CommandStage',
+          },
+          'waitTimeout': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int64',
+          },
+        },
+      },
+      'wow.command.CommandStage': {
+        'type': 'string',
+        'enum': [
+          'SENT',
+          'PROCESSED',
+          'SNAPSHOT',
+          'PROJECTED',
+          'EVENT_HANDLED',
+          'SAGA_HANDLED',
+        ],
+      },
+      'wow.command.SimpleWaitSignal': {
+        'type': 'object',
+        'properties': {
+          'aggregateId': {
+            '$ref': '#/components/schemas/wow.api.modeling.AggregateId',
+          },
+          'aggregateVersion': {
+            'type': [
+              'integer',
+              'null',
+            ],
+            'format': 'int32',
+          },
+          'bindingErrors': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.BindingError',
+            },
+          },
+          'commandId': {
+            'type': 'string',
+          },
+          'commands': {
+            'type': 'array',
+            'items': {
+              'type': 'string',
+            },
+          },
+          'errorCode': {
+            'type': 'string',
+          },
+          'errorMsg': {
+            'type': 'string',
+          },
+          'function': {
+            '$ref': '#/components/schemas/wow.api.messaging.FunctionInfoData',
+          },
+          'id': {
+            'type': 'string',
+          },
+          'result': {
+            '$ref': '#/components/schemas/example.StringObjectMap',
+          },
+          'signalTime': {
+            'type': 'integer',
+            'format': 'int64',
+          },
+          'stage': {
+            '$ref': '#/components/schemas/wow.command.CommandStage',
+          },
+          'waitCommandId': {
+            'type': 'string',
+          },
+          'succeeded': {
+            'type': 'boolean',
+            'readOnly': true,
+          },
+        },
+        'required': [
+          'aggregateId',
+          'commandId',
+          'function',
+          'id',
+          'stage',
+          'waitCommandId',
+        ],
+      },
+      'wow.configuration.Aggregate': {
+        'type': 'object',
+        'properties': {
+          'commands': {
+            'type': 'array',
+            'items': {
+              'type': 'string',
+            },
+          },
+          'events': {
+            'type': 'array',
+            'items': {
+              'type': 'string',
+            },
+          },
+          'id': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'scopes': {
+            'type': 'array',
+            'items': {
+              'type': 'string',
+            },
+          },
+          'tenantId': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'type': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+        },
+      },
+      'wow.configuration.BoundedContext': {
+        'type': 'object',
+        'properties': {
+          'aggregates': {
+            '$ref': '#/components/schemas/wow.configuration.StringAggregateMap',
+          },
+          'alias': {
+            'type': [
+              'string',
+              'null',
+            ],
+          },
+          'description': {
+            'type': 'string',
+          },
+          'scopes': {
+            'type': 'array',
+            'items': {
+              'type': 'string',
+            },
+          },
+        },
+      },
+      'wow.configuration.StringAggregateMap': {
+        'type': 'object',
+        'additionalProperties': {
+          '$ref': '#/components/schemas/wow.configuration.Aggregate',
+        },
+      },
+      'wow.configuration.StringBoundedContextMap': {
+        'type': 'object',
+        'additionalProperties': {
+          '$ref': '#/components/schemas/wow.configuration.BoundedContext',
+        },
+      },
+      'wow.configuration.WowMetadata': {
+        'type': 'object',
+        'properties': {
+          'contexts': {
+            '$ref': '#/components/schemas/wow.configuration.StringBoundedContextMap',
+          },
+        },
+      },
+      'wow.messaging.CompensationTarget': {
+        'type': 'object',
+        'properties': {
+          'function': {
+            '$ref': '#/components/schemas/wow.api.messaging.FunctionInfoData',
+          },
+          'id': {
+            'type': 'string',
+          },
+        },
+        'required': [
+          'function',
+        ],
+      },
+      'wow.openapi.BatchResult': {
+        'type': 'object',
+        'properties': {
+          'afterId': {
+            'type': 'string',
+          },
+          'errorCode': {
+            'type': 'string',
+          },
+          'errorMsg': {
+            'type': 'string',
+          },
+          'size': {
+            'type': 'integer',
+            'format': 'int32',
+          },
+          'bindingErrors': {
+            'type': 'array',
+            'items': {
+              '$ref': '#/components/schemas/wow.api.BindingError',
+            },
+            'readOnly': true,
+          },
+          'succeeded': {
+            'type': 'boolean',
+            'readOnly': true,
+          },
+        },
+        'required': [
+          'afterId',
+          'size',
+        ],
+      },
+    },
+    'responses': {
+      'wow.CommandOk': {
+        'description': '',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.command.CommandResult',
+            },
+          },
+          'text/event-stream': {
+            'schema': {
+              'anyOf': [
+                {
+                  '$ref': '#/components/schemas/wow.command.CommandResult',
+                },
+                {
+                  'type': 'string',
+                  'description': 'This value is returned when the task fails to be executed',
+                  'title': 'error',
+                },
+              ],
+            },
+          },
+        },
+      },
+      'wow.CommandBadRequest': {
+        'description': 'Command Bad Request',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.command.CommandResult',
+            },
+          },
+        },
+      },
+      'wow.CommandNotFound': {
+        'description': 'Aggregate Not Found',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.command.CommandResult',
+            },
+          },
+        },
+      },
+      'wow.CommandVersionConflict': {
+        'description': 'Command Version Conflict',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.command.CommandResult',
+            },
+          },
+        },
+      },
+      'wow.CommandTooManyRequests': {
+        'description': 'Command Too Many Requests',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.command.CommandResult',
+            },
+          },
+        },
+      },
+      'wow.CommandRequestTimeout': {
+        'description': 'Command Request Timeout',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.command.CommandResult',
+            },
+          },
+        },
+      },
+      'wow.CommandIllegalAccessDeletedAggregate': {
+        'description': 'Illegal Access Deleted Aggregate',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.command.CommandResult',
+            },
+          },
+        },
+      },
+      'wow.BadRequest': {
+        'description': 'Bad Request',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.api.DefaultErrorInfo',
+            },
+          },
+        },
+      },
+      'wow.NotFound': {
+        'description': 'Not Found',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.api.DefaultErrorInfo',
+            },
+          },
+        },
+      },
+      'wow.CountQuery': {
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              'type': 'integer',
+              'format': 'int64',
+            },
+          },
+        },
+      },
+      'wow.RequestTimeout': {
+        'description': 'Request Timeout',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.api.DefaultErrorInfo',
+            },
+          },
+        },
+      },
+      'wow.TooManyRequests': {
+        'description': 'Too Many Requests',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.api.DefaultErrorInfo',
+            },
+          },
+        },
+      },
+      'wow.CompensationTarget': {
+        'description': 'Number of event streams compensated',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'text/plain': {
+            'schema': {
+              'type': 'integer',
+              'format': 'int32',
+            },
+          },
+        },
+      },
+      'wow.BatchResult': {
+        'description': 'Batch Result',
+        'headers': {
+          'Wow-Error-Code': {
+            '$ref': '#/components/headers/wow.Wow-Error-Code',
+          },
+        },
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.openapi.BatchResult',
+            },
+          },
+        },
+      },
+    },
+    'parameters': {
+      'wow.Command-Type': {
+        'name': 'Command-Type',
+        'in': 'header',
+        'description': 'The fully qualified name of the command message body',
+        'required': true,
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Wait-Stage': {
+        'name': 'Command-Wait-Stage',
+        'in': 'header',
+        'schema': {
+          '$ref': '#/components/schemas/wow.command.CommandStage',
+        },
+      },
+      'wow.Command-Wait-Context': {
+        'name': 'Command-Wait-Context',
+        'in': 'header',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Wait-Processor': {
+        'name': 'Command-Wait-Processor',
+        'in': 'header',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Wait-Function': {
+        'name': 'Command-Wait-Function',
+        'in': 'header',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Wait-Timout': {
+        'name': 'Command-Wait-Timout',
+        'in': 'header',
+        'description': 'Command timeout period. Milliseconds',
+        'schema': {
+          'type': 'integer',
+          'format': 'int32',
+        },
+      },
+      'wow.Command-Wait-Tail-Stage': {
+        'name': 'Command-Wait-Tail-Stage',
+        'in': 'header',
+        'schema': {
+          '$ref': '#/components/schemas/wow.command.CommandStage',
+        },
+      },
+      'wow.Command-Wait-Tail-Context': {
+        'name': 'Command-Wait-Tail-Context',
+        'in': 'header',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Wait-Tail-Processor': {
+        'name': 'Command-Wait-Tail-Processor',
+        'in': 'header',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Wait-Tail-Function': {
+        'name': 'Command-Wait-Tail-Function',
+        'in': 'header',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Aggregate-Id': {
+        'name': 'Command-Aggregate-Id',
+        'in': 'header',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Aggregate-Version': {
+        'name': 'Command-Aggregate-Version',
+        'in': 'header',
+        'description': 'The version of the target aggregate, which is used to control version conflicts',
+        'schema': {
+          'type': 'integer',
+          'format': 'int32',
+        },
+      },
+      'wow.Command-Request-Id': {
+        'name': 'Command-Request-Id',
+        'in': 'header',
+        'description': 'The request ID of the command message, which is used to check the idempotency of the command message',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Local-First': {
+        'name': 'Command-Local-First',
+        'in': 'header',
+        'description': 'Whether to enable local priority mode, if false, it will be turned off, and the default is true.',
+        'schema': {
+          'type': 'boolean',
+        },
+      },
+      'wow.Accept': {
+        'name': 'Accept',
+        'in': 'header',
+        'schema': {
+          'type': 'string',
+          'default': 'application/json',
+          'enum': [
+            'application/json',
+            'text/event-stream',
+          ],
+        },
+      },
+      'wow.Command-Tenant-Id': {
+        'name': 'Command-Tenant-Id',
+        'in': 'header',
+        'description': 'The tenant ID of the aggregate',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Owner-Id': {
+        'name': 'Command-Owner-Id',
+        'in': 'header',
+        'description': 'The owner ID of the aggregate resource',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Aggregate-Context': {
+        'name': 'Command-Aggregate-Context',
+        'in': 'header',
+        'description': 'The name of the context to which the command message belongs',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Command-Aggregate-Name': {
+        'name': 'Command-Aggregate-Name',
+        'in': 'header',
+        'description': 'The name of the aggregate to which the command message belongs',
+        'schema': {
+          'type': 'string',
+        },
+      },
+      'wow.Wow-BI-Header-Sql-Type': {
+        'name': 'Wow-BI-Header-Sql-Type',
+        'in': 'header',
+        'description': 'The type of BI Message header.',
+        'schema': {
+          '$ref': '#/components/schemas/wow.MessageHeaderSqlType',
+        },
+      },
+      'wow.tenantId': {
+        'name': 'tenantId',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'string',
+          'description': 'aggregate tenant id',
+          'example': '(0)',
+        },
+      },
+      'wow.ownerId': {
+        'name': 'ownerId',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'string',
+          'description': 'aggregate owner id',
+        },
+      },
+      'wow.id': {
+        'name': 'id',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'string',
+          'description': 'aggregate id',
+        },
+      },
+      'wow.version': {
+        'name': 'version',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'integer',
+          'format': 'int32',
+          'description': 'aggregate version',
+          'example': 2147483646,
+        },
+      },
+      'wow.createTime': {
+        'name': 'createTime',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'integer',
+          'format': 'int32',
+        },
+      },
+      'wow.afterId': {
+        'name': 'afterId',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'string',
+          'description': 'The ID of the last record in the batch.',
+          'example': '(0)',
+        },
+      },
+      'wow.limit': {
+        'name': 'limit',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'integer',
+          'format': 'int32',
+          'description': 'The size of batch.',
+          'example': 2147483646,
+        },
+      },
+      'wow.headVersion': {
+        'name': 'headVersion',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'integer',
+          'format': 'int32',
+          'description': 'The head version of the aggregate.',
+          'example': 1,
+        },
+      },
+      'wow.tailVersion': {
+        'name': 'tailVersion',
+        'in': 'path',
+        'required': true,
+        'schema': {
+          'type': 'integer',
+          'format': 'int32',
+          'description': 'The tail version of the aggregate.',
+          'example': 2147483646,
+        },
+      },
+    },
+    'requestBodies': {
+      'example.order.CountQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/example.OrderAggregatedCondition',
+            },
+          },
+        },
+      },
+      'example.order.ListQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/example.OrderAggregatedListQuery',
+            },
+          },
+        },
+      },
+      'example.order.PagedQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/example.OrderAggregatedPagedQuery',
+            },
+          },
+        },
+      },
+      'example.order.SingleQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/example.OrderAggregatedSingleQuery',
+            },
+          },
+        },
+      },
+      'wow.ListQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.api.query.ListQuery',
+            },
+          },
+        },
+      },
+      'wow.PagedQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.api.query.PagedQuery',
+            },
+          },
+        },
+      },
+      'wow.CountQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.api.query.Condition',
+            },
+          },
+        },
+      },
+      'wow.CompensationTarget': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/wow.messaging.CompensationTarget',
+            },
+          },
+        },
+      },
+      'example.cart.CountQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/example.CartAggregatedCondition',
+            },
+          },
+        },
+      },
+      'example.cart.ListQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/example.CartAggregatedListQuery',
+            },
+          },
+        },
+      },
+      'example.cart.PagedQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/example.CartAggregatedPagedQuery',
+            },
+          },
+        },
+      },
+      'example.cart.SingleQuery': {
+        'content': {
+          'application/json': {
+            'schema': {
+              '$ref': '#/components/schemas/example.CartAggregatedSingleQuery',
+            },
+          },
+        },
+      },
+    },
+    'headers': {
+      'wow.Wow-Error-Code': {
+        'description': 'Error code',
+        'schema': {
+          'type': 'string',
+          'example': 'Ok',
+        },
+      },
+    },
+  },
+};
 
 // This test ensures that all exports are properly defined
 describe('index.ts', () => {


### PR DESCRIPTION
- Added 'null' as a valid type in `SchemaType`.- Made `title` and `version` in `Info` interface, and `description` in `Response` interface optional.
- Added new properties `$schema`, `const`, and `default` to `Schema` interface.
