### PR TITLE
refactor(command): add WaitSignal interface and improve type definitions

### DIFF
--- a/packages/wow/src/command/commandResult.ts
+++ b/packages/wow/src/command/commandResult.ts
@@ -12,7 +12,7 @@
  */
 
 import type {
-  AggregateId,
+  AggregateId, AggregateIdCapable,
   AggregateNameCapable,
   ErrorInfo,
   FunctionInfoCapable,
@@ -29,6 +29,35 @@ import type {
   WaitCommandIdCapable,
 } from './types';
 import { type JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
+
+/**
+ * Represents a signal that waits for command execution completion.
+ *
+ * This interface combines multiple capabilities to provide comprehensive information
+ * about a command that is being waited upon, including identification, timing,
+ * execution results, and error information.
+ *
+ * It extends several interfaces to aggregate different aspects of command execution:
+ * - Identifier: Provides unique identification
+ * - WaitCommandIdCapable: Contains the ID of the command being waited for
+ * - CommandId: Contains the command ID
+ * - AggregateIdCapable: Provides the aggregate ID associated with the command
+ * - NullableAggregateVersionCapable: Contains optional aggregate version for concurrency control
+ * - ErrorInfo: Contains error information if command execution failed
+ * - SignalTimeCapable: Provides timestamp information
+ * - CommandResultCapable: Contains the actual command execution result
+ * - FunctionInfoCapable: Provides information about the function that processed the command
+ */
+export interface WaitSignal extends Identifier,
+  WaitCommandIdCapable,
+  CommandId,
+  AggregateIdCapable,
+  NullableAggregateVersionCapable,
+  ErrorInfo,
+  SignalTimeCapable,
+  CommandResultCapable,
+  FunctionInfoCapable {
+}
 
 /**
  * Command execution result interface
@@ -55,13 +84,6 @@ export interface CommandResult
     CommandResultCapable,
     SignalTimeCapable,
     NullableAggregateVersionCapable {
-  /**
-   * Aggregate root version number
-   * - When command processing succeeds, this is the version number after the aggregate root has completed command processing
-   * - When command validation fails at the command gateway, this is null
-   * - When command execution fails in the command handler, this is the current version number of the aggregate root
-   */
-  aggregateVersion?: number;
 }
 
 /**

--- a/packages/wow/src/command/types.ts
+++ b/packages/wow/src/command/types.ts
@@ -112,7 +112,10 @@ export interface SignalTimeCapable {
  */
 export interface NullableAggregateVersionCapable {
   /**
-   * The aggregate version of the aggregate.
+   * Aggregate root version number
+   * - When command processing succeeds, this is the version number after the aggregate root has completed command processing
+   * - When command validation fails at the command gateway, this is null
+   * - When command execution fails in the command handler, this is the current version number of the aggregate root
    */
   aggregateVersion?: number;
 }

--- a/packages/wow/src/types/modeling.ts
+++ b/packages/wow/src/types/modeling.ts
@@ -98,6 +98,23 @@ export interface AggregateId extends TenantId, NamedAggregate {
 }
 
 /**
+ * Interface that provides the capability to contain an aggregate identifier.
+ *
+ * This interface is implemented by objects that need to reference an aggregate instance
+ * through its unique identifier, which includes tenant, context, aggregate name and the
+ * actual aggregate ID.
+ */
+export interface AggregateIdCapable {
+  /**
+   * The unique identifier of the aggregate instance.
+   *
+   * Contains information about the tenant, bounded context, aggregate name and the
+   * actual aggregate ID string.
+   */
+  aggregateId: AggregateId;
+}
+
+/**
  * Interface for objects that track the last operator.
  */
 export interface OperatorCapable {


### PR DESCRIPTION
- Add WaitSignal interface to represent a signal waiting for command execution completion
- Enhance NullableAggregateVersionCapable interface with detailed comments
- Introduce AggregateIdCapable interface in modeling.ts
- Update import in commandResult.ts to include AggregateIdCapable