### PR TITLE
refactor(generator): update import path resolution logic

### DIFF
--- a/packages/generator/src/utils/sourceFiles.ts
+++ b/packages/generator/src/utils/sourceFiles.ts
@@ -13,7 +13,8 @@
 
 import { JSDocableNode, Project, SourceFile } from 'ts-morph';
 import { combineURLs } from '@ahoo-wang/fetcher';
-import { IMPORT_WOW_PATH, ModelInfo } from '../model';
+import { join, relative } from 'path';
+import { ModelInfo } from '../model';
 
 /** Default file name for model files */
 const MODEL_FILE_NAME = 'types.ts';
@@ -99,10 +100,18 @@ export function addImportRefModel(
     addImport(sourceFile, refModelInfo.path, [refModelInfo.name]);
     return;
   }
-  let fileName = getModelFileName(refModelInfo);
-  fileName = combineURLs(outputDir, fileName);
-  const moduleSpecifier = combineURLs(IMPORT_ALIAS, fileName);
-  addImport(sourceFile, moduleSpecifier, [refModelInfo.name]);
+
+  const sourceDir = sourceFile.getDirectoryPath();
+  const targetFilePath = join(outputDir, refModelInfo.path, MODEL_FILE_NAME);
+  let relativePath = relative(sourceDir, targetFilePath);
+
+  relativePath = relativePath.replace(/\.ts$/, '');
+
+  if (!relativePath.startsWith('.')) {
+    relativePath = './' + relativePath;
+  }
+
+  addImport(sourceFile, relativePath, [refModelInfo.name]);
 }
 
 /**

--- a/packages/generator/test/utils/sourceFiles.test.ts
+++ b/packages/generator/test/utils/sourceFiles.test.ts
@@ -57,6 +57,7 @@ const mockSourceFile = {
   getImportDeclaration: vi.fn(),
   addImportDeclaration: vi.fn().mockReturnValue(mockDeclaration),
   addNamedImport: vi.fn(),
+  getDirectoryPath: vi.fn().mockReturnValue('/src'),
 };
 
 describe('sourceFiles', () => {
@@ -64,6 +65,7 @@ describe('sourceFiles', () => {
     mockSourceFile.getImportDeclaration.mockClear();
     mockSourceFile.addImportDeclaration.mockClear();
     mockDeclaration.addNamedImport.mockClear();
+    mockSourceFile.getDirectoryPath.mockClear();
   });
 
   describe('getModelFileName', () => {
@@ -306,7 +308,7 @@ describe('sourceFiles', () => {
       addImportRefModel(sourceFile, outputDir, refModelInfo);
 
       expect(mockSourceFile.addImportDeclaration).toHaveBeenCalledWith({
-        moduleSpecifier: '@//output/models/types.ts',
+        moduleSpecifier: '../output/models/types',
       });
     });
 
@@ -360,7 +362,7 @@ describe('sourceFiles', () => {
 
       // This should call addImportRefModel, which calls addImport
       expect(mockSourceFile.addImportDeclaration).toHaveBeenCalledWith({
-        moduleSpecifier: '@//output/products/types.ts',
+        moduleSpecifier: '../output/products/types',
       });
     });
   });


### PR DESCRIPTION
- Replace combineURLs with path.join and path.relative for accurate relative paths
- Remove unused IMPORT_WOW_PATH constant
- Add .ts extension removal in module specifier
- Ensure relative paths start with ./ when necessary
- Update tests to reflect new relative path generation
- Mock getDirectoryPath in test utilities for proper path resolution testing