### PR TITLE
fix(command): make command request body optional

### DIFF
--- a/packages/wow/src/command/commandRequest.ts
+++ b/packages/wow/src/command/commandRequest.ts
@@ -162,5 +162,5 @@ export interface CommandRequest<C extends object = object>
   /**
    * The body of the command request.
    */
-  body: C;
+  body?: C;
 }


### PR DESCRIPTION
- Updated CommandRequest interface to allow optional body property
- Changed body type from required C to optional C | undefined
- This change enables commands that don't require a body payload