### PR TITLE
feat(wow): make DomainEventStream generic with DomainEventBody type parameter

### DIFF
--- a/packages/wow/src/query/event/domainEventStream.ts
+++ b/packages/wow/src/query/event/domainEventStream.ts
@@ -89,7 +89,7 @@ export interface DomainEventStreamHeader {
  * including identification, aggregation, ownership, command information,
  * versioning, and the actual event data.
  */
-export interface DomainEventStream
+export interface DomainEventStream<DomainEventBody = any>
   extends Identifier,
     AggregateId,
     OwnerId,
@@ -97,7 +97,7 @@ export interface DomainEventStream
     CreateTimeCapable,
     RequestId,
     Version,
-    BodyCapable<DomainEvent<any>[]> {
+    BodyCapable<DomainEvent<DomainEventBody>[]> {
   /**
    * The header information for the domain event stream.
    */


### PR DESCRIPTION


- Added generic type parameter DomainEventBody to DomainEventStream interface
- Updated BodyCapable extension to use DomainEventBody type parameter
- Enhanced type safety for domain event stream body content