### PR TITLE
feat(query): add generic type parameter to Condition interface

### DIFF
--- a/packages/wow/src/query/condition.ts
+++ b/packages/wow/src/query/condition.ts
@@ -24,6 +24,7 @@ export function isValidateCondition(
 ): condition is Condition {
   return !!condition;
 }
+
 /**
  * Condition option keys enumeration
  *
@@ -118,11 +119,11 @@ export function dateOptions(
  *
  * When `operator` is `AND` or `OR` or `NOR`, `children` cannot be empty.
  */
-export interface Condition {
+export interface Condition<FIELDS extends string = string> {
   /**
    * Field name for the condition
    */
-  field?: string;
+  field?: FIELDS;
 
   /**
    * Operator for the condition


### PR DESCRIPTION
Add generic type parameter FIELDS to Condition interface to allowtype

- safe field names. The field property now uses the FIELDS generic type instead of string, enabling better type checkingfor query conditions.