### PR TITLE
refactor(decorator): remove target fetcher resolution logic

### DIFF
--- a/packages/decorator/src/requestExecutor.ts
+++ b/packages/decorator/src/requestExecutor.ts
@@ -29,32 +29,12 @@ export class RequestExecutor {
 
   /**
    * Creates a new RequestExecutor instance.
-   *
+   * @param target - The target object that the method is called on.
+   *                 This can contain a custom fetcher instance in its 'fetcher' property.
    * @param metadata - The function metadata containing all request information
    */
   constructor(private readonly target: any,
               private readonly metadata: FunctionMetadata) {
-  }
-
-  /**
-   * Retrieves the fetcher instance from the target object.
-   *
-   * @returns The fetcher instance if exists, otherwise undefined
-   */
-  private getTargetFetcher(): Fetcher | undefined {
-    if (!this.target || typeof this.target !== 'object') {
-      return undefined;
-    }
-    // Extract the fetcher property from the target object
-    const fetcher = this.target[TARGET_FETCHER_PROPERTY];
-
-    // Validate that the fetcher is an instance of the Fetcher class
-    if (fetcher instanceof Fetcher) {
-      return fetcher;
-    }
-
-    // Return undefined if no valid fetcher instance is found
-    return undefined;
   }
 
   /**
@@ -65,8 +45,7 @@ export class RequestExecutor {
    * It handles the complete request lifecycle from parameter processing to
    * response extraction.
    *
-   * @param target - The target object that the method is called on.
-   *                 This can contain a custom fetcher instance in its 'fetcher' property.
+
    * @param args - The runtime arguments passed to the decorated method.
    *               These are mapped to request components based on parameter decorators.
    * @returns A Promise that resolves to the extracted result based on the configured result extractor.
@@ -95,7 +74,7 @@ export class RequestExecutor {
    * ```
    */
   async execute(args: any[]): Promise<any> {
-    const fetcher = this.getTargetFetcher() || this.metadata.fetcher;
+    const fetcher = this.metadata.fetcher;
     const exchangeInit = this.metadata.resolveExchangeInit(args);
     exchangeInit.attributes?.set(DECORATOR_TARGET_ATTRIBUTE_KEY, this.target);
     const extractor = this.metadata.resolveResultExtractor();
@@ -110,7 +89,6 @@ export class RequestExecutor {
     return exchange.extractResult();
   }
 }
-
 
 export interface RequestExecutorsCapable {
   requestExecutors: Map<string, RequestExecutor>;

--- a/packages/decorator/test/requestExecutor.test.ts
+++ b/packages/decorator/test/requestExecutor.test.ts
@@ -54,44 +54,6 @@ describe('RequestExecutor', () => {
     });
   });
 
-  describe('getTargetFetcher', () => {
-    it('should return undefined when target is null', () => {
-      const executor = new RequestExecutor(null, mockFunctionMetadata);
-      // @ts-expect-error - accessing private method for testing
-      const result = executor.getTargetFetcher();
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined when target is not an object', () => {
-      const executor = new RequestExecutor('not-an-object', mockFunctionMetadata);
-      // @ts-expect-error - accessing private method for testing
-      const result = executor.getTargetFetcher();
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined when target has no fetcher property', () => {
-      const executor = new RequestExecutor({}, mockFunctionMetadata);
-      // @ts-expect-error - accessing private method for testing
-      const result = executor.getTargetFetcher();
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined when target fetcher is not a Fetcher instance', () => {
-      const executor = new RequestExecutor({ fetcher: 'not-a-fetcher' }, mockFunctionMetadata);
-      // @ts-expect-error - accessing private method for testing
-      const result = executor.getTargetFetcher();
-      expect(result).toBeUndefined();
-    });
-
-    it('should return fetcher when target has a valid Fetcher instance', () => {
-      const mockFetcher = new MockFetcher();
-      const executor = new RequestExecutor({ fetcher: mockFetcher }, mockFunctionMetadata);
-      // @ts-expect-error - accessing private method for testing
-      const result = executor.getTargetFetcher();
-      expect(result).toBe(mockFetcher);
-    });
-  });
-
   describe('execute', () => {
     it('should execute request with metadata fetcher when target has no fetcher', async () => {
       const mockFetcher = new MockFetcher();
@@ -118,38 +80,6 @@ describe('RequestExecutor', () => {
           attributes: new Map([[DECORATOR_TARGET_ATTRIBUTE_KEY, {}]]),
         },
       );
-    });
-
-    it('should execute request with target fetcher when available', async () => {
-      const targetFetcher = new MockFetcher();
-      const metadataFetcher = new MockFetcher();
-
-      const metadataWithFetcher = new FunctionMetadata(
-        'getUser',
-        { ...mockApiMetadata, fetcher: metadataFetcher },
-        mockEndpointMetadata,
-        mockParameterMetadata,
-      );
-
-      const executor = new RequestExecutor({ fetcher: targetFetcher }, metadataWithFetcher);
-      const target = { fetcher: targetFetcher };
-      await executor.execute(['123', 'active']);
-      expect(targetFetcher.exchange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: HttpMethod.GET,
-          url: '/api/v1/users/{id}', // URL template is not processed by FunctionMetadata
-          urlParams: {
-            path: { id: '123' },
-            query: { filter: 'active' },
-          },
-        }),
-        {
-          resultExtractor: JsonResultExtractor,
-          attributes: new Map([[DECORATOR_TARGET_ATTRIBUTE_KEY, target]]),
-        },
-      );
-      // Ensure metadata fetcher was not called
-      expect(metadataFetcher.exchange).not.toHaveBeenCalled();
     });
 
     it('should use endpoint result type when defined', async () => {


### PR DESCRIPTION
- Removed getTargetFetcher method and related tests
- Simplified fetcher resolution to only use metadata fetcher
- Updated constructor JSDoc to clarify target parameter usage
- Removed redundant test cases for target fetcher scenarios
- Cleaned up execute method by removing target fetcher fallback logic