### PR TITLE
feat(query): enhance type safety for event stream queries

### DIFF
--- a/packages/wow/src/query/event/eventStreamQueryApi.ts
+++ b/packages/wow/src/query/event/eventStreamQueryApi.ts
@@ -21,8 +21,8 @@ import type { QueryApi } from '../queryApi';
  * @template DomainEventStream - The type of domain event stream this API works with
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface EventStreamQueryApi<FIELDS extends string = string>
-  extends Omit<QueryApi<DomainEventStream, FIELDS>, 'single'> {
+export interface EventStreamQueryApi<DomainEventBody = any, FIELDS extends string = string>
+  extends Omit<QueryApi<DomainEventStream<DomainEventBody>, FIELDS>, 'single'> {
 }
 
 /**

--- a/packages/wow/src/query/event/eventStreamQueryClient.ts
+++ b/packages/wow/src/query/event/eventStreamQueryClient.ts
@@ -75,8 +75,8 @@ import {
  * ```
  */
 @api()
-export class EventStreamQueryClient<FIELDS extends string = string>
-  implements EventStreamQueryApi<FIELDS>, ApiMetadataCapable {
+export class EventStreamQueryClient<DomainEventBody = any, FIELDS extends string = string>
+  implements EventStreamQueryApi<DomainEventBody, FIELDS>, ApiMetadataCapable {
   /**
    * Creates a new EventStreamQueryClient instance.
    */
@@ -127,7 +127,7 @@ export class EventStreamQueryClient<FIELDS extends string = string>
    * ```
    */
   @post(EventStreamQueryEndpointPaths.LIST)
-  list<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(
+  list<T extends Partial<DomainEventStream<DomainEventBody>> = DomainEventStream<DomainEventBody>>(
     @body() listQuery: ListQuery<FIELDS>,
     @attribute() attributes?: Record<string, any>,
   ): Promise<T[]> {
@@ -160,7 +160,7 @@ export class EventStreamQueryClient<FIELDS extends string = string>
     headers: { Accept: ContentTypeValues.TEXT_EVENT_STREAM },
     resultExtractor: JsonEventStreamResultExtractor,
   })
-  listStream<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(
+  listStream<T extends Partial<DomainEventStream<DomainEventBody>> = DomainEventStream<DomainEventBody>>(
     @body() listQuery: ListQuery<FIELDS>,
     @attribute() attributes?: Record<string, any>,
   ): Promise<ReadableStream<JsonServerSentEvent<T>>> {
@@ -191,7 +191,7 @@ export class EventStreamQueryClient<FIELDS extends string = string>
    * ```
    */
   @post(EventStreamQueryEndpointPaths.PAGED)
-  paged<T extends Partial<DomainEventStream> = Partial<DomainEventStream>>(
+  paged<T extends Partial<DomainEventStream<DomainEventBody>> = DomainEventStream<DomainEventBody>>(
     @body() pagedQuery: PagedQuery<FIELDS>,
     @attribute() attributes?: Record<string, any>,
   ): Promise<PagedList<T>> {

--- a/packages/wow/src/query/queryApi.ts
+++ b/packages/wow/src/query/queryApi.ts
@@ -40,7 +40,7 @@ export interface QueryApi<R, FIELDS extends string = string> {
    *                     custom data between different interceptors.
    * @returns A promise that resolves to a partial resource
    */
-  single<T extends Partial<R> = Partial<R>>(
+  single<T extends Partial<R> = R>(
     singleQuery: SingleQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T>;
@@ -53,7 +53,7 @@ export interface QueryApi<R, FIELDS extends string = string> {
    *                     custom data between different interceptors.
    * @returns A promise that resolves to an array of partial resources
    */
-  list<T extends Partial<R> = Partial<R>>(
+  list<T extends Partial<R> = R>(
     listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<T[]>;
@@ -66,7 +66,7 @@ export interface QueryApi<R, FIELDS extends string = string> {
    *                     custom data between different interceptors.
    * @returns A promise that resolves to a readable stream of JSON server-sent events containing partial resources
    */
-  listStream<T extends Partial<R> = Partial<R>>(
+  listStream<T extends Partial<R> = R>(
     listQuery: ListQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<ReadableStream<JsonServerSentEvent<T>>>;
@@ -79,7 +79,7 @@ export interface QueryApi<R, FIELDS extends string = string> {
    *                     custom data between different interceptors.
    * @returns A promise that resolves to a paged list of partial resources
    */
-  paged<T extends Partial<R> = Partial<R>>(
+  paged<T extends Partial<R> = R>(
     pagedQuery: PagedQuery<FIELDS>,
     attributes?: Record<string, any>,
   ): Promise<PagedList<T>>;


### PR DESCRIPTION
- Add generic DomainEventBody type parameter to EventStreamQueryApi
- Update EventStreamQueryClient to support DomainEventBody generic
- Refactor list, listStream, and paged methods to use DomainEventBody
- Improve QueryApi method signatures with better type constraints
- Remove unnecessary Partial wrapper in default type parameters