### PR TITLE
refactor(fetcher): replace default fetcher with fetcher registrar

### DIFF
--- a/packages/react/src/fetcher/useFetcher.ts
+++ b/packages/react/src/fetcher/useFetcher.ts
@@ -12,7 +12,7 @@
  */
 
 import {
-  fetcher as defaultFetcher,
+  fetcherRegistrar,
   FetcherCapable,
   FetchExchange,
   FetchRequest,
@@ -66,7 +66,7 @@ export interface UseFetcherReturn<R, E = unknown> extends PromiseState<R, E> {
 export function useFetcher<R, E = unknown>(
   options?: UseFetcherOptions,
 ): UseFetcherReturn<R, E> {
-  const { fetcher = defaultFetcher } = options || {};
+  const { fetcher = fetcherRegistrar.default } = options || {};
   const state = usePromiseState<R, E>();
   const [exchange, setExchange] = useState<FetchExchange | undefined>(
     undefined,

--- a/packages/react/test/fetcher/useFetcher.test.ts
+++ b/packages/react/test/fetcher/useFetcher.test.ts
@@ -23,7 +23,7 @@ vi.mock('react-use/lib/useMountedState', () => () => () => true);
 
 // Mock fetcher
 vi.mock('@ahoo-wang/fetcher', () => ({
-  fetcher: {},
+  fetcherRegistrar: {},
   getFetcher: vi.fn(),
 }));
 


### PR DESCRIPTION
- Replace import of default fetcher with fetcher registrar
- Update useFetcher hook to use fetcher from registrar
- Update mock implementation in tests to use fetcher registrar