### PR TITLE
perf(wow): optimize query hooks with useMemo

### DIFF
--- a/packages/react/src/wow/useCountQuery.ts
+++ b/packages/react/src/wow/useCountQuery.ts
@@ -15,9 +15,10 @@ import { Condition } from '@ahoo-wang/fetcher-wow';
 import {
   useExecutePromise,
   UsePromiseStateOptions,
-  useLatest, UseExecutePromiseReturn,
+  useLatest,
+  UseExecutePromiseReturn,
 } from '../core';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 
 /**
  * Options for the useCountQuery hook.
@@ -101,9 +102,12 @@ export function useCountQuery<FIELDS extends string = string, E = unknown>(
     return promiseState.execute(countExecutor);
   }, [promiseState, countExecutor]);
 
-  return {
-    ...promiseState,
-    execute,
-    setCondition,
-  };
+  return useMemo(
+    () => ({
+      ...promiseState,
+      execute,
+      setCondition,
+    }),
+    [promiseState, execute, setCondition],
+  );
 }

--- a/packages/react/src/wow/useListQuery.ts
+++ b/packages/react/src/wow/useListQuery.ts
@@ -23,7 +23,7 @@ import {
   useLatest,
   UseExecutePromiseReturn,
 } from '../core';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useListQueryState } from './useListQueryState';
 
 /**
@@ -128,12 +128,22 @@ export function useListQuery<R, FIELDS extends string = string, E = unknown>(
     return promiseState.execute(listExecutor);
   }, [promiseState, listExecutor]);
 
-  return {
-    ...promiseState,
-    execute,
-    setCondition: queryState.setCondition,
-    setProjection: queryState.setProjection,
-    setSort: queryState.setSort,
-    setLimit: queryState.setLimit,
-  };
+  return useMemo(
+    () => ({
+      ...promiseState,
+      execute,
+      setCondition: queryState.setCondition,
+      setProjection: queryState.setProjection,
+      setSort: queryState.setSort,
+      setLimit: queryState.setLimit,
+    }),
+    [
+      promiseState,
+      execute,
+      queryState.setCondition,
+      queryState.setProjection,
+      queryState.setSort,
+      queryState.setLimit,
+    ],
+  );
 }

--- a/packages/react/src/wow/useListQueryState.ts
+++ b/packages/react/src/wow/useListQueryState.ts
@@ -18,7 +18,7 @@ import {
   listQuery,
   FieldSort,
 } from '@ahoo-wang/fetcher-wow';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 /**
  * Options for the useListQueryState hook.
@@ -103,15 +103,28 @@ export function useListQueryState<FIELDS extends string = string>(
     });
   }, [condition, projection, sort, limit]);
 
-  return {
-    condition,
-    projection,
-    sort,
-    limit,
-    setCondition,
-    setProjection,
-    setSort,
-    setLimit,
-    buildQuery,
-  };
+  return useMemo(
+    () => ({
+      condition,
+      projection,
+      sort,
+      limit,
+      setCondition,
+      setProjection,
+      setSort,
+      setLimit,
+      buildQuery,
+    }),
+    [
+      condition,
+      projection,
+      sort,
+      limit,
+      setCondition,
+      setProjection,
+      setSort,
+      setLimit,
+      buildQuery,
+    ],
+  );
 }

--- a/packages/react/src/wow/useListStreamQuery.ts
+++ b/packages/react/src/wow/useListStreamQuery.ts
@@ -24,7 +24,7 @@ import {
   useLatest,
   UseExecutePromiseReturn,
 } from '../core';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useListQueryState } from './useListQueryState';
 
 /**
@@ -145,12 +145,22 @@ export function useListStreamQuery<
     return promiseState.execute(streamExecutor);
   }, [promiseState, streamExecutor]);
 
-  return {
-    ...promiseState,
-    execute,
-    setCondition: queryState.setCondition,
-    setProjection: queryState.setProjection,
-    setSort: queryState.setSort,
-    setLimit: queryState.setLimit,
-  };
+  return useMemo(
+    () => ({
+      ...promiseState,
+      execute,
+      setCondition: queryState.setCondition,
+      setProjection: queryState.setProjection,
+      setSort: queryState.setSort,
+      setLimit: queryState.setLimit,
+    }),
+    [
+      promiseState,
+      execute,
+      queryState.setCondition,
+      queryState.setProjection,
+      queryState.setSort,
+      queryState.setLimit,
+    ],
+  );
 }

--- a/packages/react/src/wow/usePagedQuery.ts
+++ b/packages/react/src/wow/usePagedQuery.ts
@@ -25,7 +25,7 @@ import {
   UsePromiseStateOptions,
   useLatest, UseExecutePromiseReturn,
 } from '../core';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 /**
  * Options for the usePagedQuery hook.
@@ -138,12 +138,17 @@ export function usePagedQuery<R, FIELDS extends string = string, E = unknown>(
     return promiseState.execute(queryExecutor);
   }, [promiseState, queryExecutor]);
 
-  return {
+  return useMemo(() => ({
     ...promiseState,
     execute,
     setCondition,
     setProjection,
     setPagination,
     setSort,
-  };
+  }), [promiseState,
+    execute,
+    setCondition,
+    setProjection,
+    setPagination,
+    setSort]);
 }

--- a/packages/react/src/wow/useSingleQuery.ts
+++ b/packages/react/src/wow/useSingleQuery.ts
@@ -23,7 +23,7 @@ import {
   UsePromiseStateOptions,
   useLatest, UseExecutePromiseReturn,
 } from '../core';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 /**
  * Options for the useSingleQuery hook.
@@ -128,12 +128,11 @@ export function useSingleQuery<R, FIELDS extends string = string, E = unknown>(
   const execute = useCallback(() => {
     return promiseState.execute(queryExecutor);
   }, [promiseState, queryExecutor]);
-
-  return {
+  return useMemo(() => ({
     ...promiseState,
     execute,
     setCondition,
     setProjection,
     setSort,
-  };
+  }), [promiseState, execute, setCondition, setProjection, setSort]);
 }


### PR DESCRIPTION
- Added useMemo to useCountQuery to prevent unnecessary re-renders
- Wrapped return values in useMemo for useListQuery hook
- Optimized useListQueryState with useMemo for better performance
- Applied useMemo to useListStreamQuery return object
- Improved usePagedQuery performance with useMemo optimization
- Enhanced useSingleQuery with useMemo for efficient rendering