### PR TITLE
refactor(types): rename PathParams to UrlPathParams

### DIFF
--- a/packages/wow/src/command/commandRequest.ts
+++ b/packages/wow/src/command/commandRequest.ts
@@ -17,7 +17,7 @@ import type {
   UrlParams,
 } from '@ahoo-wang/fetcher';
 import { CommandHttpHeaders } from './commandHttpHeaders';
-import { type PathParams } from '../types/endpoints';
+import { type UrlPathParams } from '../types/endpoints';
 
 /**
  * Command Request Headers Interface
@@ -146,7 +146,7 @@ export interface CommandRequestHeaders extends RequestHeaders {
 }
 
 export interface CommandUrlParams extends Omit<UrlParams, 'path' | 'query'> {
-  path?: PathParams;
+  path?: UrlPathParams;
 }
 
 /**

--- a/packages/wow/src/types/endpoints.ts
+++ b/packages/wow/src/types/endpoints.ts
@@ -16,7 +16,7 @@
  * Defines common path parameters and allows for additional custom parameters.
  * This interface is used to provide path variables for URL templating.
  */
-export interface PathParams {
+export interface UrlPathParams {
   /**
    * Tenant identifier parameter.
    * Used in multi-tenant applications to identify the tenant context.


### PR DESCRIPTION
- Renamed PathParams interface to UrlPathParams for clarity
- Updated import statements to use UrlPathParams
- Changed CommandUrlParams path property type to UrlPathParams
- Improved type consistency across command request interfaces