### PR TITLE
fix(eventstream): remove declare global to resolve TS2345

### DIFF
--- a/packages/eventstream/src/readableStreams.ts
+++ b/packages/eventstream/src/readableStreams.ts
@@ -13,19 +13,6 @@
 
 import { ReadableStreamAsyncIterable } from './readableStreamAsyncIterable';
 
-declare global {
-  interface ReadableStream<R = any> {
-    /**
-     * Makes ReadableStream async iterable for use with for-await loops.
-     *
-     * This allows the stream to be consumed using `for await (const chunk of stream)` syntax.
-     *
-     * @returns An async iterator for the stream
-     */
-    [Symbol.asyncIterator](): AsyncIterator<R>;
-  }
-}
-
 /**
  * Checks if the current environment natively supports async iteration on ReadableStream.
  *


### PR DESCRIPTION
## Problem

TypeScript 6.0.2 的 DOM lib 已内置定义 `ReadableStream[Symbol.asyncIterator]()` 返回 `ReadableStreamAsyncIterator<R>`，但 `readableStreams.ts` 中的 `declare global` 将返回类型覆盖为更窄的 `AsyncIterator<R>`，导致 `pipeThrough(TransformStream)` 报 TS2345：

```
TS2345: Argument of type TransformStream<I, O> is not assignable to parameter of type ReadableWritablePair<O, I>
The types returned by readable[Symbol.asyncIterator](...) are incompatible between these types.
Type AsyncIterator<O, any, any> is missing the following properties from type ReadableStreamAsyncIterator<O>: [Symbol.asyncIterator], [Symbol.asyncDispose]
```

## Fix

删除 `declare global` 块。TypeScript 6.0.2 DOM lib 已提供完整的类型声明。运行时 polyfill 不受影响。

## Verification

- `tsc --noEmit` 类型检查通过
- 92 个单元测试全部通过
- 100% 代码行覆盖率