### PR TITLE
refactor(command): remove RequiredBy constraint from CommandRequest

### DIFF
--- a/packages/wow/src/command/commandRequest.ts
+++ b/packages/wow/src/command/commandRequest.ts
@@ -12,7 +12,7 @@
  */
 
 import type {
-  RequestHeaders, RequiredBy,
+  RequestHeaders,
   UrlParams,
 } from '@ahoo-wang/fetcher';
 import { CommandHeaders } from './commandHeaders';

--- a/packages/wow/src/command/commandRequest.ts
+++ b/packages/wow/src/command/commandRequest.ts
@@ -156,7 +156,7 @@ export interface CommandUrlParams extends Omit<UrlParams, 'path' | 'query'> {
  * This interface includes only the essential command headers commonly used in HTTP requests.
  */
 export interface CommandRequest<C extends object = object>
-  extends RequiredBy<ParameterRequest, 'path'> {
+  extends ParameterRequest {
   urlParams?: CommandUrlParams;
   headers?: CommandRequestHeaders;
   /**


### PR DESCRIPTION
- Removed RequiredBy<ParameterRequest, 'path'> constraint
- Made path parameter optional in CommandRequest interface
- Updated interface to extend ParameterRequest directly
- Maintained backward compatibility with existing implementations