### PR TITLE
test(sourceFiles): refactor tests to use inline mocks

### DIFF
--- a/packages/generator/src/model/modelGenerator.ts
+++ b/packages/generator/src/model/modelGenerator.ts
@@ -156,7 +156,7 @@ export class ModelGenerator extends BaseCodeGenerator {
 
   private processInterface(sourceFile: SourceFile, modelInfo: ModelInfo, schema: Schema, interfaceDeclaration: InterfaceDeclaration) {
     for (const [propName, propSchema] of Object.entries(schema.properties!)) {
-      let propType: string = this.resolvePropertyType(modelInfo, sourceFile, propName, propSchema);
+      const propType: string = this.resolvePropertyType(modelInfo, sourceFile, propName, propSchema);
       let propertySignature = interfaceDeclaration.getProperty(propName);
       if (propertySignature) {
         propertySignature.setType(propType);
@@ -184,7 +184,7 @@ export class ModelGenerator extends BaseCodeGenerator {
       return `'${propSchema.const}'`;
     }
     if (isArray(propSchema)) {
-      const itemsType = this.resolvePropertyType(currentModelInfo, sourceFile, propName, propSchema.items!!);
+      const itemsType = this.resolvePropertyType(currentModelInfo, sourceFile, propName, propSchema.items!);
       return toArrayType(itemsType);
     }
     if (propSchema.type && isPrimitive(propSchema.type)) {

--- a/packages/generator/src/utils/schemas.ts
+++ b/packages/generator/src/utils/schemas.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { Reference, Schema, SchemaType } from '@ahoo-wang/fetcher-openapi';
+import { Schema, SchemaType } from '@ahoo-wang/fetcher-openapi';
 
 /** List of primitive schema types */
 const PRIMITIVE_TYPES: SchemaType[] = [


### PR DESCRIPTION
- Add beforeEach hook to clear mock states
- Replace external mock import with inline mock objects
- Update assertions to match new mock structure
- Remove unused mocked function references
- Adjust module specifier paths in assertions
- Ensure proper mocking of ts-morph methods