### PR TITLE
refactor(react): change useLatest to return ref object

### DIFF
--- a/packages/react/src/core/useLatest.ts
+++ b/packages/react/src/core/useLatest.ts
@@ -14,11 +14,11 @@
 import { useRef } from 'react';
 
 /**
- * A React hook that returns the latest value, useful for accessing the current value in async callbacks.
+ * A React hook that returns a ref containing the latest value, useful for accessing the current value in async callbacks.
  *
  * @template T - The type of the value
  * @param value - The value to track
- * @returns The latest value
+ * @returns A ref object containing the latest value
  *
  * @example
  * ```typescript
@@ -43,8 +43,8 @@ import { useRef } from 'react';
  * };
  * ```
  */
-export function useLatest<T>(value: T): T {
+export function useLatest<T>(value: T) {
   const ref = useRef(value);
   ref.current = value;
-  return ref.current;
+  return ref;
 }

--- a/packages/react/test/core/useLatest.test.ts
+++ b/packages/react/test/core/useLatest.test.ts
@@ -16,23 +16,23 @@ import { renderHook } from '@testing-library/react';
 import { useLatest } from '../../src/core';
 
 describe('useLatest', () => {
-  it('should return the initial value', () => {
+  it('should return a ref with the initial value', () => {
     const { result } = renderHook(() => useLatest(42));
-    expect(result.current).toBe(42);
+    expect(result.current.current).toBe(42);
   });
 
-  it('should return the latest value after updates', () => {
+  it('should return a ref with the latest value after updates', () => {
     const { result, rerender } = renderHook(({ value }) => useLatest(value), {
       initialProps: { value: 1 },
     });
 
-    expect(result.current).toBe(1);
+    expect(result.current.current).toBe(1);
 
     rerender({ value: 2 });
-    expect(result.current).toBe(2);
+    expect(result.current.current).toBe(2);
 
     rerender({ value: 3 });
-    expect(result.current).toBe(3);
+    expect(result.current.current).toBe(3);
   });
 
   it('should work with object values', () => {
@@ -40,10 +40,10 @@ describe('useLatest', () => {
       initialProps: { value: { key: 'initial' } },
     });
 
-    expect(result.current).toEqual({ key: 'initial' });
+    expect(result.current.current).toEqual({ key: 'initial' });
 
     rerender({ value: { key: 'updated' } });
-    expect(result.current).toEqual({ key: 'updated' });
+    expect(result.current.current).toEqual({ key: 'updated' });
   });
 
   it('should work with array values', () => {
@@ -51,9 +51,9 @@ describe('useLatest', () => {
       initialProps: { value: [1, 2] },
     });
 
-    expect(result.current).toEqual([1, 2]);
+    expect(result.current.current).toEqual([1, 2]);
 
     rerender({ value: [3, 4, 5] });
-    expect(result.current).toEqual([3, 4, 5]);
+    expect(result.current.current).toEqual([3, 4, 5]);
   });
 });


### PR DESCRIPTION
- Updated useLatest hook to return a ref object instead of direct value
- Modified JSDoc comments to reflect the new return type
- Adjusted implementation to return the entire ref instead of ref.current
- Updated dependent hooks like usePromiseState to access .current property
- Modified test cases to check ref.current instead of direct value
- Enhanced type safety by removing explicit return type annotation
- Improved code consistency with ref usage patterns