### PR TITLE
feat(react): extend useExecutePromise and useFetcher with promise state options

### DIFF
--- a/packages/react/src/core/useExecutePromise.ts
+++ b/packages/react/src/core/useExecutePromise.ts
@@ -13,7 +13,7 @@
 
 import { useCallback, useMemo } from 'react';
 import { useMountedState } from 'react-use';
-import { usePromiseState, PromiseState } from './usePromiseState';
+import { usePromiseState, PromiseState, UsePromiseStateOptions } from './usePromiseState';
 import { useRequestId } from './useRequestId';
 
 /**
@@ -71,8 +71,8 @@ export interface UseExecutePromiseReturn<R, E = unknown>
  * }
  * ```
  */
-export function useExecutePromise<R = unknown, E = unknown>(): UseExecutePromiseReturn<R, E> {
-  const state = usePromiseState<R, E>();
+export function useExecutePromise<R = unknown, E = unknown>(options?: UsePromiseStateOptions<R, E>): UseExecutePromiseReturn<R, E> {
+  const state = usePromiseState<R, E>(options);
   const isMounted = useMountedState();
   const requestId = useRequestId();
 

--- a/packages/react/src/fetcher/useFetcher.ts
+++ b/packages/react/src/fetcher/useFetcher.ts
@@ -21,13 +21,13 @@ import {
 } from '@ahoo-wang/fetcher';
 import { useRef, useCallback, useEffect, useState, useMemo } from 'react';
 import { useMountedState } from 'react-use';
-import { PromiseState, usePromiseState, useRequestId } from '../core';
+import { PromiseState, usePromiseState, UsePromiseStateOptions, useRequestId } from '../core';
 
 /**
  * Configuration options for the useFetcher hook.
  * Extends RequestOptions and FetcherCapable interfaces.
  */
-export interface UseFetcherOptions extends RequestOptions, FetcherCapable {
+export interface UseFetcherOptions<R, E = unknown> extends RequestOptions, FetcherCapable, UsePromiseStateOptions<R, E> {
 }
 
 export interface UseFetcherReturn<R, E = unknown> extends PromiseState<R, E> {
@@ -64,10 +64,10 @@ export interface UseFetcherReturn<R, E = unknown> extends PromiseState<R, E> {
  * ```
  */
 export function useFetcher<R, E = unknown>(
-  options?: UseFetcherOptions,
+  options?: UseFetcherOptions<R, E>,
 ): UseFetcherReturn<R, E> {
   const { fetcher = fetcherRegistrar.default } = options || {};
-  const state = usePromiseState<R, E>();
+  const state = usePromiseState<R, E>(options);
   const [exchange, setExchange] = useState<FetchExchange | undefined>(
     undefined,
   );

--- a/packages/react/test/core/useExecutePromise.test.ts
+++ b/packages/react/test/core/useExecutePromise.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // Import before mocks
-import { useExecutePromise, PromiseStatus } from '../../src/core';
+import { useExecutePromise, PromiseStatus } from '../../src';
 
 // Mock useMountedState to always return true (component is mounted)
 vi.mock('react-use/lib/useMountedState', () => () => () => true);

--- a/packages/react/test/core/usePromiseState.test.ts
+++ b/packages/react/test/core/usePromiseState.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // Import before mocks
-import { usePromiseState, PromiseStatus } from '../../src/core';
+import { usePromiseState, PromiseStatus } from '../../src';
 
 // Mock useMountedState to always return true (component is mounted)
 vi.mock('react-use/lib/useMountedState', () => () => () => true);


### PR DESCRIPTION


- Added UsePromiseStateOptions type import to useExecutePromise hook
- Extended useExecutePromise function signature to accept options parameter
- Passed options to usePromiseState hook in useExecutePromise implementation
- Added UsePromiseStateOptions type import to useFetcher hook
- Extended UseFetcherOptions interface to include UsePromiseStateOptions
- Updated useFetcher function to accept generic type parameters for options
- Passed options parameter to usePromiseState hook in useFetcher implementation
- Updated test imports to use index export instead of core subpath
- Modified usePromiseState test import path to use index export