### PR TITLE
refactor(react): replace UsePromiseStateOptions with UseExecutePromiseOptions

### DIFF
--- a/packages/react/src/wow/useCountQuery.ts
+++ b/packages/react/src/wow/useCountQuery.ts
@@ -14,9 +14,8 @@
 import { Condition } from '@ahoo-wang/fetcher-wow';
 import {
   useExecutePromise,
-  UsePromiseStateOptions,
   useLatest,
-  UseExecutePromiseReturn,
+  UseExecutePromiseReturn, UseExecutePromiseOptions,
 } from '../core';
 import { useCallback, useState, useMemo, useEffect } from 'react';
 import { AttributesCapable, FetcherError } from '@ahoo-wang/fetcher';
@@ -30,7 +29,7 @@ import { AutoExecuteCapable } from './types';
 export interface UseCountQueryOptions<
   FIELDS extends string = string,
   E = FetcherError,
-> extends UsePromiseStateOptions<number, E>, AttributesCapable, AutoExecuteCapable {
+> extends UseExecutePromiseOptions<number, E>, AttributesCapable, AutoExecuteCapable {
   /**
    * The initial condition for the count query.
    */

--- a/packages/react/src/wow/useListQuery.ts
+++ b/packages/react/src/wow/useListQuery.ts
@@ -19,9 +19,8 @@ import {
 } from '@ahoo-wang/fetcher-wow';
 import {
   useExecutePromise,
-  UsePromiseStateOptions,
   useLatest,
-  UseExecutePromiseReturn,
+  UseExecutePromiseReturn, UseExecutePromiseOptions,
 } from '../core';
 import { useCallback, useMemo, useEffect } from 'react';
 import { useListQueryState } from './useListQueryState';
@@ -38,7 +37,7 @@ export interface UseListQueryOptions<
   R,
   FIELDS extends string = string,
   E = FetcherError,
-> extends UsePromiseStateOptions<R[], E>, AttributesCapable, AutoExecuteCapable {
+> extends UseExecutePromiseOptions<R[], E>, AttributesCapable, AutoExecuteCapable {
   /**
    * The initial list query configuration.
    */

--- a/packages/react/src/wow/useListStreamQuery.ts
+++ b/packages/react/src/wow/useListStreamQuery.ts
@@ -20,9 +20,8 @@ import {
 import type { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
 import {
   useExecutePromise,
-  UsePromiseStateOptions,
   useLatest,
-  UseExecutePromiseReturn,
+  UseExecutePromiseReturn, UseExecutePromiseOptions,
 } from '../core';
 import { useCallback, useMemo, useEffect } from 'react';
 import { useListQueryState } from './useListQueryState';
@@ -39,7 +38,7 @@ export interface UseListStreamQueryOptions<
   R,
   FIELDS extends string = string,
   E = FetcherError,
-> extends UsePromiseStateOptions<ReadableStream<JsonServerSentEvent<R>>, E>, AttributesCapable, AutoExecuteCapable {
+> extends UseExecutePromiseOptions<ReadableStream<JsonServerSentEvent<R>>, E>, AttributesCapable, AutoExecuteCapable {
   /**
    * The initial list query configuration.
    */

--- a/packages/react/src/wow/usePagedQuery.ts
+++ b/packages/react/src/wow/usePagedQuery.ts
@@ -22,9 +22,8 @@ import {
 } from '@ahoo-wang/fetcher-wow';
 import {
   useExecutePromise,
-  UsePromiseStateOptions,
   useLatest,
-  UseExecutePromiseReturn,
+  UseExecutePromiseReturn, UseExecutePromiseOptions,
 } from '../core';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import { AttributesCapable, FetcherError } from '@ahoo-wang/fetcher';
@@ -40,7 +39,7 @@ export interface UsePagedQueryOptions<
   R,
   FIELDS extends string = string,
   E = FetcherError,
-> extends UsePromiseStateOptions<PagedList<R>, E>, AttributesCapable, AutoExecuteCapable {
+> extends UseExecutePromiseOptions<PagedList<R>, E>, AttributesCapable, AutoExecuteCapable {
   /**
    * The initial paged query configuration.
    */

--- a/packages/react/src/wow/useSingleQuery.ts
+++ b/packages/react/src/wow/useSingleQuery.ts
@@ -20,9 +20,8 @@ import {
 } from '@ahoo-wang/fetcher-wow';
 import {
   useExecutePromise,
-  UsePromiseStateOptions,
   useLatest,
-  UseExecutePromiseReturn,
+  UseExecutePromiseReturn, UseExecutePromiseOptions,
 } from '../core';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import { AttributesCapable, FetcherError } from '@ahoo-wang/fetcher';
@@ -38,7 +37,7 @@ export interface UseSingleQueryOptions<
   R,
   FIELDS extends string = string,
   E = FetcherError,
-> extends UsePromiseStateOptions<R, E>, AttributesCapable, AutoExecuteCapable {
+> extends UseExecutePromiseOptions<R, E>, AttributesCapable, AutoExecuteCapable {
   /**
    * The initial single query configuration.
    */


### PR DESCRIPTION


- Updated useCountQuery to use UseExecutePromiseOptions
- Updated useListQuery to use UseExecutePromiseOptions
- Updated useListStreamQuery to use UseExecutePromiseOptions
- Updated usePagedQuery to use UseExecutePromiseOptions
- Updated useSingleQuery to use UseExecutePromiseOptions
- Removed deprecated UsePromiseStateOptions import
- Added UseExecutePromiseOptions import where needed