### PR TITLE
feat(react): add autoExecute option to query hooks

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -84,15 +84,34 @@ const MyComponent = () => {
 
   const handleFetch = () => {
     execute({ url: '/api/users', method: 'GET' });
-  };
+};
+```
+
+#### Auto Execute Example
+
+```typescript jsx
+import { useListQuery } from '@ahoo-wang/fetcher-react';
+
+const MyComponent = () => {
+  const { result, loading, error, execute, setCondition } = useListQuery({
+    initialQuery: { condition: {}, projection: {}, sort: [], limit: 10 },
+    list: async (listQuery) => fetchListData(listQuery),
+    autoExecute: true, // Automatically execute on component mount
+  });
+
+  // The query will execute automatically when the component mounts
+  // You can still manually trigger it with execute() or update conditions
 
   if (loading) return <div>Loading...</div>;
   if (error) return <div>Error: {error.message}</div>;
 
   return (
     <div>
-      <pre>{JSON.stringify(result, null, 2)}</pre>
-      <button onClick={handleFetch}>Fetch Data</button>
+      <ul>
+        {result?.map((item, index) => (
+          <li key={index}>{item.name}</li>
+        ))}
+      </ul>
     </div>
   );
 };
@@ -691,6 +710,7 @@ A React hook for managing list queries with state management for conditions, pro
 **Parameters:**
 
 - `options`: Configuration options including initialQuery and list function
+    - `autoExecute`: Whether to automatically execute the query on component mount (defaults to false)
 
 **Returns:**
 
@@ -715,6 +735,7 @@ A React hook for managing paged queries with state management for conditions, pr
 **Parameters:**
 
 - `options`: Configuration options including initialQuery and query function
+    - `autoExecute`: Whether to automatically execute the query on component mount (defaults to false)
 
 **Returns:**
 
@@ -739,6 +760,7 @@ A React hook for managing single queries with state management for conditions, p
 **Parameters:**
 
 - `options`: Configuration options including initialQuery and query function
+    - `autoExecute`: Whether to automatically execute the query on component mount (defaults to false)
 
 **Returns:**
 
@@ -762,6 +784,7 @@ A React hook for managing count queries with state management for conditions.
 **Parameters:**
 
 - `options`: Configuration options including initialCondition and count function
+    - `autoExecute`: Whether to automatically execute the query on component mount (defaults to false)
 
 **Returns:**
 
@@ -787,6 +810,7 @@ Returns a readable stream of JSON server-sent events.
 **Parameters:**
 
 - `options`: Configuration options including initialQuery and listStream function
+    - `autoExecute`: Whether to automatically execute the query on component mount (defaults to false)
 
 **Returns:**
 

--- a/packages/react/README.zh-CN.md
+++ b/packages/react/README.zh-CN.md
@@ -83,15 +83,34 @@ const MyComponent = () => {
 
   const handleFetch = () => {
     execute({ url: '/api/users', method: 'GET' });
-  };
+};
+```
+
+#### 自动执行示例
+
+```typescript jsx
+import { useListQuery } from '@ahoo-wang/fetcher-react';
+
+const MyComponent = () => {
+  const { result, loading, error, execute, setCondition } = useListQuery({
+    initialQuery: { condition: {}, projection: {}, sort: [], limit: 10 },
+    list: async (listQuery) => fetchListData(listQuery),
+    autoExecute: true, // 在组件挂载时自动执行
+  });
+
+  // 查询将在组件挂载时自动执行
+  // 您仍然可以通过 execute() 手动触发或更新条件
 
   if (loading) return <div>加载中...</div>;
   if (error) return <div>错误: {error.message}</div>;
 
   return (
     <div>
-      <pre>{JSON.stringify(result, null, 2)}</pre>
-      <button onClick={handleFetch}>获取数据</button>
+      <ul>
+        {result?.map((item, index) => (
+          <li key={index}>{item.name}</li>
+        ))}
+      </ul>
     </div>
   );
 };
