### PR TITLE
feat(openapi): add extension support to OpenAPI specification interfaces

### DIFF
--- a/packages/openapi/src/base-types.ts
+++ b/packages/openapi/src/base-types.ts
@@ -18,6 +18,7 @@
 import { Schema } from './schema';
 import { Reference } from './reference';
 import { MediaType } from './parameters';
+import { Extensible } from './extensions';
 
 /**
  * HTTP methods as defined in the OpenAPI specification
@@ -55,7 +56,7 @@ export type SchemaType =
  * @property description - A description of the target documentation
  * @property url - The URL for the target documentation
  */
-export interface ExternalDocumentation {
+export interface ExternalDocumentation extends Extensible {
   description?: string;
   url: string;
 }
@@ -68,7 +69,7 @@ export interface ExternalDocumentation {
  * @property value - Embedded literal example
  * @property externalValue - A URL that points to the literal example
  */
-export interface Example {
+export interface Example extends Extensible {
   summary?: string;
   description?: string;
   value?: any;
@@ -78,7 +79,7 @@ export interface Example {
 /**
  * The Header Object follows the structure of the Parameter Object
  */
-export interface Header {
+export interface Header extends Extensible {
   description?: string;
   required?: boolean;
   deprecated?: boolean;

--- a/packages/openapi/src/components.ts
+++ b/packages/openapi/src/components.ts
@@ -24,6 +24,7 @@ import { SecurityScheme } from './security';
 import { Link } from './responses';
 import { Callback } from './responses';
 import { Example, Header } from './base-types';
+import { Extensible } from './extensions';
 
 /**
  * Holds a set of reusable objects for different aspects of the OAS
@@ -38,7 +39,7 @@ import { Example, Header } from './base-types';
  * @property links - An object to hold reusable Link Objects
  * @property callbacks - An object to hold reusable Callback Objects
  */
-export interface Components {
+export interface Components extends Extensible {
   schemas?: Record<string, Schema | Reference>;
   responses?: Record<string, Response | Reference>;
   parameters?: Record<string, Parameter | Reference>;

--- a/packages/openapi/src/extensions.ts
+++ b/packages/openapi/src/extensions.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Extension support for OpenAPI Specification
+ */
+
+/**
+ * Base interface for all OpenAPI objects that support extensions
+ * Extensions are custom properties that start with "x-"
+ */
+export interface Extensible {
+  /**
+   * Extension properties that start with "x-"
+   * These can be used to add custom functionality to the OpenAPI document
+   */
+  [extension: `x-${string}`]: any;
+}
+
+/**
+ * Common extensions used in OpenAPI specifications
+ */
+export interface CommonExtensions {
+  /** Marks an element as internal use only */
+  'x-internal'?: boolean;
+  /** Deprecation information with details */
+  'x-deprecated'?: {
+    message?: string;
+    since?: string;
+    removedIn?: string;
+    replacement?: string;
+  };
+  /** Tags for categorization beyond standard tags */
+  'x-tags'?: string[];
+  /** Example values for documentation */
+  'x-examples'?: any[];
+  /** Order of display in documentation */
+  'x-order'?: number;
+  /** Groups for organizing in UI */
+  'x-group'?: string;
+}

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -28,3 +28,4 @@ export * from './security';
 export * from './schema';
 export * from './tags';
 export * from './openAPI';
+export * from './extensions';

--- a/packages/openapi/src/info.ts
+++ b/packages/openapi/src/info.ts
@@ -15,6 +15,8 @@
  * API metadata type definitions for OpenAPI Specification
  */
 
+import { Extensible } from './extensions';
+
 /**
  * Contact information for the exposed API
  *
@@ -22,7 +24,7 @@
  * @property url - The URL pointing to the contact information
  * @property email - The email address of the contact person/organization
  */
-export interface Contact {
+export interface Contact extends Extensible {
   name?: string;
   url?: string;
   email?: string;
@@ -34,7 +36,7 @@ export interface Contact {
  * @property name - The license name used for the API
  * @property url - A URL to the license used for the API
  */
-export interface License {
+export interface License extends Extensible {
   name: string;
   url?: string;
 }
@@ -49,7 +51,7 @@ export interface License {
  * @property license - The license information for the exposed API
  * @property version - The version of the OpenAPI document
  */
-export interface Info {
+export interface Info extends Extensible {
   title?: string;
   description?: string;
   termsOfService?: string;

--- a/packages/openapi/src/openAPI.ts
+++ b/packages/openapi/src/openAPI.ts
@@ -22,6 +22,7 @@ import { Components } from './components';
 import { SecurityRequirement } from './security';
 import { Tag } from './tags';
 import { ExternalDocumentation } from './base-types';
+import { Extensible } from './extensions';
 
 /**
  * Root document object for the OpenAPI specification
@@ -35,7 +36,7 @@ import { ExternalDocumentation } from './base-types';
  * @property tags - A list of tags used by the specification with additional metadata
  * @property externalDocs - Additional external documentation
  */
-export interface OpenAPI {
+export interface OpenAPI extends Extensible {
   openapi: string;
   info: Info;
   servers?: Server[];

--- a/packages/openapi/src/parameters.ts
+++ b/packages/openapi/src/parameters.ts
@@ -18,6 +18,7 @@
 import { Example, Header, ParameterLocation } from './base-types';
 import { Reference } from './reference';
 import { Schema } from './schema';
+import { Extensible } from './extensions';
 
 /**
  * Describes a single operation parameter
@@ -36,7 +37,7 @@ import { Schema } from './schema';
  * @property examples - Examples of the parameter's potential value
  * @property content - A map containing the representations for the parameter
  */
-export interface Parameter {
+export interface Parameter extends Extensible {
   name: string;
   in: ParameterLocation;
   description?: string;
@@ -59,7 +60,7 @@ export interface Parameter {
  * @property content - The content of the request body
  * @property required - Determines if the request body is required in the request
  */
-export interface RequestBody {
+export interface RequestBody extends Extensible {
   description?: string;
   content: Record<string, MediaType>;
   required?: boolean;
@@ -73,7 +74,7 @@ export interface RequestBody {
  * @property examples - Examples of the media type
  * @property encoding - A map between a property name and its encoding information
  */
-export interface MediaType {
+export interface MediaType extends Extensible {
   schema?: Schema | Reference;
   example?: any;
   examples?: Record<string, Example | Reference>;
@@ -89,7 +90,7 @@ export interface MediaType {
  * @property explode - When true, property values of type array or object generate separate parameters
  * @property allowReserved - Determines whether the parameter value should allow reserved characters
  */
-export interface Encoding {
+export interface Encoding extends Extensible {
   contentType?: string;
   headers?: Record<string, Header | Reference>;
   style?: string;

--- a/packages/openapi/src/paths.ts
+++ b/packages/openapi/src/paths.ts
@@ -23,6 +23,7 @@ import { Responses } from './responses';
 import { Callback } from './responses';
 import { SecurityRequirement } from './security';
 import { ExternalDocumentation } from './base-types';
+import { Extensible } from './extensions';
 
 /**
  * Describes a single API operation on a path
@@ -40,7 +41,7 @@ import { ExternalDocumentation } from './base-types';
  * @property security - Declaration of which security mechanisms can be used for this operation
  * @property servers - Alternative server array to service this operation
  */
-export interface Operation {
+export interface Operation extends Extensible {
   tags?: string[];
   summary?: string;
   description?: string;
@@ -72,7 +73,7 @@ export interface Operation {
  * @property servers - Alternative server array to service all operations in this path
  * @property parameters - List of parameters that are applicable for all operations in this path
  */
-export interface PathItem {
+export interface PathItem extends Extensible {
   $ref?: string;
   summary?: string;
   description?: string;
@@ -91,6 +92,6 @@ export interface PathItem {
 /**
  * Holds the relative paths to the individual endpoints and their operations
  */
-export interface Paths {
+export interface Paths extends Extensible {
   [path: string]: PathItem;
 }

--- a/packages/openapi/src/responses.ts
+++ b/packages/openapi/src/responses.ts
@@ -20,6 +20,7 @@ import { MediaType } from './parameters';
 import { Server } from './server';
 import { PathItem } from './paths';
 import { Header } from './base-types';
+import { Extensible } from './extensions';
 
 /**
  * The Link object represents a possible design-time link for a response
@@ -31,7 +32,7 @@ import { Header } from './base-types';
  * @property description - A description of the link
  * @property server - A server object to be used by the target operation
  */
-export interface Link {
+export interface Link extends Extensible {
   operationRef?: string;
   operationId?: string;
   parameters?: Record<string, any>;
@@ -48,7 +49,7 @@ export interface Link {
  * @property content - A map containing descriptions of potential response payloads
  * @property links - A map of operations links that can be followed from the response
  */
-export interface Response {
+export interface Response extends Extensible {
   description?: string;
   headers?: Record<string, Header | Reference>;
   content?: Record<string, MediaType>;
@@ -58,7 +59,7 @@ export interface Response {
 /**
  * A container for the expected responses of an operation
  */
-export interface Responses {
+export interface Responses extends Extensible {
   default?: Response | Reference;
 
   [httpCode: string]: Response | Reference | undefined;
@@ -67,6 +68,6 @@ export interface Responses {
 /**
  * A map of possible out-of-band callbacks related to the parent operation
  */
-export interface Callback {
+export interface Callback extends Extensible {
   [expression: string]: PathItem;
 }

--- a/packages/openapi/src/schema.ts
+++ b/packages/openapi/src/schema.ts
@@ -17,6 +17,7 @@
 
 import { ExternalDocumentation, SchemaType } from './base-types';
 import { Reference } from './reference';
+import { Extensible } from './extensions';
 
 /**
  * Adds support for polymorphism using discriminator
@@ -24,7 +25,7 @@ import { Reference } from './reference';
  * @property propertyName - The name of the property in the payload that will hold the discriminator value
  * @property mapping - An object to hold mappings between payload values and schema names or references
  */
-export interface Discriminator {
+export interface Discriminator extends Extensible {
   propertyName: string;
   mapping?: Record<string, string>;
 }
@@ -38,7 +39,7 @@ export interface Discriminator {
  * @property attribute - Declares whether the property definition translates to an attribute instead of an element
  * @property wrapped - MAY be used only for an array definition and signifies whether the array is wrapped
  */
-export interface XML {
+export interface XML extends Extensible {
   name?: string;
   namespace?: string;
   prefix?: string;
@@ -87,7 +88,7 @@ export interface XML {
  * @property xml - Additional metadata for XML formatting
  * @property externalDocs - Additional external documentation for this schema
  */
-export interface Schema {
+export interface Schema extends Extensible {
   $schema?: string;
   // General properties
   title?: string;

--- a/packages/openapi/src/security.ts
+++ b/packages/openapi/src/security.ts
@@ -16,6 +16,7 @@
  */
 
 import { ParameterLocation } from './base-types';
+import { Extensible } from './extensions';
 
 /**
  * Configuration details for a supported OAuth Flow
@@ -25,7 +26,7 @@ import { ParameterLocation } from './base-types';
  * @property refreshUrl - The URL to be used for obtaining refresh tokens
  * @property scopes - The available scopes for the OAuth2 security scheme
  */
-export interface OAuthFlow {
+export interface OAuthFlow extends Extensible {
   authorizationUrl?: string;
   tokenUrl?: string;
   refreshUrl?: string;
@@ -40,7 +41,7 @@ export interface OAuthFlow {
  * @property clientCredentials - Configuration for the OAuth Client Credentials flow
  * @property authorizationCode - Configuration for the OAuth Authorization Code flow
  */
-export interface OAuthFlows {
+export interface OAuthFlows extends Extensible {
   implicit?: OAuthFlow;
   password?: OAuthFlow;
   clientCredentials?: OAuthFlow;
@@ -59,7 +60,7 @@ export interface OAuthFlows {
  * @property flows - An object containing configuration information for the flow types supported
  * @property openIdConnectUrl - OpenId Connect URL to discover OAuth2 configuration values
  */
-export interface SecurityScheme {
+export interface SecurityScheme extends Extensible {
   type: 'apiKey' | 'http' | 'oauth2' | 'openIdConnect';
   description?: string;
   name?: string;
@@ -73,6 +74,6 @@ export interface SecurityScheme {
 /**
  * Lists the required security schemes to execute this operation
  */
-export interface SecurityRequirement {
+export interface SecurityRequirement extends Extensible {
   [name: string]: string[];
 }

--- a/packages/openapi/src/server.ts
+++ b/packages/openapi/src/server.ts
@@ -15,6 +15,8 @@
  * Server configuration type definitions for OpenAPI Specification
  */
 
+import { Extensible } from './extensions';
+
 /**
  * Server variable for URL template substitution
  *
@@ -22,7 +24,7 @@
  * @property default - The default value to use for substitution
  * @property description - An optional description for the server variable
  */
-export interface ServerVariable {
+export interface ServerVariable extends Extensible {
   enum?: string[];
   default: string;
   description?: string;
@@ -35,7 +37,7 @@ export interface ServerVariable {
  * @property description - An optional string describing the host designated by the URL
  * @property variables - A map between a variable name and its value
  */
-export interface Server {
+export interface Server extends Extensible {
   url: string;
   description?: string;
   variables?: Record<string, ServerVariable>;

--- a/packages/openapi/src/tags.ts
+++ b/packages/openapi/src/tags.ts
@@ -12,6 +12,7 @@
  */
 
 import { ExternalDocumentation } from './base-types';
+import { Extensible } from './extensions';
 
 /**
  * Adds metadata to a single tag that is used by the Operation Object
@@ -20,7 +21,7 @@ import { ExternalDocumentation } from './base-types';
  * @property description - A description for the tag
  * @property externalDocs - Additional external documentation for this tag
  */
-export interface Tag {
+export interface Tag extends Extensible {
   name: string;
   description?: string;
   externalDocs?: ExternalDocumentation;


### PR DESCRIPTION
- Created new `Extensible` interface with `x-` prefixed extension properties
- Added `CommonExtensions` interface with frequently used extensions
- Extended all OpenAPI interfaces to support custom extensions
- Added extension support to Contact, License, Info, Server, Tag interfaces
- Extended ExternalDocumentation, Example, Header with extensibility
- Updated Components, OpenAPI, Parameter, RequestBody, MediaType interfaces
- Added extension support to Encoding, Operation, PathItem, Paths interfaces
- Extended Link, Response, Responses, Callback with extension capabilities
- Updated Discriminator, XML, Schema interfaces with extensibility
- Added extension support to OAuthFlow, OAuthFlows, SecurityScheme interfaces
- Extended ServerVariable and SecurityRequirement with custom extensions
- Exported extensions module in main index file