### PR TITLE
feat(react): use FetcherError as default error type in hooks

### DIFF
--- a/packages/react/src/fetcher/useFetcher.ts
+++ b/packages/react/src/fetcher/useFetcher.ts
@@ -17,7 +17,7 @@ import {
   FetchExchange,
   FetchRequest,
   getFetcher,
-  RequestOptions,
+  RequestOptions, FetcherError,
 } from '@ahoo-wang/fetcher';
 import { useMounted } from '../core';
 import { useRef, useCallback, useEffect, useState, useMemo } from 'react';
@@ -33,13 +33,13 @@ import {
  * Configuration options for the useFetcher hook.
  * Extends RequestOptions and FetcherCapable interfaces.
  */
-export interface UseFetcherOptions<R, E = unknown>
+export interface UseFetcherOptions<R, E = FetcherError>
   extends RequestOptions,
     FetcherCapable,
     UsePromiseStateOptions<R, E> {
 }
 
-export interface UseFetcherReturn<R, E = unknown> extends PromiseState<R, E> {
+export interface UseFetcherReturn<R, E = FetcherError> extends PromiseState<R, E> {
   /** The FetchExchange object representing the ongoing fetch operation */
   exchange?: FetchExchange;
   execute: (request: FetchRequest) => Promise<void>;
@@ -72,7 +72,7 @@ export interface UseFetcherReturn<R, E = unknown> extends PromiseState<R, E> {
  * }
  * ```
  */
-export function useFetcher<R, E = unknown>(
+export function useFetcher<R, E = FetcherError>(
   options?: UseFetcherOptions<R, E>,
 ): UseFetcherReturn<R, E> {
   const { fetcher = fetcherRegistrar.default } = options || {};

--- a/packages/react/src/wow/useCountQuery.ts
+++ b/packages/react/src/wow/useCountQuery.ts
@@ -19,6 +19,7 @@ import {
   UseExecutePromiseReturn,
 } from '../core';
 import { useCallback, useState, useMemo } from 'react';
+import { FetcherError } from '@ahoo-wang/fetcher';
 
 /**
  * Options for the useCountQuery hook.
@@ -27,7 +28,7 @@ import { useCallback, useState, useMemo } from 'react';
  */
 export interface UseCountQueryOptions<
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UsePromiseStateOptions<number, E> {
   /**
    * The initial condition for the count query.
@@ -56,7 +57,7 @@ export interface UseCountQueryOptions<
  */
 export interface UseCountQueryReturn<
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UseExecutePromiseReturn<number, E> {
   /**
    * Executes the count query.
@@ -84,7 +85,7 @@ export interface UseCountQueryReturn<
  * });
  * ```
  */
-export function useCountQuery<FIELDS extends string = string, E = unknown>(
+export function useCountQuery<FIELDS extends string = string, E = FetcherError>(
   options: UseCountQueryOptions<FIELDS, E>,
 ): UseCountQueryReturn<FIELDS, E> {
   const { initialCondition } = options;

--- a/packages/react/src/wow/useListQuery.ts
+++ b/packages/react/src/wow/useListQuery.ts
@@ -25,6 +25,7 @@ import {
 } from '../core';
 import { useCallback, useMemo } from 'react';
 import { useListQueryState } from './useListQueryState';
+import { FetcherError } from '@ahoo-wang/fetcher';
 
 /**
  * Options for the useListQuery hook.
@@ -35,7 +36,7 @@ import { useListQueryState } from './useListQueryState';
 export interface UseListQueryOptions<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UsePromiseStateOptions<R[], E> {
   /**
    * The initial list query configuration.
@@ -66,7 +67,7 @@ export interface UseListQueryOptions<
 export interface UseListQueryReturn<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UseExecutePromiseReturn<R[], E> {
   /**
    * Executes the list query.
@@ -110,7 +111,7 @@ export interface UseListQueryReturn<
  * });
  * ```
  */
-export function useListQuery<R, FIELDS extends string = string, E = unknown>(
+export function useListQuery<R, FIELDS extends string = string, E = FetcherError>(
   options: UseListQueryOptions<R, FIELDS, E>,
 ): UseListQueryReturn<R, FIELDS, E> {
   const promiseState = useExecutePromise<R[], E>(options);

--- a/packages/react/src/wow/useListStreamQuery.ts
+++ b/packages/react/src/wow/useListStreamQuery.ts
@@ -26,6 +26,7 @@ import {
 } from '../core';
 import { useCallback, useMemo } from 'react';
 import { useListQueryState } from './useListQueryState';
+import { FetcherError } from '@ahoo-wang/fetcher';
 
 /**
  * Options for the useListStreamQuery hook.
@@ -36,7 +37,7 @@ import { useListQueryState } from './useListQueryState';
 export interface UseListStreamQueryOptions<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UsePromiseStateOptions<ReadableStream<JsonServerSentEvent<R>>, E> {
   /**
    * The initial list query configuration.
@@ -67,7 +68,7 @@ export interface UseListStreamQueryOptions<
 export interface UseListStreamQueryReturn<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UseExecutePromiseReturn<ReadableStream<JsonServerSentEvent<R>>, E> {
   /**
    * Executes the list stream query.
@@ -121,7 +122,7 @@ export interface UseListStreamQueryReturn<
 export function useListStreamQuery<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 >(
   options: UseListStreamQueryOptions<R, FIELDS, E>,
 ): UseListStreamQueryReturn<R, FIELDS, E> {

--- a/packages/react/src/wow/usePagedQuery.ts
+++ b/packages/react/src/wow/usePagedQuery.ts
@@ -26,6 +26,7 @@ import {
   useLatest, UseExecutePromiseReturn,
 } from '../core';
 import { useCallback, useMemo, useState } from 'react';
+import { FetcherError } from '@ahoo-wang/fetcher';
 
 /**
  * Options for the usePagedQuery hook.
@@ -36,7 +37,7 @@ import { useCallback, useMemo, useState } from 'react';
 export interface UsePagedQueryOptions<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UsePromiseStateOptions<PagedList<R>, E> {
   /**
    * The initial paged query configuration.
@@ -67,7 +68,7 @@ export interface UsePagedQueryOptions<
 export interface UsePagedQueryReturn<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UseExecutePromiseReturn<PagedList<R>, E> {
   /**
    * Executes the paged query.
@@ -111,7 +112,7 @@ export interface UsePagedQueryReturn<
  * });
  * ```
  */
-export function usePagedQuery<R, FIELDS extends string = string, E = unknown>(
+export function usePagedQuery<R, FIELDS extends string = string, E = FetcherError>(
   options: UsePagedQueryOptions<R, FIELDS, E>,
 ): UsePagedQueryReturn<R, FIELDS, E> {
   const { initialQuery } = options;

--- a/packages/react/src/wow/useSingleQuery.ts
+++ b/packages/react/src/wow/useSingleQuery.ts
@@ -24,6 +24,7 @@ import {
   useLatest, UseExecutePromiseReturn,
 } from '../core';
 import { useCallback, useMemo, useState } from 'react';
+import { FetcherError } from '@ahoo-wang/fetcher';
 
 /**
  * Options for the useSingleQuery hook.
@@ -34,7 +35,7 @@ import { useCallback, useMemo, useState } from 'react';
 export interface UseSingleQueryOptions<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UsePromiseStateOptions<R, E> {
   /**
    * The initial single query configuration.
@@ -65,7 +66,7 @@ export interface UseSingleQueryOptions<
 export interface UseSingleQueryReturn<
   R,
   FIELDS extends string = string,
-  E = unknown,
+  E = FetcherError,
 > extends UseExecutePromiseReturn<R, E> {
   /**
    * Executes the single query.
@@ -104,7 +105,7 @@ export interface UseSingleQueryReturn<
  * });
  * ```
  */
-export function useSingleQuery<R, FIELDS extends string = string, E = unknown>(
+export function useSingleQuery<R, FIELDS extends string = string, E = FetcherError>(
   options: UseSingleQueryOptions<R, FIELDS, E>,
 ): UseSingleQueryReturn<R, FIELDS, E> {
   const { initialQuery } = options;


### PR DESCRIPTION
- Import FetcherError from @ahoo-wang/fetcher in all query hooks
- Change default error type from unknown to FetcherError