### PR TITLE
perf(viewer): optimize field lookup O(n*m) to O(n) using Map

### DIFF
--- a/packages/viewer/src/table/ViewTable.tsx
+++ b/packages/viewer/src/table/ViewTable.tsx
@@ -134,12 +134,14 @@ export function ViewTable<RecordType>(props: ViewTableProps<RecordType>) {
   const { selectedRowKeys, setSelectedRowKeys, reset, clearSelectedRowKeys } =
     useViewTableState();
 
+  const fieldMap = new Map(fields.map(f => [f.name, f]));
+
   /**
    * Builds table columns from field definitions and column configurations.
    * Each column is mapped to its definition for rendering and behavior.
    */
   const tableColumns: TableColumnsType<RecordType> = columns.map(col => {
-    const columnDefinition = fields.find(f => f.name === col.name);
+    const columnDefinition = fieldMap.get(col.name);
     return {
       // Unique key for React reconciliation
       key: col.key,


### PR DESCRIPTION
## Summary
- Replace `fields.find()` inside `columns.map()` loop with `Map.get()` for O(1) field lookups instead of O(n) array search per column
- Changes complexity from O(n*m) to O(n+m)

## Test plan
- [x] All 1078 tests pass (1 skipped)

🤖 Generated with [Claude Code](https://claude.ai/code)