### PR TITLE
fix(generator): resolve import path handling for ref models

### DIFF
--- a/packages/generator/src/utils/sourceFiles.ts
+++ b/packages/generator/src/utils/sourceFiles.ts
@@ -95,19 +95,13 @@ export function addImportRefModel(
   outputDir: string,
   refModelInfo: ModelInfo,
 ) {
-  if (refModelInfo.path === IMPORT_WOW_PATH) {
+  if (refModelInfo.path.startsWith(IMPORT_ALIAS)) {
     addImport(sourceFile, refModelInfo.path, [refModelInfo.name]);
     return;
   }
   let fileName = getModelFileName(refModelInfo);
-  // If the path already starts with an alias, don't combine with outputDir
-  if (!refModelInfo.path.startsWith(IMPORT_ALIAS)) {
-    fileName = combineURLs(outputDir, fileName);
-  }
-  let moduleSpecifier = fileName;
-  if (!fileName.startsWith(IMPORT_ALIAS)) {
-    moduleSpecifier = combineURLs(IMPORT_ALIAS, fileName);
-  }
+  fileName = combineURLs(outputDir, fileName);
+  const moduleSpecifier = combineURLs(IMPORT_ALIAS, fileName);
   addImport(sourceFile, moduleSpecifier, [refModelInfo.name]);
 }
 

--- a/packages/generator/test/utils/sourceFiles.test.ts
+++ b/packages/generator/test/utils/sourceFiles.test.ts
@@ -321,7 +321,7 @@ describe('sourceFiles', () => {
       addImportRefModel(sourceFile, outputDir, refModelInfo);
 
       expect(mockSourceFile.addImportDeclaration).toHaveBeenCalledWith({
-        moduleSpecifier: '@/custom/path/types.ts',
+        moduleSpecifier: '@/custom/path',
       });
     });
   });


### PR DESCRIPTION
- Simplify import path logic by removing conditional checks
- Always combine output directory with model file name
- Ensure module specifier starts with import alias
- Update test case to match new path handling behavior