### PR TITLE
fix(viewer): 修复创建共享视图时 ownerId 被自动替换为当前用户 ID 的问题  

### DIFF
--- a/packages/viewer/src/fetcherviewer/FetcherViewer.tsx
+++ b/packages/viewer/src/fetcherviewer/FetcherViewer.tsx
@@ -37,6 +37,7 @@ import type {
   PagedList,
   PagedQuery,
 } from '@ahoo-wang/fetcher-wow';
+import type { UrlParams } from '@ahoo-wang/fetcher';
 import { fetcherRegistrar, TextResultExtractor } from '@ahoo-wang/fetcher';
 import { useKeyStorage } from '@ahoo-wang/fetcher-react';
 import { KeyStorage } from '@ahoo-wang/fetcher-storage';
@@ -196,9 +197,15 @@ export function FetcherViewer<RecordType = any>({
       const command: CreateView = {
         ...view,
       };
+
+      const requestOptions = view.type === 'SHARED'
+        ? { urlParams: { path: { ownerId: '(shared)' } as UrlParams['path'] } }
+        : {};
+
       viewCommandClient
         .createView(view.type, {
           body: command,
+          ...requestOptions,
         })
         .then((result: CommandResult) => {
           const newView = {


### PR DESCRIPTION
 ## Summary                                                                                                                                                                 

  修复创建共享视图（SHARED）时，`ownerId` 被 interceptor 自动替换为当前用户 ID 的问题。                                                                                      
   
  ## Problem                                                                                                                                                                 
                  
  创建 `SHARED` 类型的视图时，`ResourceAttributionRequestInterceptor` 会从 token 中自动提取 `ownerId`（当前用户 ID）填充到 URL 路径参数，但共享视图的 `ownerId` 应为         
  `(shared)`，导致创建后查询失败。
                                                                                                                                                                             
  ## Solution                                                                                                                                                                
  
  在调用 `createView` 时，当视图类型为 `SHARED` 时，显式传入 `urlParams.path.ownerId = '(shared)'`，阻止 interceptor 覆盖。                                                  
                  
  ## Changes

  - `packages/viewer/src/fetcherviewer/FetcherViewer.tsx`                                                                                                                    
    - 新增 `UrlParams` 类型导入
    - `handleCreateView` 中，当 `view.type === 'SHARED'` 时，通过 `requestOptions` 显式传递 `ownerId: '(shared)'`              