### PR TITLE
feat(wow): introduce WowMetadata interface and DescriptionCapable type

### DIFF
--- a/packages/wow/src/configuration/wowMetadata.ts
+++ b/packages/wow/src/configuration/wowMetadata.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { DescriptionCapable } from '../types';
+
+export interface ScopesCapable {
+  scopes: string[];
+}
+
+export interface Aggregate extends ScopesCapable {
+  /**
+   * Aggregate type fully qualified name
+   */
+  type: string | null;
+  /**
+   * Static tenant ID
+   */
+  tenantId: string | null;
+  /**
+   * Custom ID generator name
+   */
+  id: string | null;
+  /**
+   * Command type fully qualified name
+   */
+  commands: string[];
+  /**
+   * Domain Event type fully qualified name
+   */
+  events: string[];
+}
+
+export interface BoundedContext extends ScopesCapable, DescriptionCapable {
+  alias: string | null;
+  aggregates: Record<string, Aggregate>;
+}
+
+export interface WowMetadata extends DescriptionCapable {
+  contexts: Record<string, BoundedContext>;
+}

--- a/packages/wow/src/types/naming.ts
+++ b/packages/wow/src/types/naming.ts
@@ -24,3 +24,14 @@ export interface NamedBoundedContext {
 export interface Named {
   name: string;
 }
+
+/**
+ * Interface for entities that have a description.
+ *
+ * This interface defines a contract for objects that can provide a descriptive text.
+ * It is commonly used in conjunction with other naming interfaces to provide additional
+ * context or information about an entity.
+ */
+export interface DescriptionCapable {
+  description: string;
+}


### PR DESCRIPTION
- Add WowMetadata interface to define the structure for wow metadata
- Introduce DescriptionCapable type for entities with a description
- Update naming.ts to include the new DescriptionCapable interface