### PR TITLE
feat(command): add BatchResult interface for batch operation results

### DIFF
--- a/packages/wow/src/command/types.ts
+++ b/packages/wow/src/command/types.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { FunctionInfoCapable, Identifier } from '../types';
+import { ErrorInfo, FunctionInfoCapable, Identifier } from '../types';
 import { PartialBy } from '@ahoo-wang/fetcher';
 
 /**
@@ -149,4 +149,23 @@ export interface DeleteAggregate {
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface RecoverAggregate {
+}
+
+/**
+ * Represents the result of a batch operation, containing information about
+ * the pagination and error status of the operation.
+ *
+ * Extends ErrorInfo to include error details if the batch operation failed.
+ */
+export interface BatchResult extends ErrorInfo {
+  /**
+   * The cursor or identifier for the next item after the current batch.
+   * Used for pagination to continue fetching the next batch of items.
+   */
+  after: string;
+
+  /**
+   * The number of items in the current batch.
+   */
+  size: number;
 }


### PR DESCRIPTION
- Define BatchResult interface to represent the result of a batch operation
- Include pagination and error information in the BatchResult
- Extend ErrorInfo to include error details if the batch operation failed
- Add 'after' field for the next item cursor/identifier for pagination
- Add 'size' field for the number of items in the current batch