### PR TITLE
refactor(model): remove redundant model name handling logic

### DIFF
--- a/packages/generator/src/model/modelInfo.ts
+++ b/packages/generator/src/model/modelInfo.ts
@@ -62,11 +62,6 @@ export function resolveModelInfo(schemaKey: string): ModelInfo {
     }
   }
 
-  // If no part starts with uppercase letter, treat the whole thing as the name
-  if (modelNameIndex === -1) {
-    return { name: schemaKey, path: '/' };
-  }
-
   // Construct the path from parts before the model name
   const pathParts = parts.slice(0, modelNameIndex);
   const path = pathParts.length > 0 ? `/${pathParts.join('/')}` : '/';

--- a/packages/generator/test/e2e.test.ts
+++ b/packages/generator/test/e2e.test.ts
@@ -41,7 +41,7 @@ describe('E2E Test', () => {
   it('should generate [test/demo-spec.json] code', async () => {
     clearOutputSubDirs();
     await generateAction({
-      input: 'http://localhost:8080/v3/api-docs',
+      input: 'test/demo-spec.json',
       output: OUT_PUT_DIR,
       config: 'test/fetcher-generator.config.json',
       tsConfigFilePath: `${OUT_PUT_DIR}/tsconfig.json`,

--- a/packages/generator/test/e2e.test.ts
+++ b/packages/generator/test/e2e.test.ts
@@ -41,7 +41,7 @@ describe('E2E Test', () => {
   it('should generate [test/demo-spec.json] code', async () => {
     clearOutputSubDirs();
     await generateAction({
-      input: 'test/demo-spec.json',
+      input: 'http://localhost:8080/v3/api-docs',
       output: OUT_PUT_DIR,
       config: 'test/fetcher-generator.config.json',
       tsConfigFilePath: `${OUT_PUT_DIR}/tsconfig.json`,

--- a/packages/generator/test/model/modelInfo.test.ts
+++ b/packages/generator/test/model/modelInfo.test.ts
@@ -14,16 +14,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { resolveModelInfo, WOW_TYPE_MAPPING } from '../../src/model';
 
-// Mock the pascalCase function to avoid dependencies on the actual implementation
-vi.mock('@/utils/naming.ts', () => ({
-  pascalCase: vi.fn(parts => {
-    if (Array.isArray(parts)) {
-      return parts.join('');
-    }
-    return parts;
-  }),
-}));
-
 describe('modelInfo', () => {
   describe('resolveModelInfo', () => {
     it('should return empty name and root path for empty schemaKey', () => {
@@ -59,7 +49,7 @@ describe('modelInfo', () => {
     it('should treat whole string as name when no uppercase letter is found', () => {
       const result = resolveModelInfo('result');
       expect(result).toEqual({
-        name: 'result',
+        name: 'Result',
         path: '/',
       });
     });
@@ -85,6 +75,13 @@ describe('modelInfo', () => {
       expect(result).toEqual({
         name: 'User',
         path: '/',
+      });
+    });
+    it('should handle schema key with ', () => {
+      const result = resolveModelInfo('wow.byteArray');
+      expect(result).toEqual({
+        name: 'ByteArray',
+        path: '/wow',
       });
     });
   });

--- a/packages/generator/test/utils/operations.test.ts
+++ b/packages/generator/test/utils/operations.test.ts
@@ -41,8 +41,6 @@ vi.mock('../../src/utils/schemas', () => ({
 }));
 
 describe('operations', () => {
-  // ... existing tests ...
-
   describe('extractPathParameters', () => {
     it('should return empty array if operation has no parameters', () => {
       const operation: Operation = {

--- a/packages/generator/test/utils/schemas.test.ts
+++ b/packages/generator/test/utils/schemas.test.ts
@@ -25,7 +25,7 @@ import {
   toArrayType,
   isEmptyObject,
   resolvePrimitiveType,
-} from '../../src/utils/schemas';
+} from '../../src/utils';
 
 describe('schemas', () => {
   describe('isPrimitive', () => {


### PR DESCRIPTION
- Removed fallback logic for cases where no part starts with uppercase
- Simplified path construction by removing unnecessary conditional check
- Preserved core functionality for extracting model name and path segments