### PR TITLE
chore(test): increase test timeout to 15000ms

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "vite build",
     "test:ui": "vitest --ui",
-    "test": "vitest run --coverage  --testTimeout=10000",
+    "test": "vitest run --coverage  --testTimeout=15000",
     "lint": "eslint . --fix",
     "clean": "rm -rf dist",
     "analyze": "npx vite-bundle-analyzer -p auto",


### PR DESCRIPTION
- Updated test script timeout from 10000ms to 15000ms
- Ensures sufficient time for test completion in CI environments
- Prevents premature test termination due to timeout limits
- Maintains existing coverage and run configurations
- Aligns timeout setting with typical test execution requirements