### PR TITLE
fix(types): update generic type parameters in query hooks

### DIFF
--- a/packages/react/src/wow/useCountQuery.ts
+++ b/packages/react/src/wow/useCountQuery.ts
@@ -86,7 +86,7 @@ export interface UseCountQueryReturn<
  */
 export function useCountQuery<FIELDS extends string = string, E = unknown>(
   options: UseCountQueryOptions<FIELDS, E>,
-): UseCountQueryReturn<FIELDS> {
+): UseCountQueryReturn<FIELDS, E> {
   const { initialCondition } = options;
   const promiseState = useExecutePromise<number, E>(options);
   const [condition, setCondition] = useState(initialCondition);

--- a/packages/react/src/wow/useListQuery.ts
+++ b/packages/react/src/wow/useListQuery.ts
@@ -112,7 +112,7 @@ export interface UseListQueryReturn<
  */
 export function useListQuery<R, FIELDS extends string = string, E = unknown>(
   options: UseListQueryOptions<R, FIELDS, E>,
-): UseListQueryReturn<R, FIELDS> {
+): UseListQueryReturn<R, FIELDS, E> {
   const promiseState = useExecutePromise<R[], E>(options);
   const queryState = useListQueryState({ initialQuery: options.initialQuery });
   const latestOptions = useLatest(options);

--- a/packages/react/src/wow/useListStreamQuery.ts
+++ b/packages/react/src/wow/useListStreamQuery.ts
@@ -124,7 +124,7 @@ export function useListStreamQuery<
   E = unknown,
 >(
   options: UseListStreamQueryOptions<R, FIELDS, E>,
-): UseListStreamQueryReturn<R, FIELDS> {
+): UseListStreamQueryReturn<R, FIELDS, E> {
   const promiseState = useExecutePromise<
     ReadableStream<JsonServerSentEvent<R>>,
     E

--- a/packages/react/src/wow/usePagedQuery.ts
+++ b/packages/react/src/wow/usePagedQuery.ts
@@ -113,7 +113,7 @@ export interface UsePagedQueryReturn<
  */
 export function usePagedQuery<R, FIELDS extends string = string, E = unknown>(
   options: UsePagedQueryOptions<R, FIELDS, E>,
-): UsePagedQueryReturn<R, FIELDS> {
+): UsePagedQueryReturn<R, FIELDS, E> {
   const { initialQuery } = options;
   const promiseState = useExecutePromise<PagedList<R>, E>(options);
   const [condition, setCondition] = useState(initialQuery.condition);

--- a/packages/react/src/wow/useSingleQuery.ts
+++ b/packages/react/src/wow/useSingleQuery.ts
@@ -106,7 +106,7 @@ export interface UseSingleQueryReturn<
  */
 export function useSingleQuery<R, FIELDS extends string = string, E = unknown>(
   options: UseSingleQueryOptions<R, FIELDS, E>,
-): UseSingleQueryReturn<R, FIELDS> {
+): UseSingleQueryReturn<R, FIELDS, E> {
   const { initialQuery } = options;
   const promiseState = useExecutePromise<R, E>(options);
   const [condition, setCondition] = useState(initialQuery.condition);


### PR DESCRIPTION
- Added missing error type parameter to UseCountQuery return type
- Updated UseListQuery return type to include error type parameter
- Fixed UseListStreamQuery return type to properly propagate error types
- Corrected UsePagedQuery return type with explicit error type handling
- Enhanced UseSingleQuery return type to support custom error typing