### PR TITLE
feat(query): extend domain event stream with state and operator capabilities

### DIFF
--- a/packages/wow/src/query/event/domainEventStream.ts
+++ b/packages/wow/src/query/event/domainEventStream.ts
@@ -13,10 +13,10 @@
 
 import type {
   AggregateId,
-  CreateTimeCapable,
+  CreateTimeCapable, DeletedCapable, FirstEventTimeCapable, FirstOperatorCapable,
   Identifier,
   Named,
-  OwnerId,
+  OwnerId, StateCapable,
   Version,
 } from '../../types';
 import type { CommandId, CommandStage, RequestId } from '../../command';
@@ -102,6 +102,10 @@ export interface DomainEventStream<DomainEventBody = any>
    * The header information for the domain event stream.
    */
   header: DomainEventStreamHeader;
+}
+
+export interface StateEvent<DomainEventBody = any, S = any> extends DomainEventStream<DomainEventBody>, StateCapable<S>, FirstOperatorCapable, FirstEventTimeCapable, DeletedCapable {
+
 }
 
 /**

--- a/packages/wow/src/query/snapshot/snapshot.ts
+++ b/packages/wow/src/query/snapshot/snapshot.ts
@@ -53,7 +53,7 @@ export interface MaterializedSnapshot<S>
  * Each snapshot corresponds to a specific version of the state within a tenant and owner context,
  * and records information such as event IDs and operation times to support tracing and auditing.
  */
-export interface MaterializedSnapshot<S>
+export interface MediumMaterializedSnapshot<S>
   extends StateCapable<S>,
     NamedAggregate,
     TenantId,


### PR DESCRIPTION


- Added DeletedCapable, FirstEventTimeCapable, FirstOperatorCapable, and StateCapable to domain event stream imports
- Created StateEvent interface extending DomainEventStream with state and operator capabilities
- Renamed MaterializedSnapshot to MediumMaterializedSnapshot in snapshot module