### PR TITLE
feat(wow): add resource attribution path specifications enum

### DIFF
--- a/packages/wow/src/types/endpoints.ts
+++ b/packages/wow/src/types/endpoints.ts
@@ -39,3 +39,24 @@ export interface UrlPathParams {
    */
   [key: string]: string | undefined;
 }
+
+/**
+ * Enumeration of resource attribution path specifications.
+ * Defines standard path patterns for accessing resources with different attribution scopes.
+ * These paths are used to construct URLs that include tenant and/or owner identifiers.
+ *
+ * @example
+ * ```typescript
+ * // Using TENANT path spec
+ * const path = ResourceAttributionPathSpec.TENANT; // 'tenant/{tenantId}'
+ *
+ * // Using TENANT_OWNER path spec
+ * const path = ResourceAttributionPathSpec.TENANT_OWNER; // 'tenant/{tenantId}/owner/{ownerId}'
+ * ```
+ */
+export enum ResourceAttributionPathSpec {
+  DEFAULT = '',
+  TENANT = 'tenant/{tenantId}',
+  OWNER = 'owner/{ownerId}',
+  TENANT_OWNER = 'tenant/{tenantId}/owner/{ownerId}',
+}

--- a/packages/wow/test/types/endpoints.test.ts
+++ b/packages/wow/test/types/endpoints.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ResourceAttributionPathSpec, UrlPathParams } from '../../src/types/endpoints';
+
+describe('endpoints', () => {
+  describe('ResourceAttributionPathSpec', () => {
+    it('should define correct path specifications', () => {
+      expect(ResourceAttributionPathSpec.DEFAULT).toBe('');
+      expect(ResourceAttributionPathSpec.TENANT).toBe('tenant/{tenantId}');
+      expect(ResourceAttributionPathSpec.OWNER).toBe('owner/{ownerId}');
+      expect(ResourceAttributionPathSpec.TENANT_OWNER).toBe('tenant/{tenantId}/owner/{ownerId}');
+    });
+  });
+
+  describe('UrlPathParams', () => {
+    it('should allow tenantId, ownerId, and id properties', () => {
+      const params: UrlPathParams = {
+        tenantId: 'tenant-1',
+        ownerId: 'owner-1',
+        id: 'id-1',
+      };
+
+      expect(params.tenantId).toBe('tenant-1');
+      expect(params.ownerId).toBe('owner-1');
+      expect(params.id).toBe('id-1');
+    });
+
+    it('should allow additional custom properties', () => {
+      const params: UrlPathParams = {
+        tenantId: 'tenant-1',
+        customParam: 'custom-value',
+        anotherParam: 'another-value',
+      };
+
+      expect(params.tenantId).toBe('tenant-1');
+      expect(params.customParam).toBe('custom-value');
+      expect(params.anotherParam).toBe('another-value');
+    });
+
+    it('should allow undefined values', () => {
+      const params: UrlPathParams = {
+        tenantId: undefined,
+        ownerId: undefined,
+        id: undefined,
+      };
+
+      expect(params.tenantId).toBeUndefined();
+      expect(params.ownerId).toBeUndefined();
+      expect(params.id).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
- Introduced ResourceAttributionPathSpec enum with DEFAULT, TENANT, OWNER, and TENANT_OWNER values
- Added JSDoc documentation with usage examples
- Defined standard path patterns for accessing resources with different attribution scopes
- Included tenant and owner identifier placeholders in path definitions