### PR TITLE
refactor(query): introduce QueryClientFactory for creating query clients

### DIFF
--- a/packages/wow/src/query/queryClients.ts
+++ b/packages/wow/src/query/queryClients.ts
@@ -47,24 +47,40 @@ export function createQueryApiMetadata(options: QueryClientOptions): ApiMetadata
   return { ...options, basePath };
 }
 
-/**
- * Creates a snapshot query client for querying aggregate snapshots.
- *
- * @param options - The query client options used to configure the snapshot query client
- * @returns A new instance of SnapshotQueryClient
- */
-export function createSnapshotQueryClient<S, FIELDS extends string = string>(options: QueryClientOptions): SnapshotQueryClient<S, FIELDS> {
-  const apiMetadata = createQueryApiMetadata(options);
-  return new SnapshotQueryClient(apiMetadata);
-}
+export class QueryClientFactory<S, FIELDS extends string = string, DomainEventBody = any> {
+  /**
+   * Creates a new QueryClientFactory instance with the specified default options.
+   *
+   * @param defaultOptions - The default options to be used for all query clients created by this factory
+   */
+  constructor(private readonly defaultOptions: QueryClientOptions) {
+  }
 
-/**
- * Creates an event stream query client for querying domain event streams.
- *
- * @param options - The query client options used to configure the event stream query client
- * @returns A new instance of EventStreamQueryClient
- */
-export function createEventStreamQueryClient<DomainEventBody = any, FIELDS extends string = string>(options: QueryClientOptions): EventStreamQueryClient<DomainEventBody, FIELDS> {
-  const apiMetadata = createQueryApiMetadata(options);
-  return new EventStreamQueryClient(apiMetadata);
+  /**
+   * Creates a snapshot query client for querying aggregate snapshots.
+   *
+   * This method merges the provided options with the factory's default options,
+   * then creates API metadata and instantiates a SnapshotQueryClient.
+   *
+   * @param options - The query client options used to configure the snapshot query client
+   * @returns A new instance of SnapshotQueryClient
+   */
+  createSnapshotQueryClient(options: QueryClientOptions): SnapshotQueryClient<S, FIELDS> {
+    const apiMetadata = createQueryApiMetadata({ ...this.defaultOptions, ...options });
+    return new SnapshotQueryClient(apiMetadata);
+  }
+
+  /**
+   * Creates an event stream query client for querying domain event streams.
+   *
+   * This method merges the provided options with the factory's default options,
+   * then creates API metadata and instantiates an EventStreamQueryClient.
+   *
+   * @param options - The query client options used to configure the event stream query client
+   * @returns A new instance of EventStreamQueryClient
+   */
+  createEventStreamQueryClient<FIELDS extends string = string>(options: QueryClientOptions): EventStreamQueryClient<DomainEventBody, FIELDS> {
+    const apiMetadata = createQueryApiMetadata({ ...this.defaultOptions, ...options });
+    return new EventStreamQueryClient(apiMetadata);
+  }
 }

--- a/packages/wow/test/query/queryClients.test.ts
+++ b/packages/wow/test/query/queryClients.test.ts
@@ -13,28 +13,10 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import {
-  createQueryApiMetadata,
-  createSnapshotQueryClient,
-  createEventStreamQueryClient,
+  QueryClientFactory,
   QueryClientOptions,
+  createQueryApiMetadata,
 } from '../../src';
-
-// Mock the SnapshotQueryClient and EventStreamQueryClient classes
-vi.mock('../../src/query/snapshot', () => {
-  return {
-    SnapshotQueryClient: vi.fn().mockImplementation(() => {
-      return {};
-    }),
-  };
-});
-
-vi.mock('../../src/query/event', () => {
-  return {
-    EventStreamQueryClient: vi.fn().mockImplementation(() => {
-      return {};
-    }),
-  };
-});
 
 describe('queryClients', () => {
   describe('createQueryApiMetadata', () => {
@@ -87,27 +69,77 @@ describe('queryClients', () => {
     });
   });
 
-  describe('createSnapshotQueryClient', () => {
-    it('should create a SnapshotQueryClient instance', () => {
-      const options: QueryClientOptions = {
-        aggregateName: 'testAggregate',
-      };
+  describe('QueryClientFactory', () => {
+    const defaultOptions: QueryClientOptions = {
+      aggregateName: 'defaultAggregate',
+    };
 
-      const client = createSnapshotQueryClient(options);
+    describe('constructor', () => {
+      it('should create a factory with default options', () => {
+        const factory = new QueryClientFactory(defaultOptions);
 
-      expect(client).toBeDefined();
+        expect(factory).toBeInstanceOf(QueryClientFactory);
+      });
     });
-  });
 
-  describe('createEventStreamQueryClient', () => {
-    it('should create an EventStreamQueryClient instance', () => {
-      const options: QueryClientOptions = {
-        aggregateName: 'testAggregate',
-      };
+    describe('createSnapshotQueryClient', () => {
+      it('should create a SnapshotQueryClient with merged options', () => {
+        const factory = new QueryClientFactory(defaultOptions);
+        const options: QueryClientOptions = {
+          aggregateName: 'testAggregate',
+        };
 
-      const client = createEventStreamQueryClient(options);
+        const client = factory.createSnapshotQueryClient(options);
 
-      expect(client).toBeDefined();
+        expect(client).toBeDefined();
+      });
+
+      it('should merge default options with provided options', () => {
+        const factoryDefaultOptions: QueryClientOptions = {
+          aggregateName: 'defaultAggregate',
+          contextAlias: 'defaultContext',
+        };
+        const factory = new QueryClientFactory(factoryDefaultOptions);
+
+        const options: QueryClientOptions = {
+          aggregateName: 'testAggregate',
+          // contextAlias should come from defaults
+        };
+
+        const client = factory.createSnapshotQueryClient(options);
+
+        expect(client).toBeDefined();
+      });
+    });
+
+    describe('createEventStreamQueryClient', () => {
+      it('should create an EventStreamQueryClient with merged options', () => {
+        const factory = new QueryClientFactory(defaultOptions);
+        const options: QueryClientOptions = {
+          aggregateName: 'testAggregate',
+        };
+
+        const client = factory.createEventStreamQueryClient(options);
+
+        expect(client).toBeDefined();
+      });
+
+      it('should merge default options with provided options', () => {
+        const factoryDefaultOptions: QueryClientOptions = {
+          aggregateName: 'defaultAggregate',
+          contextAlias: 'defaultContext',
+        };
+        const factory = new QueryClientFactory(factoryDefaultOptions);
+
+        const options: QueryClientOptions = {
+          aggregateName: 'testAggregate',
+          // contextAlias should come from defaults
+        };
+
+        const client = factory.createEventStreamQueryClient(options);
+
+        expect(client).toBeDefined();
+      });
     });
   });
 });


### PR DESCRIPTION
- Replace standalone functions with QueryClientFactory class
- Add support for default options in factory constructor
- Merge default and instance options when creating clients
- Maintain existing snapshot query client functionality
- Maintain existing event stream query client functionality
- Update JSDoc comments to reflect new factory pattern