### PR TITLE
feat(generator): add tsConfigFilePath option for project initialization

### DIFF
--- a/packages/generator/src/cli.ts
+++ b/packages/generator/src/cli.ts
@@ -24,11 +24,12 @@ export function setupCLI() {
     .command('generate')
     .description('Generate TypeScript code from OpenAPI specification')
     .requiredOption(
-      '-i, --input <path>',
+      '-i, --input <file>',
       'Input OpenAPI specification file path or URL (http/https)',
     )
     .option('-o, --output <path>', 'Output directory path', 'src/generated')
     .option('-c, --config <file>', 'Configuration file path', DEFAULT_CONFIG_PATH)
+    .option('-t, --ts-config-file-path <file>', 'TypeScript configuration file path')
     .option('-v, --verbose', 'Enable verbose logging')
     .option('--dry-run', 'Show what would be generated without writing files')
     .action(generateAction);

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -33,7 +33,7 @@ export class CodeGenerator {
    * @param options - Configuration options for code generation
    */
   constructor(private readonly options: GeneratorOptions) {
-    this.project = options.project;
+    this.project = new Project({ tsConfigFilePath: this.options.tsConfigFilePath });
     this.options.logger.info('CodeGenerator instance created');
   }
 

--- a/packages/generator/src/types.ts
+++ b/packages/generator/src/types.ts
@@ -19,13 +19,12 @@ import { BoundedContextAggregates } from './aggregate';
  * Configuration options for the code generator.
  */
 export interface GeneratorOptions {
-  /** The ts-morph project instance to use for code generation */
-  readonly project: Project;
   /** Path to the input OpenAPI specification file */
   readonly inputPath: string;
   /** Output directory for generated files */
   readonly outputDir: string;
   readonly configPath?: string;
+  readonly tsConfigFilePath?: string;
   /** Optional logger for friendly output */
   readonly logger: Logger;
 }

--- a/packages/generator/src/utils/clis.ts
+++ b/packages/generator/src/utils/clis.ts
@@ -14,7 +14,6 @@
 import { ConsoleLogger } from './logger';
 import { GeneratorOptions } from '../types';
 import { CodeGenerator } from '../index';
-import { Project } from 'ts-morph';
 
 /**
  * Validates the input path or URL.
@@ -42,7 +41,8 @@ export function validateInput(input: string): boolean {
 export async function generateAction(options: {
   input: string;
   output: string;
-  config?: string,
+  config?: string;
+  tsConfigFilePath?: string;
   verbose?: boolean;
   dryRun?: boolean;
 }) {
@@ -62,12 +62,11 @@ export async function generateAction(options: {
 
   try {
     logger.info('Starting code generation...');
-    const project = new Project();
     const generatorOptions: GeneratorOptions = {
       inputPath: options.input,
       outputDir: options.output,
       configPath: options.config,
-      project,
+      tsConfigFilePath: options.tsConfigFilePath,
       logger,
     };
     const codeGenerator = new CodeGenerator(generatorOptions);

--- a/packages/generator/test/cli.test.ts
+++ b/packages/generator/test/cli.test.ts
@@ -60,7 +60,7 @@ describe('CLI setup', () => {
 
     expect(result.command).toHaveBeenCalledWith('generate');
     expect(result.requiredOption).toHaveBeenCalledWith(
-      '-i, --input <path>',
+      '-i, --input <file>',
       'Input OpenAPI specification file path or URL (http/https)',
     );
     expect(result.option).toHaveBeenCalledWith(

--- a/packages/generator/test/e2e.test.ts
+++ b/packages/generator/test/e2e.test.ts
@@ -44,6 +44,7 @@ describe('E2E Test', () => {
       input: 'test/demo-spec.json',
       output: OUT_PUT_DIR,
       config: 'test/fetcher-generator.config.json',
+      tsConfigFilePath: `${OUT_PUT_DIR}/tsconfig.json`,
     });
   });
 

--- a/packages/generator/test/index.test.ts
+++ b/packages/generator/test/index.test.ts
@@ -16,6 +16,10 @@ import { CodeGenerator } from '../src';
 import { GeneratorOptions } from '../src/types';
 
 // Mock dependencies
+vi.mock('ts-morph', () => ({
+  Project: vi.fn(),
+}));
+
 vi.mock('../src/utils', () => ({
   parseOpenAPI: vi.fn(),
 }));
@@ -33,6 +37,7 @@ vi.mock('../src/client', () => ({
 }));
 
 // Import after mocking
+import { Project } from 'ts-morph';
 import { parseOpenAPI } from '../src/utils';
 import { AggregateResolver } from '../src/aggregate';
 import { ModelGenerator } from '../src/model';
@@ -58,6 +63,8 @@ describe('CodeGenerator', () => {
       createSourceFile: vi.fn(),
       save: vi.fn(),
     };
+
+    (Project as any).mockImplementation(() => mockProject);
 
     mockLogger = {
       info: vi.fn(),
@@ -95,7 +102,7 @@ describe('CodeGenerator', () => {
     mockProject.save.mockResolvedValue(undefined);
 
     options = {
-      project: mockProject,
+      tsConfigFilePath: undefined,
       inputPath: '/path/to/openapi.yaml',
       outputDir: '/output/dir',
       logger: mockLogger,
@@ -106,7 +113,6 @@ describe('CodeGenerator', () => {
     it('should initialize with provided options', () => {
       const generator = new CodeGenerator(options);
 
-      expect(generator['project']).toBe(mockProject);
       expect(generator['options']).toBe(options);
     });
 

--- a/packages/generator/test/utils/clis.test.ts
+++ b/packages/generator/test/utils/clis.test.ts
@@ -105,7 +105,7 @@ describe('generateAction', () => {
     expect(CodeGenerator).toHaveBeenCalledWith({
       inputPath: 'http://example.com',
       outputDir: '/output',
-      project: mockProject,
+      tsConfigFilePath: undefined,
       logger: mockLogger,
     });
     expect(mockCodeGenerator.generate).toHaveBeenCalled();


### PR DESCRIPTION
- Added tsConfigFilePath property to GeneratorOptions interface
- Updated CodeGenerator to create Project instance with tsConfigFilePath
- Removed direct project instance from GeneratorOptions
- Updated CLI to accept --ts-config-file-path option
- Modified e2e tests to include tsConfigFilePath option
- Updated unit tests to reflect project instance initialization changes