@@ -676,6 +695,7 @@ function useListQuery<R, FIELDS extends string = string, E = unknown>(
 **参数:**
 
 - `options`: 包含 initialQuery 和 list 函数的配置选项
+  - `autoExecute`: 是否在组件挂载时自动执行查询（默认为 false）
 
 **返回值:**
 
@@ -700,6 +720,7 @@ function usePagedQuery<R, FIELDS extends string = string, E = unknown>(
 **参数:**
 
 - `options`: 包含 initialQuery 和 query 函数的配置选项
+  - `autoExecute`: 是否在组件挂载时自动执行查询（默认为 false）
 
 **返回值:**
 
@@ -724,6 +745,7 @@ function useSingleQuery<R, FIELDS extends string = string, E = unknown>(
 **参数:**
 
 - `options`: 包含 initialQuery 和 query 函数的配置选项
+  - `autoExecute`: 是否在组件挂载时自动执行查询（默认为 false）
 
 **返回值:**
 
@@ -747,6 +769,7 @@ function useCountQuery<FIELDS extends string = string, E = unknown>(
 **参数:**
 
 - `options`: 包含 initialCondition 和 count 函数的配置选项
+  - `autoExecute`: 是否在组件挂载时自动执行查询（默认为 false）
 
 **返回值:**
 
@@ -771,6 +794,7 @@ function useListStreamQuery<R, FIELDS extends string = string, E = unknown>(
 **参数:**
 
 - `options`: 包含 initialQuery 和 listStream 函数的配置选项
+  - `autoExecute`: 是否在组件挂载时自动执行查询（默认为 false）
 
 **返回值:**
 

--- a/packages/react/src/wow/useCountQuery.ts
+++ b/packages/react/src/wow/useCountQuery.ts
@@ -18,7 +18,7 @@ import {
   useLatest,
   UseExecutePromiseReturn,
 } from '../core';
-import { useCallback, useState, useMemo } from 'react';
+import { useCallback, useState, useMemo, useEffect } from 'react';
 import { FetcherError } from '@ahoo-wang/fetcher';
 
 /**
@@ -48,6 +48,10 @@ export interface UseCountQueryOptions<
    * Optional additional attributes to pass to the count function.
    */
   attributes?: Record<string, any>;
+  /**
+   * Whether to automatically execute the query on component mount. Defaults to false.
+   */
+  autoExecute?: boolean;
 }
 
 /**
@@ -102,6 +106,14 @@ export function useCountQuery<FIELDS extends string = string, E = FetcherError>(
   const execute = useCallback(() => {
     return promiseState.execute(countExecutor);
   }, [promiseState, countExecutor]);
+
+  const { autoExecute } = options;
+
+  useEffect(() => {
+    if (autoExecute) {
+      execute();
+    }
+  }, [autoExecute, execute]);
 
   return useMemo(
     () => ({

--- a/packages/react/src/wow/useListQuery.ts
+++ b/packages/react/src/wow/useListQuery.ts
@@ -23,7 +23,7 @@ import {
   useLatest,
   UseExecutePromiseReturn,
 } from '../core';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useEffect } from 'react';
 import { useListQueryState } from './useListQueryState';
 import { FetcherError } from '@ahoo-wang/fetcher';
 
@@ -56,6 +56,10 @@ export interface UseListQueryOptions<
    * Optional additional attributes to pass to the list function.
    */
   attributes?: Record<string, any>;
+  /**
+   * Whether to automatically execute the query on component mount. Defaults to false.
+   */
+  autoExecute?: boolean;
 }
 
 /**
@@ -111,7 +115,11 @@ export interface UseListQueryReturn<
  * });
  * ```
  */
-export function useListQuery<R, FIELDS extends string = string, E = FetcherError>(
+export function useListQuery<
+  R,
+  FIELDS extends string = string,
+  E = FetcherError,
+>(
   options: UseListQueryOptions<R, FIELDS, E>,
 ): UseListQueryReturn<R, FIELDS, E> {
   const promiseState = useExecutePromise<R[], E>(options);
@@ -128,6 +136,14 @@ export function useListQuery<R, FIELDS extends string = string, E = FetcherError
   const execute = useCallback(() => {
     return promiseState.execute(listExecutor);
   }, [promiseState, listExecutor]);
+
+  const { autoExecute } = options;
+
+  useEffect(() => {
+    if (autoExecute) {
+      execute();
+    }
+  }, [autoExecute, execute]);
 
   return useMemo(
     () => ({

--- a/packages/react/src/wow/useListStreamQuery.ts
+++ b/packages/react/src/wow/useListStreamQuery.ts
@@ -24,7 +24,7 @@ import {
   useLatest,
   UseExecutePromiseReturn,
 } from '../core';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useEffect } from 'react';
 import { useListQueryState } from './useListQueryState';
 import { FetcherError } from '@ahoo-wang/fetcher';
 
@@ -57,6 +57,10 @@ export interface UseListStreamQueryOptions<
    * Optional additional attributes to pass to the listStream function.
    */
   attributes?: Record<string, any>;
+  /**
+   * Whether to automatically execute the query on component mount. Defaults to false.
+   */
+  autoExecute?: boolean;
 }
 
 /**
@@ -145,6 +149,14 @@ export function useListStreamQuery<
   const execute = useCallback(() => {
     return promiseState.execute(streamExecutor);
   }, [promiseState, streamExecutor]);
+
+  const { autoExecute } = options;
+
+  useEffect(() => {
+    if (autoExecute) {
+      execute();
+    }
+  }, [autoExecute, execute]);
 
   return useMemo(
     () => ({

--- a/packages/react/src/wow/usePagedQuery.ts
+++ b/packages/react/src/wow/usePagedQuery.ts
@@ -23,9 +23,10 @@ import {
 import {
   useExecutePromise,
   UsePromiseStateOptions,
-  useLatest, UseExecutePromiseReturn,
+  useLatest,
+  UseExecutePromiseReturn,
 } from '../core';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 import { FetcherError } from '@ahoo-wang/fetcher';
 
 /**
@@ -57,6 +58,10 @@ export interface UsePagedQueryOptions<
    * Optional additional attributes to pass to the query function.
    */
   attributes?: Record<string, any>;
+  /**
+   * Whether to automatically execute the query on component mount. Defaults to false.
+   */
+  autoExecute?: boolean;
 }
 
 /**
@@ -112,7 +117,11 @@ export interface UsePagedQueryReturn<
  * });
  * ```
  */
-export function usePagedQuery<R, FIELDS extends string = string, E = FetcherError>(
+export function usePagedQuery<
+  R,
+  FIELDS extends string = string,
+  E = FetcherError,
+>(
   options: UsePagedQueryOptions<R, FIELDS, E>,
 ): UsePagedQueryReturn<R, FIELDS, E> {
   const { initialQuery } = options;
@@ -139,17 +148,30 @@ export function usePagedQuery<R, FIELDS extends string = string, E = FetcherErro
     return promiseState.execute(queryExecutor);
   }, [promiseState, queryExecutor]);
 
-  return useMemo(() => ({
-    ...promiseState,
-    execute,
-    setCondition,
-    setProjection,
-    setPagination,
-    setSort,
-  }), [promiseState,
-    execute,
-    setCondition,
-    setProjection,
-    setPagination,
-    setSort]);
+  const { autoExecute } = options;
+
+  useEffect(() => {
+    if (autoExecute) {
+      execute();
+    }
+  }, [autoExecute, execute]);
+
+  return useMemo(
+    () => ({
+      ...promiseState,
+      execute,
+      setCondition,
+      setProjection,
+      setPagination,
+      setSort,
+    }),
+    [
+      promiseState,
+      execute,
+      setCondition,
+      setProjection,
+      setPagination,
+      setSort,
+    ],
+  );
 }

--- a/packages/react/src/wow/useSingleQuery.ts
+++ b/packages/react/src/wow/useSingleQuery.ts
@@ -21,9 +21,10 @@ import {
 import {
   useExecutePromise,
   UsePromiseStateOptions,
-  useLatest, UseExecutePromiseReturn,
+  useLatest,
+  UseExecutePromiseReturn,
 } from '../core';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 import { FetcherError } from '@ahoo-wang/fetcher';
 
 /**
@@ -55,6 +56,10 @@ export interface UseSingleQueryOptions<
    * Optional additional attributes to pass to the query function.
    */
   attributes?: Record<string, any>;
+  /**
+   * Whether to automatically execute the query on component mount. Defaults to false.
+   */
+  autoExecute?: boolean;
 }
 
 /**
@@ -105,7 +110,11 @@ export interface UseSingleQueryReturn<
  * });
  * ```
  */
-export function useSingleQuery<R, FIELDS extends string = string, E = FetcherError>(
+export function useSingleQuery<
+  R,
+  FIELDS extends string = string,
+  E = FetcherError,
+>(
   options: UseSingleQueryOptions<R, FIELDS, E>,
 ): UseSingleQueryReturn<R, FIELDS, E> {
   const { initialQuery } = options;
@@ -129,11 +138,23 @@ export function useSingleQuery<R, FIELDS extends string = string, E = FetcherErr
   const execute = useCallback(() => {
     return promiseState.execute(queryExecutor);
   }, [promiseState, queryExecutor]);
-  return useMemo(() => ({
-    ...promiseState,
-    execute,
-    setCondition,
-    setProjection,
-    setSort,
-  }), [promiseState, execute, setCondition, setProjection, setSort]);
+
+  const { autoExecute } = options;
+
+  useEffect(() => {
+    if (autoExecute) {
+      execute();
+    }
+  }, [autoExecute, execute]);
+
+  return useMemo(
+    () => ({
+      ...promiseState,
+      execute,
+      setCondition,
+      setProjection,
+      setSort,
+    }),
+    [promiseState, execute, setCondition, setProjection, setSort],
+  );
 }


### PR DESCRIPTION
- Added autoExecute option to useCountQuery, useListQuery, useListStreamQuery, usePagedQuery, and useSingleQuery
- Implemented useEffect to automatically execute queries when autoExecute is true