### PR TITLE
fix(data-monitor): fetch latest data when condition updated

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,9 @@
       "Bash(ls packages/react/vitest.config* packages/viewer/vitest.config*)",
       "Bash(ls vitest.config*)",
       "Bash(node -e \"console.log\\(JSON.parse\\(require\\('fs'\\).readFileSync\\('package.json','utf8'\\)\\).scripts.test\\)\")",
-      "Bash(pnpm lint:*)"
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm test:unit packages/react/test/dataMonitor/ --run)",
+      "Bash(pnpm --filter @ahoo-wang/fetcher-react test --run)"
     ]
   }
 }

--- a/packages/react/src/dataMonitor/DataMonitorService.ts
+++ b/packages/react/src/dataMonitor/DataMonitorService.ts
@@ -101,6 +101,8 @@ export class DataMonitorService {
     if (monitored) {
       monitored.condition = condition;
       this.saveToStorage();
+      // 立即用新条件获取数据，避免因条件变化导致数量不一致而误发通知
+      this.fetchAndCheck(viewId).then();
     }
   }
 

--- a/packages/viewer/src/fetcherviewer/stories/FetcherViewer.stories.tsx
+++ b/packages/viewer/src/fetcherviewer/stories/FetcherViewer.stories.tsx
@@ -33,7 +33,7 @@ class TestFetcherRequestInterceptor implements RequestInterceptor {
       [X_WAREHOUSE_ID]: 'mydao-SH',
       [COSEC_APP_ID]: 'pms',
       Authorization:
-        'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwVkZHUnEybDAwQ24zcTgiLCJzdWIiOiIxWkUiLCJpYXQiOjE3NzQ3OTIzNTEsImV4cCI6MTc3NTA1MTU1MSwicm9sZXMiOlsiM1F2Il0sImF0dHJpYnV0ZXMiOnsiaXNPd25lciI6ImZhbHNlIiwiYXBwSWQiOiJwbXMiLCJkZXBhcnRtZW50cyI6W10sImF1dGhlbnRpY2F0ZUlkIjoiMFZCd3RBeDMwMGZoMTQ0In0sInRlbmFudElkIjoibXlkYW8ifQ.Mnv7F2X26zLJVgprat1mD7pJLhgxDEORVEVyEhpxX2g',
+        'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwVkh4WDlONjAwMkM1T1IiLCJzdWIiOiIxWkUiLCJpYXQiOjE3NzcyNjEyNjUsImV4cCI6MTc3NzUyMDQ2NSwicm9sZXMiOlsiM1F2Il0sImF0dHJpYnV0ZXMiOnsiaXNPd25lciI6ImZhbHNlIiwiYXBwSWQiOiJwbXMiLCJkZXBhcnRtZW50cyI6W10sImF1dGhlbnRpY2F0ZUlkIjoiMFZIZmdENGcwMDJDMDZwIn0sInRlbmFudElkIjoibXlkYW8ifQ.5G4-X0_UZQRa9qIA44MybZCO2f8rZSuTLvdHUrCzNfQ',
     };
 
     exchange.request.url = exchange.request.url.replace('{tenantId}', 'mydao');


### PR DESCRIPTION
This pull request introduces improvements to testing and data monitoring behavior, as well as updates to test configuration and mock authentication. The key changes are grouped below:

**Data Monitoring Behavior:**

* Updated `DataMonitorService` so that when a monitored condition is updated, it immediately fetches and checks data with the new condition. This prevents false notifications due to condition changes causing count mismatches.
