### PR TITLE
refactor(generator): improve code generation and CLI entry point

### DIFF
--- a/packages/generator/src/cli.ts
+++ b/packages/generator/src/cli.ts
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
 
+/**
+ * CLI entry point for the Fetcher OpenAPI code generator.
+ * Sets up the commander program with generate command and handles execution.
+ */
+
 import { program } from 'commander';
 import { CodeGenerator } from '@/index.ts';
 import { GeneratorOptions } from '@/types.ts';
 import { Project } from 'ts-morph';
 
 program
-  .name('fetcher-openapi-generator')
-  .description('OpenAPI Specification TypeScript code generator for Fetcher')
+  .name('fetcher-generator')
+  .description('OpenAPI Specification TypeScript code generator for Wow')
   .version('1.0.0');
 
 program

--- a/packages/generator/src/client/clientGenerator.ts
+++ b/packages/generator/src/client/clientGenerator.ts
@@ -13,7 +13,7 @@
 
 import { GenerateContext } from '@/types.ts';
 import { getOrCreateSourceFile } from '@/utils/sourceFiles.ts';
-import { BaseCodeGenerator } from '@/BaseCodeGenerator.ts';
+import { BaseCodeGenerator } from '@/baseCodeGenerator.ts';
 import { QueryClientGenerator } from '@/client/queryClientGenerator.ts';
 import { CommandClientGenerator } from '@/client/commandClientGenerator.ts';
 
