### PR TITLE
feat(generator): add event stream support in client generators

### DIFF
--- a/packages/generator/src/client/apiClientGenerator.ts
+++ b/packages/generator/src/client/apiClientGenerator.ts
@@ -52,7 +52,7 @@ import {
 } from '../utils';
 import {
   addApiMetadataCtor,
-  addImportDecorator,
+  addImportDecorator, addImportEventStream,
   createDecoratorClass, DEFAULT_RETURN_TYPE, MethodReturnType,
   STREAM_RESULT_EXTRACTOR_METADATA,
 } from './decorators';
@@ -158,6 +158,7 @@ export class ApiClientGenerator implements Generator {
     );
     const apiClientFile = this.createApiClientFile(modelInfo);
     addImportDecorator(apiClientFile);
+    addImportEventStream(apiClientFile);
     const apiClientClass = createDecoratorClass(
       modelInfo.name + 'ApiClient',
       apiClientFile,

--- a/packages/generator/src/client/commandClientGenerator.ts
+++ b/packages/generator/src/client/commandClientGenerator.ts
@@ -28,8 +28,7 @@ import {
 } from '../utils';
 import {
   addApiMetadataCtor,
-  addImportDecorator,
-  createDecoratorClass,
+  addImportDecorator, addImportEventStream, createDecoratorClass,
   STREAM_RESULT_EXTRACTOR_METADATA,
 } from './decorators';
 import { createClientFilePath, getClientName, methodToDecorator } from './utils';
@@ -133,10 +132,7 @@ export class CommandClientGenerator implements Generator {
     this.context.logger.info(
       `Adding import from @ahoo-wang/fetcher-eventstream: JsonEventStreamResultExtractor`,
     );
-    commandClientFile.addImportDeclaration({
-      moduleSpecifier: '@ahoo-wang/fetcher-eventstream',
-      namedImports: ['JsonEventStreamResultExtractor'],
-    });
+    addImportEventStream(commandClientFile);
 
     this.context.logger.info(
       `Adding import from @ahoo-wang/fetcher: ContentTypeValues`,

--- a/packages/generator/src/client/decorators.ts
+++ b/packages/generator/src/client/decorators.ts
@@ -138,3 +138,9 @@ export function addApiMetadataCtor(
     ],
   });
 }
+
+export const EVENTSTREAM_MODULE_SPECIFIER = '@ahoo-wang/fetcher-eventstream';
+
+export function addImportEventStream(sourceFile: SourceFile) {
+  addImport(sourceFile, EVENTSTREAM_MODULE_SPECIFIER, ['JsonEventStreamResultExtractor', 'type JsonServerSentEventStream']);
+}


### PR DESCRIPTION
- Added `addImportEventStream` utility to handle event stream imports
- Updated `apiClientGenerator` to use the new event stream import helper
- Modified `commandClientGenerator` to utilize event stream import utility
- Removed direct import declaration for `JsonEventStreamResultExtractor`
- Introduced `EVENTSTREAM_MODULE_SPECIFIER` constant for better maintainability
- Enhanced decorator utilities to support event stream result extraction