### PR TITLE
refactor(endpoints): rename DEFAULT to NONE in ResourceAttributionPathSpec

### DIFF
--- a/packages/generator/expected/compensation/execution_failed/queryClient.ts
+++ b/packages/generator/expected/compensation/execution_failed/queryClient.ts
@@ -29,7 +29,7 @@ import { ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow/dist/types/e
 const DEFAULT_CLIENT_OPTIONS: QueryClientOptions = {
   contextAlias: AGGREGATE.contextAlias,
   aggregateName: AGGREGATE.aggregateName,
-  resourceAttribution: ResourceAttributionPathSpec.DEFAULT,
+  resourceAttribution: ResourceAttributionPathSpec.NONE,
 };
 
 export function createExecutionFailedSnapshotQueryClient(options: QueryClientOptions = DEFAULT_CLIENT_OPTIONS): SnapshotQueryClient<ExecutionFailedState, ExecutionFailedAggregatedFields | string> {

--- a/packages/wow/src/types/endpoints.ts
+++ b/packages/wow/src/types/endpoints.ts
@@ -55,7 +55,7 @@ export interface UrlPathParams {
  * ```
  */
 export enum ResourceAttributionPathSpec {
-  DEFAULT = '',
+  NONE = '',
   TENANT = 'tenant/{tenantId}',
   OWNER = 'owner/{ownerId}',
   TENANT_OWNER = 'tenant/{tenantId}/owner/{ownerId}',

--- a/packages/wow/test/types/endpoints.test.ts
+++ b/packages/wow/test/types/endpoints.test.ts
@@ -17,7 +17,7 @@ import { ResourceAttributionPathSpec, UrlPathParams } from '../../src/types/endp
 describe('endpoints', () => {
   describe('ResourceAttributionPathSpec', () => {
     it('should define correct path specifications', () => {
-      expect(ResourceAttributionPathSpec.DEFAULT).toBe('');
+      expect(ResourceAttributionPathSpec.NONE).toBe('');
       expect(ResourceAttributionPathSpec.TENANT).toBe('tenant/{tenantId}');
       expect(ResourceAttributionPathSpec.OWNER).toBe('owner/{ownerId}');
       expect(ResourceAttributionPathSpec.TENANT_OWNER).toBe('tenant/{tenantId}/owner/{ownerId}');


### PR DESCRIPTION


- Updated enum value from DEFAULT to NONE in endpoints.ts- Changed corresponding test expectation in endpoints.test.ts- Updated query client configuration to use NONE instead of DEFAULT