@@ -39,7 +39,7 @@ export class ClientGenerator extends BaseCodeGenerator {
    * Generates client classes for all aggregates.
    */
   generate(): void {
-    for (const [contextAlias, _] of this.contextAggregates) {
+    for (const [contextAlias] of this.contextAggregates) {
       this.processBoundedContext(contextAlias);
     }
     this.queryClientGenerator.generate();

--- a/packages/generator/src/client/commandClientGenerator.ts
+++ b/packages/generator/src/client/commandClientGenerator.ts
@@ -27,16 +27,28 @@ import {
 import { HTTPMethod } from '@ahoo-wang/fetcher-openapi';
 import { createClientFilePath, getClientName } from '@/client/utils.ts';
 
+/**
+ * Generates TypeScript command client classes for aggregates.
+ * Creates command clients that can send commands to aggregates.
+ */
 export class CommandClientGenerator extends BaseCodeGenerator {
   private readonly commandEndpointPathsName = 'COMMAND_ENDPOINT_PATHS';
-  private readonly defaultCommandClientOptionsName = 'DEFAULT_COMMAND_CLIENT_OPTIONS';
+  private readonly defaultCommandClientOptionsName =
+    'DEFAULT_COMMAND_CLIENT_OPTIONS';
 
+  /**
+   * Creates a new CommandClientGenerator instance.
+   * @param context - The generation context containing OpenAPI spec and project details
+   */
   constructor(context: GenerateContext) {
     super(context);
   }
 
+  /**
+   * Generates command client classes for all aggregates.
+   */
   generate(): void {
-    for (const [_, aggregates] of this.contextAggregates) {
+    for (const [, aggregates] of this.contextAggregates) {
       aggregates.forEach(aggregateDefinition => {
         this.processAggregate(aggregateDefinition);
       });
@@ -57,13 +69,15 @@ export class CommandClientGenerator extends BaseCodeGenerator {
     this.processCommandEndpointPaths(commandClientFile, aggregate);
     commandClientFile.addVariableStatement({
       declarationKind: VariableDeclarationKind.Const,
-      declarations: [{
-        name: this.defaultCommandClientOptionsName,
-        type: 'ApiMetadata',
-        initializer: `{
+      declarations: [
+        {
+          name: this.defaultCommandClientOptionsName,
+          type: 'ApiMetadata',
+          initializer: `{
         basePath: '${aggregate.aggregate.contextAlias}'
       }`,
-      }],
+        },
+      ],
       isExported: false,
     });
     commandClientFile.addImportDeclaration({
@@ -79,13 +93,9 @@ export class CommandClientGenerator extends BaseCodeGenerator {
     });
     commandClientFile.addImportDeclaration({
       moduleSpecifier: '@ahoo-wang/fetcher-eventstream',
-      namedImports: [
-        'JsonEventStreamResultExtractor',
-      ],
+      namedImports: ['JsonEventStreamResultExtractor'],
     });
-    addImport(commandClientFile, '@ahoo-wang/fetcher', [
-      'ContentTypeValues',
-    ]);
+    addImport(commandClientFile, '@ahoo-wang/fetcher', ['ContentTypeValues']);
     addImport(commandClientFile, '@ahoo-wang/fetcher-decorator', [
       'type ApiMetadata',
       'type ApiMetadataCapable',
@@ -103,7 +113,10 @@ export class CommandClientGenerator extends BaseCodeGenerator {
     this.processCommandClient(commandClientFile, aggregate, true);
   }
 
-  processCommandEndpointPaths(clientFile: SourceFile, aggregateDefinition: AggregateDefinition) {
+  processCommandEndpointPaths(
+    clientFile: SourceFile,
+    aggregateDefinition: AggregateDefinition,
+  ) {
     const enumDeclaration = clientFile.addEnum({
       name: this.commandEndpointPathsName,
     });
@@ -119,7 +132,11 @@ export class CommandClientGenerator extends BaseCodeGenerator {
     return `${this.commandEndpointPathsName}.${command.name.toUpperCase()}`;
   }
 
-  processCommandClient(clientFile: SourceFile, aggregateDefinition: AggregateDefinition, isStream: boolean = false) {
+  processCommandClient(
+    clientFile: SourceFile,
+    aggregateDefinition: AggregateDefinition,
+    isStream: boolean = false,
+  ) {
     let suffix = 'CommandClient';
     let apiDecorator: OptionalKind<DecoratorStructure> = {
       name: 'api',
@@ -130,10 +147,13 @@ export class CommandClientGenerator extends BaseCodeGenerator {
       suffix = 'Stream' + suffix;
       apiDecorator = {
         name: 'api',
-        arguments: [`''`, `{
+        arguments: [
+          `''`,
+          `{
   headers: { Accept: ContentTypeValues.TEXT_EVENT_STREAM },
   resultExtractor: JsonEventStreamResultExtractor,
-}`],
+}`,
+        ],
       };
       returnType = `Promise<CommandResultEventStream>`;
     }

--- a/packages/generator/src/utils/openAPIParser.ts
+++ b/packages/generator/src/utils/openAPIParser.ts
@@ -57,7 +57,7 @@ export function inferFileFormat(content: string): FileFormat {
   try {
     JSON.parse(trimmedContent);
     return FileFormat.JSON;
-  } catch (e) {
+  } catch {
     // If it's not valid JSON, we'll assume it's YAML if it's not empty
     if (trimmedContent.length > 0) {
       return FileFormat.YAML;

--- a/packages/generator/src/utils/operations.ts
+++ b/packages/generator/src/utils/operations.ts
@@ -52,6 +52,11 @@ export function extractOperations(pathItem: PathItem): MethodOperation[] {
   }>;
 }
 
+/**
+ * Extracts the OK (200) response from an operation.
+ * @param operation - The OpenAPI operation
+ * @returns The 200 response or undefined if not found
+ */
 export function extractOkResponse(
   operation: Operation,
 ): Response | Reference | undefined {


### PR DESCRIPTION
- Rename imported BaseCodeGenerator path from uppercase to lowercase
- Remove unused underscore variables in for-of loops
- Add JSDoc comments to CommandClientGenerator and QueryClientGenerator classes
- Add JSDoc comments to CLI entry point and update program description
- Simplify array declarations and import statements
- Update extractOkResponse function with JSDoc documentation
- Fix JSON parsing catch block to remove unused error parameter
- Adjust function parameter formatting for better readability