### PR TITLE
feat(query): add generic field type parameter to query interfaces and clients

### DIFF
--- a/packages/wow/src/query/event/eventStreamQueryApi.ts
+++ b/packages/wow/src/query/event/eventStreamQueryApi.ts
@@ -21,8 +21,8 @@ import type { QueryApi } from '../queryApi';
  * @template DomainEventStream - The type of domain event stream this API works with
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface EventStreamQueryApi
-  extends Omit<QueryApi<DomainEventStream>, 'single'> {
+export interface EventStreamQueryApi<FIELDS extends string = string>
+  extends Omit<QueryApi<DomainEventStream, FIELDS>, 'single'> {
 }
 
 /**

--- a/packages/wow/src/query/event/eventStreamQueryClient.ts
+++ b/packages/wow/src/query/event/eventStreamQueryClient.ts
@@ -69,9 +69,9 @@ import { ContentTypeValues, mergeRequestOptions } from '@ahoo-wang/fetcher';
  * const paged = await eventStreamQueryClient.paged(pagedQuery);
  * ```
  */
-export class EventStreamQueryClient
-  extends QueryClient
-  implements EventStreamQueryApi {
+export class EventStreamQueryClient<FIELDS extends string = string>
+  extends QueryClient<FIELDS>
+  implements EventStreamQueryApi<FIELDS> {
   /**
    * Creates a new EventStreamQueryClient instance.
    * @param options - The client configuration options including fetcher and base path
@@ -96,7 +96,7 @@ export class EventStreamQueryClient
    * ```
    */
   count(
-    condition: Condition,
+    condition: Condition<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<number> {
     return this.query(EventStreamQueryEndpointPaths.COUNT, condition, {
@@ -125,7 +125,7 @@ export class EventStreamQueryClient
    * ```
    */
   list<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T[]> {
     return this.query(EventStreamQueryEndpointPaths.LIST, listQuery, {
@@ -156,7 +156,7 @@ export class EventStreamQueryClient
    * ```
    */
   listStream<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<ReadableStream<JsonServerSentEvent<T>>> {
     return this.query(
@@ -194,7 +194,7 @@ export class EventStreamQueryClient
    * ```
    */
   paged<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(
-    pagedQuery: PagedQuery,
+    pagedQuery: PagedQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<PagedList<T>> {
     return this.query(EventStreamQueryEndpointPaths.PAGED, pagedQuery, {

--- a/packages/wow/src/query/queryApi.ts
+++ b/packages/wow/src/query/queryApi.ts
@@ -49,7 +49,7 @@ export const JSON_EVENT_STREAM_QUERY_REQUEST_OPTIONS: RequestOptions = {
  * @see {@link SnapshotQueryApi}
  * @template R - The type of resource being queried
  */
-export interface QueryApi<R> {
+export interface QueryApi<R, FIELDS extends string = string> {
   /**
    * Retrieves a single resource based on the provided query parameters.
    * @param singleQuery - The query parameters for retrieving a single resource
@@ -59,7 +59,7 @@ export interface QueryApi<R> {
    * @returns A promise that resolves to a partial resource
    */
   single<T extends Partial<R> = Partial<R>>(
-    singleQuery: SingleQuery,
+    singleQuery: SingleQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T>;
 
@@ -72,7 +72,7 @@ export interface QueryApi<R> {
    * @returns A promise that resolves to an array of partial resources
    */
   list<T extends Partial<R> = Partial<R>>(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T[]>;
 
@@ -85,7 +85,7 @@ export interface QueryApi<R> {
    * @returns A promise that resolves to a readable stream of JSON server-sent events containing partial resources
    */
   listStream<T extends Partial<R> = Partial<R>>(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<ReadableStream<JsonServerSentEvent<T>>>;
 
@@ -98,7 +98,7 @@ export interface QueryApi<R> {
    * @returns A promise that resolves to a paged list of partial resources
    */
   paged<T extends Partial<R> = Partial<R>>(
-    pagedQuery: PagedQuery,
+    pagedQuery: PagedQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<PagedList<T>>;
 
@@ -111,7 +111,7 @@ export interface QueryApi<R> {
    * @returns A promise that resolves to the count of matching resources
    */
   count(
-    condition: Condition,
+    condition: Condition<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<number>;
 }
@@ -124,7 +124,7 @@ export interface QueryApi<R> {
  * @see {@link EventStreamQueryClient}
  * @see {@link SnapshotQueryClient}
  */
-export class QueryClient {
+export class QueryClient<FIELDS extends string = string> {
   /**
    * Creates a new QueryClient instance.
    * @param options - The client configuration options including fetcher and base path
@@ -148,7 +148,7 @@ export class QueryClient {
    */
   protected async query<R>(
     path: string,
-    query: Condition | ListQuery | PagedQuery | SingleQuery,
+    query: Condition<FIELDS> | ListQuery<FIELDS> | PagedQuery<FIELDS> | SingleQuery<FIELDS>,
     options?: RequestOptions,
     accept: string = ContentTypeValues.APPLICATION_JSON,
   ): Promise<R> {

--- a/packages/wow/src/query/snapshot/snapshotQueryApi.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryApi.ts
@@ -27,7 +27,7 @@ import type { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
  * for querying snapshot states directly without the full MaterializedSnapshot wrapper.
  * @template S - The type of the snapshot state
  */
-export interface SnapshotQueryApi<S> extends QueryApi<MaterializedSnapshot<S>> {
+export interface SnapshotQueryApi<S, FIELDS extends string = string> extends QueryApi<MaterializedSnapshot<S>, FIELDS> {
   /**
    * Retrieves a single snapshot state based on the provided query parameters.
    * @param singleQuery - The query parameters for retrieving a single snapshot state
@@ -37,7 +37,7 @@ export interface SnapshotQueryApi<S> extends QueryApi<MaterializedSnapshot<S>> {
    * @returns A promise that resolves to a partial snapshot state
    */
   singleState<T extends Partial<S> = Partial<S>>(
-    singleQuery: SingleQuery,
+    singleQuery: SingleQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T>;
 
@@ -50,7 +50,7 @@ export interface SnapshotQueryApi<S> extends QueryApi<MaterializedSnapshot<S>> {
    * @returns A promise that resolves to an array of partial snapshot states
    */
   listState<T extends Partial<S> = Partial<S>>(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T[]>;
 
@@ -63,7 +63,7 @@ export interface SnapshotQueryApi<S> extends QueryApi<MaterializedSnapshot<S>> {
    * @returns A promise that resolves to a readable stream of JSON server-sent events containing partial snapshot states
    */
   listStateStream<T extends Partial<S> = Partial<S>>(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<ReadableStream<JsonServerSentEvent<T>>>;
 
@@ -76,7 +76,7 @@ export interface SnapshotQueryApi<S> extends QueryApi<MaterializedSnapshot<S>> {
    * @returns A promise that resolves to a paged list of partial snapshot states
    */
   pagedState<T extends Partial<S> = Partial<S>>(
-    pagedQuery: PagedQuery,
+    pagedQuery: PagedQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<PagedList<T>>;
 }

--- a/packages/wow/src/query/snapshot/snapshotQueryClient.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryClient.ts
@@ -109,9 +109,9 @@ import {
  *
  * @template S The type of the snapshot state
  */
-export class SnapshotQueryClient<S>
-  extends QueryClient
-  implements SnapshotQueryApi<S> {
+export class SnapshotQueryClient<S, FIELDS extends string = string>
+  extends QueryClient<FIELDS>
+  implements SnapshotQueryApi<S, FIELDS> {
   /**
    * Creates a new SnapshotQueryClient instance.
    * @param options - The configuration options for the client
@@ -136,7 +136,7 @@ export class SnapshotQueryClient<S>
    * ```
    */
   async count(
-    condition: Condition,
+    condition: Condition<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<number> {
     return this.query(SnapshotQueryEndpointPaths.COUNT, condition, {
@@ -168,7 +168,7 @@ export class SnapshotQueryClient<S>
     T extends Partial<MaterializedSnapshot<S>> = Partial<
       MaterializedSnapshot<S>
     >,
-  >(listQuery: ListQuery, attributes?: Record<string, any>): Promise<T[]> {
+  >(listQuery: ListQuery<FIELDS>, attributes?: Record<string, any>): Promise<T[]> {
     return this.query(SnapshotQueryEndpointPaths.LIST, listQuery, {
       attributes,
     });
@@ -200,7 +200,7 @@ export class SnapshotQueryClient<S>
       MaterializedSnapshot<S>
     >,
   >(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<ReadableStream<JsonServerSentEvent<T>>> {
     return this.query(
@@ -235,7 +235,7 @@ export class SnapshotQueryClient<S>
    * ```
    */
   listState<T extends Partial<S> = Partial<S>>(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T[]> {
     return this.query(SnapshotQueryEndpointPaths.LIST_STATE, listQuery, {
@@ -265,7 +265,7 @@ export class SnapshotQueryClient<S>
    * ```
    */
   listStateStream<T extends Partial<S> = Partial<S>>(
-    listQuery: ListQuery,
+    listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<ReadableStream<JsonServerSentEvent<T>>> {
     return this.query(
@@ -307,7 +307,7 @@ export class SnapshotQueryClient<S>
       MaterializedSnapshot<S>
     >,
   >(
-    pagedQuery: PagedQuery,
+    pagedQuery: PagedQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<PagedList<T>> {
     return this.query(SnapshotQueryEndpointPaths.PAGED, pagedQuery, {
@@ -338,7 +338,7 @@ export class SnapshotQueryClient<S>
    * ```
    */
   pagedState<T extends Partial<S> = Partial<S>>(
-    pagedQuery: PagedQuery,
+    pagedQuery: PagedQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<PagedList<T>> {
     return this.query(SnapshotQueryEndpointPaths.PAGED_STATE, pagedQuery, {
@@ -368,7 +368,7 @@ export class SnapshotQueryClient<S>
     T extends Partial<MaterializedSnapshot<S>> = Partial<
       MaterializedSnapshot<S>
     >,
-  >(singleQuery: SingleQuery, attributes?: Record<string, any>): Promise<T> {
+  >(singleQuery: SingleQuery<FIELDS>, attributes?: Record<string, any>): Promise<T> {
     return this.query(SnapshotQueryEndpointPaths.SINGLE, singleQuery, {
       attributes,
     });
@@ -393,7 +393,7 @@ export class SnapshotQueryClient<S>
    * ```
    */
   singleState<T extends Partial<S> = Partial<S>>(
-    singleQuery: SingleQuery,
+    singleQuery: SingleQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T> {
     return this.query(SnapshotQueryEndpointPaths.SINGLE_STATE, singleQuery, {


### PR DESCRIPTION

- Added FIELDS generic type parameter to QueryApi interface
- Updated EventStreamQueryApi to accept FIELDS generic type
- Modified SnapshotQueryApi to include FIELDS generic type
- Enhanced QueryClient with FIELDS generic type parameter
- Updated method signatures to use FIELDS-typed query parameters
- Changed Condition, ListQuery, PagedQuery, and SingleQuery to use FIELDS types