### PR TITLE
refactor(react): optimize useRequestId hook with useMemo

### DIFF
--- a/packages/react/src/core/usePromiseState.ts
+++ b/packages/react/src/core/usePromiseState.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useMountedState } from 'react-use';
 import { useLatest } from './useLatest';
 
@@ -130,7 +130,7 @@ export function usePromiseState<R = unknown, E = unknown>(
         latestOptions.current?.onSuccess?.(result);
       }
     },
-    [isMounted],
+    [isMounted, latestOptions],
   );
 
   const setErrorFn = useCallback(
@@ -142,7 +142,7 @@ export function usePromiseState<R = unknown, E = unknown>(
         latestOptions.current?.onError?.(error);
       }
     },
-    [isMounted],
+    [isMounted, latestOptions],
   );
 
   const setIdleFn = useCallback(() => {

--- a/packages/react/src/core/useRequestId.ts
+++ b/packages/react/src/core/useRequestId.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useMemo } from 'react';
 
 /**
  * Return type for useRequestId hook
@@ -90,12 +90,13 @@ export function useRequestId(): UseRequestIdReturn {
   const reset = useCallback((): void => {
     requestIdRef.current = 0;
   }, []);
-
-  return {
-    generate,
-    current,
-    isLatest,
-    invalidate,
-    reset,
-  };
+  return useMemo(() => {
+    return {
+      generate,
+      current,
+      isLatest,
+      invalidate,
+      reset,
+    };
+  }, [generate, current, isLatest, invalidate, reset]);
 }

--- a/packages/react/src/fetcher/useFetcher.ts
+++ b/packages/react/src/fetcher/useFetcher.ts
@@ -127,7 +127,7 @@ export function useFetcher<R, E = unknown>(
         }
       }
     },
-    [currentFetcher, isMounted, state, requestId],
+    [currentFetcher, isMounted, latestOptions, state, requestId],
   );
 
   useEffect(() => {


### PR DESCRIPTION
- Import useMemo from react
- Wrap hook return value with useMemo to prevent unnecessary re-renders
- Add dependency array to useMemo for proper memoization
- Maintain existing hook functionality while improving performance