### PR TITLE
chore(deps): update nanoid dependency to catalog version

### DIFF
--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@ahoo-wang/fetcher": "workspace:*",
     "@ahoo-wang/fetcher-storage": "workspace:*",
-    "nanoid": "^5.1.5"
+    "nanoid": "catalog:"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,3 +30,4 @@ catalog:
   vite-bundle-analyzer: ^1.2.3
   vitest: ^3.2.4
   yaml: ^2.3.1
+  nanoid: ^5.1.6


### PR DESCRIPTION
- Replace direct nanoid version with catalog reference in package.json
- Add nanoid to pnpm workspace catalog with version ^5.1.6
- Ensure consistent dependency management across workspace packages