### PR TITLE
feat(decorator): remove deprecated `@attributes` parameter decorator

### DIFF
--- a/packages/decorator/src/functionMetadata.ts
+++ b/packages/decorator/src/functionMetadata.ts
@@ -241,9 +241,6 @@ export class FunctionMetadata implements NamedCapable {
         case ParameterType.ATTRIBUTE:
           this.processAttributeParam(funParameter, value, attributes);
           break;
-        case ParameterType.ATTRIBUTES:
-          this.processAttributesParam(value, attributes);
-          break;
       }
     });
     const urlParams: UrlParams = {
@@ -354,15 +351,12 @@ export class FunctionMetadata implements NamedCapable {
     value: any,
     attributes: Map<string, any>,
   ) {
+    if (typeof value === 'object' || value instanceof Map) {
+      mergeRecordToMap(value, attributes);
+      return;
+    }
     if (param.name && value !== undefined) {
       attributes.set(param.name, value);
     }
-  }
-
-  private processAttributesParam(value: any, attributes: Map<string, any>) {
-    if (typeof value !== 'object' || value! instanceof Map) {
-      throw new Error('@attributes() parameter must be an object or an Map');
-    }
-    mergeRecordToMap(value, attributes);
   }
 }

--- a/packages/decorator/src/parameterDecorator.ts
+++ b/packages/decorator/src/parameterDecorator.ts
@@ -80,14 +80,6 @@ export enum ParameterType {
    * information that can be accessed by interceptors.
    */
   ATTRIBUTE = 'attribute',
-  /**
-   * Attributes parameter that will be used as the request attributes.
-   *
-   * The attributes parameter allows passing custom data that can be accessed
-   * by interceptors throughout the request lifecycle. This is useful for
-   * sharing contextual information between different parts of the request processing.
-   */
-  ATTRIBUTES = 'attributes',
 }
 
 /**
@@ -323,23 +315,4 @@ export function request() {
  */
 export function attribute(name: string = '') {
   return parameter(ParameterType.ATTRIBUTE, name);
-}
-
-/**
- * Parameter decorator for adding multiple attributes to the request.
- *
- * This decorator allows you to pass an entire object as attributes that can be accessed
- * by interceptors during the request lifecycle. The parameter should be an object whose
- * properties will be merged into the request attributes.
- *
- * @returns A parameter decorator function
- *
- * @example
- * ```typescript
- * @get('/users/{id}')
- * getUser(@path('id') id: string, @attributes() attrs: Record<string, any>): Promise<Response>
- * ```
- */
-export function attributes() {
-  return parameter(ParameterType.ATTRIBUTES);
 }

--- a/packages/decorator/test/functionMetadata.test.ts
+++ b/packages/decorator/test/functionMetadata.test.ts
@@ -341,7 +341,7 @@ describe('FunctionMetadata', () => {
         'test',
         {},
         { method: HttpMethod.GET },
-        new Map([[0, { type: ParameterType.ATTRIBUTES, index: 0 }]]),
+        new Map([[0, { type: ParameterType.ATTRIBUTE, index: 0 }]]),
       );
 
       const attrs = { attr1: 'value1', attr2: 'value2' };
@@ -495,21 +495,6 @@ describe('FunctionMetadata', () => {
 
       // Arrays are objects, so Object.entries will create entries for indices
       expect(params).toEqual({ '0': 'item1', '1': 'item2' });
-    });
-  });
-
-  describe('processAttributesParam', () => {
-    it('should throw error when attributes parameter is not an object', () => {
-      const functionMetadata = new FunctionMetadata(
-        'test',
-        {},
-        { method: HttpMethod.GET },
-        new Map([[0, { type: ParameterType.ATTRIBUTES, index: 0 }]]),
-      );
-
-      expect(() => {
-        functionMetadata.resolveExchangeInit(['not-an-object']);
-      }).toThrow('@attributes() parameter must be an object');
     });
   });
 

--- a/packages/decorator/test/parameterDecorator.test.ts
+++ b/packages/decorator/test/parameterDecorator.test.ts
@@ -9,7 +9,6 @@ import {
   body,
   request,
   attribute,
-  attributes,
   PARAMETER_METADATA_KEY,
   type ParameterMetadata,
 } from '../src';
@@ -23,7 +22,6 @@ class TestClass {
     bodyParam: any,
     requestParam: any,
     attrParam: string,
-    attrsParam: Record<string, any>,
   ) {
     return {
       pathParam,
@@ -32,7 +30,6 @@ class TestClass {
       bodyParam,
       requestParam,
       attrParam,
-      attrsParam,
     };
   }
 }
@@ -46,7 +43,6 @@ describe('parameterDecorator', () => {
       expect(ParameterType.BODY).toBe('body');
       expect(ParameterType.REQUEST).toBe('request');
       expect(ParameterType.ATTRIBUTE).toBe('attribute');
-      expect(ParameterType.ATTRIBUTES).toBe('attributes');
     });
   });
 
@@ -321,26 +317,6 @@ describe('parameterDecorator', () => {
       const paramMetadata = metadata.get(5)!;
       expect(paramMetadata.type).toBe(ParameterType.ATTRIBUTE);
       expect(paramMetadata.name).toBe('attrParam');
-    });
-  });
-
-  describe('attributes', () => {
-    it('should create attributes parameter decorator', () => {
-      const decorator = attributes();
-      const target = new TestClass();
-
-      decorator(target, 'testMethod', 6);
-
-      const metadata: Map<number, ParameterMetadata> = Reflect.getMetadata(
-        PARAMETER_METADATA_KEY,
-        target,
-        'testMethod',
-      );
-
-      expect(metadata).toBeDefined();
-      const paramMetadata = metadata.get(6)!;
-      expect(paramMetadata.type).toBe(ParameterType.ATTRIBUTES);
-      expect(paramMetadata.name).toBe('attrsParam');
     });
   });
 });


### PR DESCRIPTION
The `@attributes` parameter decorator has been removed in favor of usingthe `@attribute` decorator with an object value. This change simplifiesthe API and reduces redundancy in handling request attributes.

The `ParameterType.ATTRIBUTES` enum member and its associated processing logic have also been removed from the metadata handling code.