### PR TITLE
chore(deps): remove unused @types/yaml dependency

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -69,7 +69,6 @@
   "devDependencies": {
     "@eslint/js": "catalog:",
     "@types/node": "catalog:",
-    "@types/yaml": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "eslint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ catalogs:
     '@types/react-dom':
       specifier: ^18.0.0
       version: 18.3.7
-    '@types/yaml':
-      specifier: ^1.9.7
-      version: 1.9.7
     '@vitest/coverage-v8':
       specifier: ^3.2.4
       version: 3.2.4
@@ -409,9 +406,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.5.2
-      '@types/yaml':
-        specifier: 'catalog:'
-        version: 1.9.7
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4)
@@ -1325,10 +1319,6 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
-
-  '@types/yaml@1.9.7':
-    resolution: {integrity: sha512-8WMXRDD1D+wCohjfslHDgICd2JtMATZU8CkhH8LVJqcJs6dyYj5TGptzP8wApbmEullGBSsCEzzap73DQ1HJaA==}
-    deprecated: This is a stub types definition. yaml provides its own type definitions, so you do not need this installed.
 
   '@typescript-eslint/eslint-plugin@8.45.0':
     resolution: {integrity: sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==}
@@ -3479,10 +3469,6 @@ snapshots:
       csstype: 3.1.3
 
   '@types/statuses@2.0.6': {}
-
-  '@types/yaml@1.9.7':
-    dependencies:
-      yaml: 2.8.1
 
   '@typescript-eslint/eslint-plugin@8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0)(typescript@5.9.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,6 @@ catalog:
   '@types/node': ^24.5.2
   '@types/react': ^18.0.0
   '@types/react-dom': ^18.0.0
-  '@types/yaml': ^1.9.7
   '@vitest/coverage-v8': ^3.2.4
   '@vitest/ui': ^3.2.4
   commander: ^14.0.0


### PR DESCRIPTION
- Removed @types/yaml from generator package devDependencies
- Removed @types/yaml from pnpm workspace catalog
- Clean up unused type definitions to reduce dependency footprint