### PR TITLE
build(generator): enable sourcemap generation

### DIFF
--- a/packages/generator/vite.config.ts
+++ b/packages/generator/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     },
   },
   build: {
+    sourcemap: true,
     lib: {
       entry: {
         index: resolve(__dirname, 'src/index.ts'),


### PR DESCRIPTION
- Added sourcemap: true to vite config for better debugging
- This will help developers debug the generated library more easily
- Sourcemaps will be included in the build output
- No functional changes to the code itself
- Only affects the build configuration
- Improves developer experience when debugging issues