### PR TITLE
refactor(eventstream): add SafeTransformer abstract base class

### DIFF
--- a/packages/eventstream/src/index.ts
+++ b/packages/eventstream/src/index.ts
@@ -68,4 +68,5 @@ export * from './serverSentEventTransformStream';
 export * from './textLineTransformStream';
 export * from './readableStreamAsyncIterable';
 export * from './readableStreams';
+export * from './safeTransformer';
 export * from './streamController';

--- a/packages/eventstream/src/jsonServerSentEventTransformStream.ts
+++ b/packages/eventstream/src/jsonServerSentEventTransformStream.ts
@@ -13,32 +13,18 @@
 
 import { type ServerSentEvent } from './serverSentEventTransformStream';
 import type { ServerSentEventStream } from './eventStreamConverter';
-import { safeEnqueue, safeError, safeTerminate } from './streamController';
+import { SafeTransformer } from './safeTransformer';
 
 /**
  * A function type that determines whether a Server-Sent Event should terminate the stream.
  *
- * This detector function is called for each incoming ServerSentEvent. If it returns true,
- * the stream transformation will be terminated, preventing further events from being processed.
- *
  * @param event - The ServerSentEvent to evaluate for termination
  * @returns true if the stream should be terminated, false otherwise
- *
- * @example
- * ```typescript
- * const terminateOnDone: TerminateDetector = (event) => {
- *   return event.event === 'done' || event.data === '[DONE]';
- * };
- * ```
  */
 export type TerminateDetector = (event: ServerSentEvent) => boolean;
 
 /**
  * Represents a Server-Sent Event with parsed JSON data.
- *
- * This interface extends the base ServerSentEvent but replaces the string 'data' field
- * with a parsed JSON object of the specified generic type. This allows for type-safe
- * access to the event payload.
  *
  * @template DATA - The expected type of the parsed JSON data
  */
@@ -51,87 +37,44 @@ export interface JsonServerSentEvent<DATA> extends Omit<
 }
 
 /**
- * A TransformStream transformer that converts ServerSentEvent to JsonServerSentEvent with optional termination detection.
+ * A TransformStream transformer that converts ServerSentEvent to
+ * JsonServerSentEvent with optional termination detection.
  *
- * This transformer parses the JSON data from ServerSentEvent chunks and optionally terminates
- * the stream when a termination condition is met. It's designed to work within a TransformStream
- * to convert raw server-sent events into typed JSON events.
+ * Inherits termination guard and safe controller operations from SafeTransformer.
  *
  * @template DATA - The expected type of the parsed JSON data in each event
  */
-export class JsonServerSentEventTransform<DATA> implements Transformer<
+export class JsonServerSentEventTransform<DATA> extends SafeTransformer<
   ServerSentEvent,
   JsonServerSentEvent<DATA>
 > {
-  /**
-   * Guard flag to prevent any controller operations after the stream has been
-   * terminated or errored. Once set, all subsequent chunks are silently dropped.
-   */
-  private terminated = false;
+  constructor(private readonly terminateDetector?: TerminateDetector) {
+    super();
+  }
 
-  /**
-   * Creates a new JsonServerSentEventTransform instance.
-   *
-   * @param terminateDetector - Optional function to detect when the stream should be terminated.
-   *                           If provided, this function is called for each event and can terminate
-   *                           the stream by returning true.
-   */
-  constructor(private readonly terminateDetector?: TerminateDetector) {}
-
-  /**
-   * Transforms a ServerSentEvent chunk into a JsonServerSentEvent.
-   *
-   * This method first checks if the stream has already been terminated. If so,
-   * the chunk is silently dropped. Otherwise, it checks if the event should
-   * terminate the stream using the terminateDetector. If termination is required,
-   * the controller is safely terminated. Otherwise, the event data is parsed
-   * as JSON and enqueued as a JsonServerSentEvent.
-   *
-   * All controller operations use safe wrappers (safeTerminate, safeEnqueue,
-   * safeError) that suppress TypeError from already-closed streams as normal
-   * control flow. Any error thrown during detection or parsing (including
-   * TypeError from detector/parse logic) is caught, the stream is errored
-   * via safeError, and subsequent chunks are dropped.
-   *
-   * @param chunk - The ServerSentEvent to transform
-   * @param controller - The TransformStream controller for managing the stream
-   */
-  transform(
+  protected onTransform(
     chunk: ServerSentEvent,
     controller: TransformStreamDefaultController<JsonServerSentEvent<DATA>>,
-  ) {
-    if (this.terminated) {
+  ): void {
+    // Check if this is a terminate event
+    if (this.terminateDetector?.(chunk)) {
+      this.terminate(controller);
       return;
     }
 
-    try {
-      // Check if this is a terminate event
-      if (this.terminateDetector?.(chunk)) {
-        this.terminated = true;
-        safeTerminate(controller);
-        return;
-      }
-
-      const json = JSON.parse(chunk.data) as DATA;
-      safeEnqueue(controller, {
-        data: json,
-        event: chunk.event,
-        id: chunk.id,
-        retry: chunk.retry,
-      });
-    } catch (error) {
-      this.terminated = true;
-      safeError(controller, error);
-    }
+    const json = JSON.parse(chunk.data) as DATA;
+    this.enqueue(controller, {
+      data: json,
+      event: chunk.event,
+      id: chunk.id,
+      retry: chunk.retry,
+    });
   }
 }
 
 /**
- * A TransformStream that converts ServerSentEvent streams to JsonServerSentEvent streams with optional termination detection.
- *
- * This class extends TransformStream to provide a convenient way to transform streams of ServerSentEvent
- * objects into streams of JsonServerSentEvent objects. It supports optional termination detection to
- * automatically end the stream when certain conditions are met.
+ * A TransformStream that converts ServerSentEvent streams to
+ * JsonServerSentEvent streams with optional termination detection.
  *
  * @template DATA - The expected type of the parsed JSON data in each event
  */
@@ -139,33 +82,13 @@ export class JsonServerSentEventTransformStream<DATA> extends TransformStream<
   ServerSentEvent,
   JsonServerSentEvent<DATA>
 > {
-  /**
-   * Creates a new JsonServerSentEventTransformStream instance.
-   *
-   * @param terminateDetector - Optional function to detect when the stream should be terminated.
-   *                           When provided, the stream will automatically terminate when this
-   *                           function returns true for any event.
-   *
-   * @example
-   * ```typescript
-   * // Create a stream that terminates on 'done' events
-   * const terminateOnDone: TerminateDetector = (event) => event.event === 'done';
-   * const transformStream = new JsonServerSentEventTransformStream<MyData>(terminateOnDone);
-   *
-   * // Create a stream without termination detection
-   * const basicStream = new JsonServerSentEventTransformStream<MyData>();
-   * ```
-   */
   constructor(terminateDetector?: TerminateDetector) {
-    super(new JsonServerSentEventTransform(terminateDetector));
+    super(new JsonServerSentEventTransform<DATA>(terminateDetector));
   }
 }
 
 /**
  * A ReadableStream of JsonServerSentEvent objects.
- *
- * This type represents a stream that yields parsed JSON server-sent events.
- * Each chunk in the stream contains the event metadata along with parsed JSON data.
  *
  * @template DATA - The expected type of the parsed JSON data in each event
  */
@@ -176,34 +99,10 @@ export type JsonServerSentEventStream<DATA> = ReadableStream<
 /**
  * Converts a ServerSentEventStream to a JsonServerSentEventStream with optional termination detection.
  *
- * This function takes a stream of raw server-sent events and transforms it into a stream of
- * parsed JSON events. It optionally accepts a termination detector to automatically end the
- * stream when certain conditions are met.
- *
  * @template DATA - The expected type of the parsed JSON data in each event
  * @param serverSentEventStream - The input stream of ServerSentEvent objects to transform
  * @param terminateDetector - Optional function to detect when the stream should be terminated
  * @returns A ReadableStream that yields JsonServerSentEvent objects with parsed JSON data
- * @throws {SyntaxError} If any event data is not valid JSON (thrown during stream consumption)
- *
- * @example
- * ```typescript
- * // Basic usage without termination detection
- * const jsonStream = toJsonServerSentEventStream<MyData>(serverSentEventStream);
- *
- * // With termination detection
- * const terminateOnDone: TerminateDetector = (event) => event.data === '[DONE]';
- * const terminatingStream = toJsonServerSentEventStream<MyData>(
- *   serverSentEventStream,
- *   terminateOnDone
- * );
- *
- * // Consume the stream
- * for await (const event of jsonStream) {
- *   console.log('Received:', event.data);
- *   console.log('Event type:', event.event);
- * }
- * ```
  */
 export function toJsonServerSentEventStream<DATA>(
   serverSentEventStream: ServerSentEventStream,

--- a/packages/eventstream/src/safeTransformer.ts
+++ b/packages/eventstream/src/safeTransformer.ts
@@ -14,6 +14,11 @@
 import { safeEnqueue, safeError, safeTerminate } from './streamController';
 
 /**
+ * Identifies the lifecycle phase where an error occurred.
+ */
+export type TransformerPhase = 'transform' | 'flush';
+
+/**
  * Abstract base class for TransformStream transformers with built-in error safety
  * and termination guard.
  *
@@ -59,7 +64,7 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
       this.onTransform(chunk, controller);
     } catch (error) {
       this.terminated = true;
-      this.onError(error);
+      this.onError(error, 'transform');
       safeError(controller, error);
     }
   }
@@ -73,6 +78,7 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
     try {
       this.onFlush(controller);
     } catch (error) {
+      this.onError(error, 'flush');
       safeError(controller, error);
     } finally {
       this.terminated = true;
@@ -100,13 +106,14 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
   }
 
   /**
-   * Called when an error occurs during `onTransform()`. Subclasses can
-   * override to clean up internal state (e.g. reset buffers).
+   * Called when an error occurs during `onTransform()` or `onFlush()`.
+   * Subclasses can override to clean up internal state (e.g. reset buffers).
    * The stream is already marked as terminated when this is called.
    *
    * @param error - The error that was caught
+   * @param phase - The lifecycle phase where the error occurred
    */
-  protected onError(error: unknown): void {
+  protected onError(error: unknown, phase: TransformerPhase): void {
     // Default: nothing to clean up
   }
 

--- a/packages/eventstream/src/safeTransformer.ts
+++ b/packages/eventstream/src/safeTransformer.ts
@@ -80,6 +80,7 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
     try {
       await this.onFlush(controller);
     } catch (error) {
+      this.terminated = true;
       this.safeOnError(error, 'flush');
       safeError(controller, error);
     } finally {
@@ -127,7 +128,7 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
    * @param error - The error that was caught
    * @param phase - The lifecycle phase where the error occurred
    */
-  protected onError(error: unknown, phase: TransformerPhase): void {
+  protected onError(_error: unknown, _phase: TransformerPhase): void {
     // Default: nothing to clean up
   }
 

--- a/packages/eventstream/src/safeTransformer.ts
+++ b/packages/eventstream/src/safeTransformer.ts
@@ -59,6 +59,7 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
       this.onTransform(chunk, controller);
     } catch (error) {
       this.terminated = true;
+      this.onError(error);
       safeError(controller, error);
     }
   }
@@ -72,8 +73,9 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
     try {
       this.onFlush(controller);
     } catch (error) {
-      this.terminated = true;
       safeError(controller, error);
+    } finally {
+      this.terminated = true;
     }
   }
 
@@ -98,6 +100,17 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
   }
 
   /**
+   * Called when an error occurs during `onTransform()`. Subclasses can
+   * override to clean up internal state (e.g. reset buffers).
+   * The stream is already marked as terminated when this is called.
+   *
+   * @param error - The error that was caught
+   */
+  protected onError(error: unknown): void {
+    // Default: nothing to clean up
+  }
+
+  /**
    * Transform an input chunk into output chunk(s).
    * Use `this.enqueue(controller, chunk)` instead of `controller.enqueue()`.
    *
@@ -113,9 +126,9 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
    * Called when the stream is ending. Override to flush remaining state.
    * Default implementation does nothing.
    *
-   * @param _controller
+   * @param controller
    */
-  protected onFlush(_controller: TransformStreamDefaultController<O>): void {
+  protected onFlush(controller: TransformStreamDefaultController<O>): void {
     // Default: nothing to flush
   }
 }

--- a/packages/eventstream/src/safeTransformer.ts
+++ b/packages/eventstream/src/safeTransformer.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { safeEnqueue, safeError, safeTerminate } from './streamController';
+
+/**
+ * Abstract base class for TransformStream transformers with built-in error safety
+ * and termination guard.
+ *
+ * Provides three guarantees that every concrete transformer inherits:
+ *
+ * 1. **Termination guard** — Once `terminated` is set (via `terminate()` or an
+ *    unhandled error), all subsequent chunks are silently dropped in `transform()`.
+ *
+ * 2. **Safe controller operations** — `enqueue()` and `error()` delegate to
+ *    `safeEnqueue` / `safeError` which suppress TypeError from already-closed
+ *    streams. `terminate()` delegates to `safeTerminate`.
+ *
+ * 3. **Error boundary** — Unhandled errors in `onTransform()` / `onFlush()`
+ *    are caught, the transformer is terminated, and the error is forwarded
+ *    via `safeError()`.
+ *
+ * Subclasses implement `onTransform()` and optionally `onFlush()` instead of
+ * the raw `transform()` / `flush()` methods.
+ *
+ * @template I - The type of input chunks
+ * @template O - The type of output chunks
+ */
+export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
+  /**
+   * Guard flag preventing any controller operations after the stream has been
+   * terminated or errored. Once set, all subsequent chunks are silently dropped.
+   */
+  protected terminated = false;
+
+  /**
+   * Transforms an input chunk. Drops immediately if terminated.
+   * Delegates to `onTransform()` with error protection.
+   */
+  transform(
+    chunk: I,
+    controller: TransformStreamDefaultController<O>,
+  ): void {
+    if (this.terminated) {
+      return;
+    }
+
+    try {
+      this.onTransform(chunk, controller);
+    } catch (error) {
+      this.terminated = true;
+      safeError(controller, error);
+    }
+  }
+
+  /**
+   * Called when the stream ends. Always invokes `onFlush()` for cleanup,
+   * even if already terminated. Errors in `onFlush()` are caught and
+   * forwarded via `safeError()`.
+   */
+  flush(controller: TransformStreamDefaultController<O>): void {
+    try {
+      this.onFlush(controller);
+    } catch (error) {
+      this.terminated = true;
+      safeError(controller, error);
+    }
+  }
+
+  /**
+   * Marks the transformer as terminated and safely terminates the controller.
+   * After calling this, all subsequent chunks are silently dropped.
+   */
+  protected terminate(controller: TransformStreamDefaultController<O>): boolean {
+    this.terminated = true;
+    return safeTerminate(controller);
+  }
+
+  /**
+   * Safely enqueues a chunk to the controller.
+   * Suppresses TypeError if the stream is already closed.
+   */
+  protected enqueue(
+    controller: TransformStreamDefaultController<O>,
+    chunk: O,
+  ): boolean {
+    return safeEnqueue(controller, chunk);
+  }
+
+  /**
+   * Transform an input chunk into output chunk(s).
+   * Use `this.enqueue(controller, chunk)` instead of `controller.enqueue()`.
+   *
+   * @param chunk - The input chunk to transform
+   * @param controller - The stream controller (use `this.enqueue()` for output)
+   */
+  protected abstract onTransform(
+    chunk: I,
+    controller: TransformStreamDefaultController<O>,
+  ): void;
+
+  /**
+   * Called when the stream is ending. Override to flush remaining state.
+   * Default implementation does nothing.
+   *
+   * @param _controller
+   */
+  protected onFlush(_controller: TransformStreamDefaultController<O>): void {
+    // Default: nothing to flush
+  }
+}

--- a/packages/eventstream/src/safeTransformer.ts
+++ b/packages/eventstream/src/safeTransformer.ts
@@ -128,8 +128,7 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
    * @param error - The error that was caught
    * @param phase - The lifecycle phase where the error occurred
    */
-  protected onError(_error: unknown, _phase: TransformerPhase): void {
-    // Default: nothing to clean up
+  protected onError(error: unknown, phase: TransformerPhase): void {
   }
 
   /**

--- a/packages/eventstream/src/safeTransformer.ts
+++ b/packages/eventstream/src/safeTransformer.ts
@@ -27,9 +27,9 @@ export type TransformerPhase = 'transform' | 'flush';
  * 1. **Termination guard** — Once `terminated` is set (via `terminate()` or an
  *    unhandled error), all subsequent chunks are silently dropped in `transform()`.
  *
- * 2. **Safe controller operations** — `enqueue()` and `error()` delegate to
- *    `safeEnqueue` / `safeError` which suppress TypeError from already-closed
- *    streams. `terminate()` delegates to `safeTerminate`.
+ * 2. **Safe controller operations** — `enqueue()` delegates to
+ *    `safeEnqueue` which suppresses TypeError from already-closed streams.
+ *    `terminate()` delegates to `safeTerminate`.
  *
  * 3. **Error boundary** — Unhandled errors in `onTransform()` / `onFlush()`
  *    are caught, the transformer is terminated, and the error is forwarded
@@ -51,20 +51,21 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
   /**
    * Transforms an input chunk. Drops immediately if terminated.
    * Delegates to `onTransform()` with error protection.
+   * Supports both synchronous and asynchronous `onTransform()` implementations.
    */
-  transform(
+  async transform(
     chunk: I,
     controller: TransformStreamDefaultController<O>,
-  ): void {
+  ): Promise<void> {
     if (this.terminated) {
       return;
     }
 
     try {
-      this.onTransform(chunk, controller);
+      await this.onTransform(chunk, controller);
     } catch (error) {
       this.terminated = true;
-      this.onError(error, 'transform');
+      this.safeOnError(error, 'transform');
       safeError(controller, error);
     }
   }
@@ -73,15 +74,28 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
    * Called when the stream ends. Always invokes `onFlush()` for cleanup,
    * even if already terminated. Errors in `onFlush()` are caught and
    * forwarded via `safeError()`.
+   * Supports both synchronous and asynchronous `onFlush()` implementations.
    */
-  flush(controller: TransformStreamDefaultController<O>): void {
+  async flush(controller: TransformStreamDefaultController<O>): Promise<void> {
     try {
-      this.onFlush(controller);
+      await this.onFlush(controller);
     } catch (error) {
-      this.onError(error, 'flush');
+      this.safeOnError(error, 'flush');
       safeError(controller, error);
     } finally {
       this.terminated = true;
+    }
+  }
+
+  /**
+   * Safely invokes `onError()`, catching any exception to prevent
+   * cleanup logic from breaking the error boundary guarantee.
+   */
+  private safeOnError(error: unknown, phase: TransformerPhase): void {
+    try {
+      this.onError(error, phase);
+    } catch {
+      // onError must not break the error boundary
     }
   }
 
@@ -120,6 +134,7 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
   /**
    * Transform an input chunk into output chunk(s).
    * Use `this.enqueue(controller, chunk)` instead of `controller.enqueue()`.
+   * May return a Promise for asynchronous processing.
    *
    * @param chunk - The input chunk to transform
    * @param controller - The stream controller (use `this.enqueue()` for output)
@@ -127,15 +142,18 @@ export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
   protected abstract onTransform(
     chunk: I,
     controller: TransformStreamDefaultController<O>,
-  ): void;
+  ): void | Promise<void>;
 
   /**
    * Called when the stream is ending. Override to flush remaining state.
+   * May return a Promise for asynchronous processing.
    * Default implementation does nothing.
    *
    * @param controller
    */
-  protected onFlush(controller: TransformStreamDefaultController<O>): void {
+  protected onFlush(
+    controller: TransformStreamDefaultController<O>,
+  ): void | Promise<void> {
     // Default: nothing to flush
   }
 }

--- a/packages/eventstream/src/safeTransformer.ts
+++ b/packages/eventstream/src/safeTransformer.ts
@@ -43,9 +43,10 @@ export type TransformerPhase = 'transform' | 'flush';
  */
 export abstract class SafeTransformer<I, O> implements Transformer<I, O> {
   /**
-   * Guard flag preventing any controller operations after the stream has been
-   * terminated or errored. Once set, all subsequent chunks are silently dropped.
+   * Guard flag indicating the stream has been terminated or errored.
+   * Once set, subsequent chunks are silently dropped in `transform()`.
    */
+
   protected terminated = false;
 
   /**

--- a/packages/eventstream/src/serverSentEventTransformStream.ts
+++ b/packages/eventstream/src/serverSentEventTransformStream.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { SafeTransformer } from './safeTransformer';
+import { SafeTransformer, type TransformerPhase } from './safeTransformer';
 
 /**
  * Represents a message sent in an event stream.
@@ -97,7 +97,7 @@ export class ServerSentEventTransformer extends SafeTransformer<
     this.currentEventState.data = [];
   }
 
-  protected override onError(error: unknown): void {
+  protected override onError(error: unknown, phase: TransformerPhase): void {
     this.resetEventState();
   }
 

--- a/packages/eventstream/src/serverSentEventTransformStream.ts
+++ b/packages/eventstream/src/serverSentEventTransformStream.ts
@@ -11,12 +11,10 @@
  * limitations under the License.
  */
 
+import { SafeTransformer } from './safeTransformer';
+
 /**
  * Represents a message sent in an event stream.
- *
- * This interface defines the structure of Server-Sent Events (SSE) as specified by the W3C.
- * Each event contains metadata and data that can be processed by clients to handle real-time
- * updates from the server.
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format}
  */
@@ -33,42 +31,14 @@ export interface ServerSentEvent {
 
 /**
  * Constants for Server-Sent Event field names.
- *
- * This class provides string constants for the standard SSE field names as defined
- * in the W3C Server-Sent Events specification. These constants help ensure
- * consistent field name usage throughout the parsing logic.
  */
-import { safeEnqueue, safeError } from './streamController';
-
 export class ServerSentEventFields {
-  /** The field name for event ID */
   static readonly ID = 'id';
-  /** The field name for retry interval */
   static readonly RETRY = 'retry';
-  /** The field name for event type */
   static readonly EVENT = 'event';
-  /** The field name for event data */
   static readonly DATA = 'data';
 }
 
-/**
- * Processes a field-value pair and updates the current event state accordingly.
- *
- * This internal function handles the parsing of individual SSE fields according to the
- * Server-Sent Events specification. It updates the provided event state object with
- * the parsed field values.
- *
- * @param field - The field name (e.g., 'event', 'data', 'id', 'retry')
- * @param value - The field value as a string
- * @param currentEvent - The current event state object to update
- *
- * @example
- * ```typescript
- * const eventState: EventState = { event: 'message', data: [] };
- * processFieldInternal('event', 'custom', eventState);
- * // eventState.event is now 'custom'
- * ```
- */
 function processFieldInternal(
   field: string,
   value: string,
@@ -92,42 +62,27 @@ function processFieldInternal(
       break;
     }
     default:
-      // Ignore unknown fields
       break;
   }
 }
 
-/**
- * Internal state representation during Server-Sent Event parsing.
- *
- * This interface tracks the current state of an event being parsed from the SSE stream.
- * It accumulates field values until a complete event is ready to be emitted.
- */
 interface EventState {
-  /** The event type (defaults to 'message') */
   event?: string;
-  /** The event ID */
   id?: string;
-  /** The retry interval in milliseconds */
   retry?: number;
-  /** Array of data lines that will be joined with newlines */
   data: string[];
 }
 
 const DEFAULT_EVENT_TYPE = 'message';
 
 /**
- * Transformer responsible for converting a string stream into a ServerSentEvent object stream.
- *
- * Implements the Transformer interface for processing data transformation in TransformStream.
- * This transformer handles the parsing of Server-Sent Events (SSE) according to the W3C specification.
- * It processes incoming text chunks and converts them into structured ServerSentEvent objects.
+ * Transformer responsible for converting a string stream into a
+ * ServerSentEvent object stream, following the W3C SSE specification.
  */
-export class ServerSentEventTransformer implements Transformer<
+export class ServerSentEventTransformer extends SafeTransformer<
   string,
   ServerSentEvent
 > {
-  // Initialize currentEventState with default values in a closure
   private currentEventState: EventState = {
     event: DEFAULT_EVENT_TYPE,
     id: undefined,
@@ -135,10 +90,6 @@ export class ServerSentEventTransformer implements Transformer<
     data: [],
   };
 
-  /**
-   * Reset the current event state to default values.
-   * This method is called after processing each complete event or when an error occurs.
-   */
   private resetEventState() {
     this.currentEventState.event = DEFAULT_EVENT_TYPE;
     this.currentEventState.id = undefined;
@@ -146,146 +97,82 @@ export class ServerSentEventTransformer implements Transformer<
     this.currentEventState.data = [];
   }
 
-  /**
-   * Transform input string chunk into ServerSentEvent object.
-   * This method processes individual chunks of text data, parsing them according to the SSE format.
-   * It handles:
-   * - Empty lines (used as event separators)
-   * - Comment lines (starting with ':')
-   * - Field lines (field: value format)
-   * - Event completion and emission
-   *
-   * @param chunk Input string chunk
-   * @param controller Controller for controlling the transform stream
-   */
-  transform(
+  protected onTransform(
     chunk: string,
     controller: TransformStreamDefaultController<ServerSentEvent>,
-  ) {
+  ): void {
     const currentEvent = this.currentEventState;
-    try {
-      // Skip empty lines (event separator)
-      if (chunk.trim() === '') {
-        // If there is accumulated event data, send event
-        if (currentEvent.data.length > 0) {
-          safeEnqueue(controller, {
-            event: currentEvent.event || DEFAULT_EVENT_TYPE,
-            data: currentEvent.data.join('\n'),
-            id: currentEvent.id || '',
-            retry: currentEvent.retry,
-          } as ServerSentEvent);
 
-          // Reset current event (preserve id and retry for subsequent events)
-          currentEvent.event = DEFAULT_EVENT_TYPE;
-          // Preserve id and retry for subsequent events (no need to reassign to themselves)
-          currentEvent.data = [];
-        }
-        return;
+    // Skip empty lines (event separator)
+    if (chunk.trim() === '') {
+      if (currentEvent.data.length > 0) {
+        this.enqueue(controller, {
+          event: currentEvent.event || DEFAULT_EVENT_TYPE,
+          data: currentEvent.data.join('\n'),
+          id: currentEvent.id || '',
+          retry: currentEvent.retry,
+        } as ServerSentEvent);
+
+        currentEvent.event = DEFAULT_EVENT_TYPE;
+        currentEvent.data = [];
       }
-
-      // Ignore comment lines (starting with colon)
-      if (chunk.startsWith(':')) {
-        return;
-      }
-
-      // Parse fields
-      const colonIndex = chunk.indexOf(':');
-      let field: string;
-      let value: string;
-
-      if (colonIndex === -1) {
-        // No colon, entire line as field name, value is empty
-        field = chunk.toLowerCase();
-        value = '';
-      } else {
-        // Extract field name and value
-        field = chunk.substring(0, colonIndex).toLowerCase();
-        value = chunk.substring(colonIndex + 1);
-
-        // If value starts with space, remove leading space
-        if (value.startsWith(' ')) {
-          value = value.substring(1);
-        }
-      }
-
-      // Remove trailing newlines from field and value
-      field = field.trim();
-      value = value.trim();
-
-      processFieldInternal(field, value, currentEvent);
-    } catch (error) {
-      const enhancedError = new Error(
-        `Failed to process chunk: "${chunk}". ${error instanceof Error ? error.message : String(error)}`,
-      );
-      safeError(controller, enhancedError);
-      // Reset state
-      this.resetEventState();
+      return;
     }
+
+    // Ignore comment lines (starting with colon)
+    if (chunk.startsWith(':')) {
+      return;
+    }
+
+    // Parse fields
+    const colonIndex = chunk.indexOf(':');
+    let field: string;
+    let value: string;
+
+    if (colonIndex === -1) {
+      field = chunk.toLowerCase();
+      value = '';
+    } else {
+      field = chunk.substring(0, colonIndex).toLowerCase();
+      value = chunk.substring(colonIndex + 1);
+      if (value.startsWith(' ')) {
+        value = value.substring(1);
+      }
+    }
+
+    field = field.trim();
+    value = value.trim();
+
+    processFieldInternal(field, value, currentEvent);
   }
 
-  /**
-   * Called when the stream ends, used to process remaining data.
-   *
-   * @param controller Controller for controlling the transform stream
-   */
-  flush(controller: TransformStreamDefaultController<ServerSentEvent>) {
+  protected onFlush(
+    controller: TransformStreamDefaultController<ServerSentEvent>,
+  ): void {
     const currentEvent = this.currentEventState;
     try {
-      // Send the last event (if any)
       if (currentEvent.data.length > 0) {
-        safeEnqueue(controller, {
+        this.enqueue(controller, {
           event: currentEvent.event || DEFAULT_EVENT_TYPE,
           data: currentEvent.data.join('\n'),
           id: currentEvent.id || '',
           retry: currentEvent.retry,
         } as ServerSentEvent);
       }
-    } catch (error) {
-      const enhancedError = new Error(
-        `Failed to flush remaining data. ${error instanceof Error ? error.message : String(error)}`,
-      );
-      safeError(controller, enhancedError);
     } finally {
-      // Reset state
       this.resetEventState();
     }
   }
 }
 
 /**
- * A TransformStream that converts a stream of strings into a stream of ServerSentEvent objects.
- *
- * This class provides a convenient way to transform raw text streams containing Server-Sent Events
- * into structured event objects. It wraps the ServerSentEventTransformer in a TransformStream
- * for easy integration with other stream processing pipelines.
- *
- * The stream processes SSE format text and emits ServerSentEvent objects as they are completed.
- * Events are separated by empty lines, and the stream handles partial events across multiple chunks.
- *
- * @example
- * ```typescript
- * // Create a transform stream
- * const sseStream = new ServerSentEventTransformStream();
- *
- * // Pipe a text stream through it
- * const eventStream = textStream.pipeThrough(sseStream);
- *
- * // Consume the events
- * for await (const event of eventStream) {
- *   console.log('Event:', event.event, 'Data:', event.data);
- * }
- * ```
+ * A TransformStream that converts a stream of strings into a stream of
+ * ServerSentEvent objects.
  */
 export class ServerSentEventTransformStream extends TransformStream<
   string,
   ServerSentEvent
 > {
-  /**
-   * Creates a new ServerSentEventTransformStream instance.
-   *
-   * Initializes the stream with a ServerSentEventTransformer that handles
-   * the parsing of SSE format text into structured events.
-   */
   constructor() {
     super(new ServerSentEventTransformer());
   }

--- a/packages/eventstream/src/serverSentEventTransformStream.ts
+++ b/packages/eventstream/src/serverSentEventTransformStream.ts
@@ -97,6 +97,10 @@ export class ServerSentEventTransformer extends SafeTransformer<
     this.currentEventState.data = [];
   }
 
+  protected override onError(error: unknown): void {
+    this.resetEventState();
+  }
+
   protected onTransform(
     chunk: string,
     controller: TransformStreamDefaultController<ServerSentEvent>,

--- a/packages/eventstream/src/serverSentEventTransformStream.ts
+++ b/packages/eventstream/src/serverSentEventTransformStream.ts
@@ -97,7 +97,7 @@ export class ServerSentEventTransformer extends SafeTransformer<
     this.currentEventState.data = [];
   }
 
-  protected override onError(error: unknown, phase: TransformerPhase): void {
+  protected override onError(_error: unknown, _phase: TransformerPhase): void {
     this.resetEventState();
   }
 

--- a/packages/eventstream/src/textLineTransformStream.ts
+++ b/packages/eventstream/src/textLineTransformStream.ts
@@ -11,74 +11,37 @@
  * limitations under the License.
  */
 
+import { SafeTransformer } from './safeTransformer';
+
 /**
  * Transformer that splits text into lines.
  *
- * This transformer accumulates chunks of text and splits them by newline characters ('\n'),
- * emitting each complete line as a separate chunk. It handles partial lines that span multiple
- * input chunks by maintaining an internal buffer. Lines are emitted without the newline character.
- *
- * The transformer handles various edge cases:
- * - Lines that span multiple input chunks
- * - Empty lines (emitted as empty strings)
- * - Text without trailing newlines (buffered until stream ends)
- * - Mixed line endings (only '\n' is recognized as line separator)
- *
- * @implements {Transformer<string, string>}
- *
- * @example
- * ```typescript
- * const transformer = new TextLineTransformer();
- * // Input: "line1\nline2\npartial"
- * // Output: ["line1", "line2"]
- * // Buffer: "partial"
- *
- * // Later input: "line\n"
- * // Output: ["partialline"]
- * // Buffer: ""
- * ```
+ * Accumulates chunks of text and splits them by newline characters ('\n'),
+ * emitting each complete line as a separate chunk. Handles partial lines
+ * that span multiple input chunks by maintaining an internal buffer.
  */
-import { safeEnqueue, safeError } from './streamController';
-
-export class TextLineTransformer implements Transformer<string, string> {
+export class TextLineTransformer extends SafeTransformer<string, string> {
   private buffer = '';
 
-  /**
-   * Transform input string chunk by splitting it into lines.
-   *
-   * @param chunk Input string chunk
-   * @param controller Controller for controlling the transform stream
-   */
-  transform(
+  protected onTransform(
     chunk: string,
     controller: TransformStreamDefaultController<string>,
-  ) {
-    try {
-      this.buffer += chunk;
-      const lines = this.buffer.split('\n');
-      this.buffer = lines.pop() || '';
+  ): void {
+    this.buffer += chunk;
+    const lines = this.buffer.split('\n');
+    this.buffer = lines.pop() || '';
 
-      for (const line of lines) {
-        safeEnqueue(controller, line);
-      }
-    } catch (error) {
-      safeError(controller, error);
+    for (const line of lines) {
+      this.enqueue(controller, line);
     }
   }
 
-  /**
-   * Flush remaining buffer when the stream ends.
-   *
-   * @param controller Controller for controlling the transform stream
-   */
-  flush(controller: TransformStreamDefaultController<string>) {
-    try {
-      // Only send when buffer is not empty, avoid sending meaningless empty lines
-      if (this.buffer) {
-        safeEnqueue(controller, this.buffer);
-      }
-    } catch (error) {
-      safeError(controller, error);
+  protected onFlush(
+    controller: TransformStreamDefaultController<string>,
+  ): void {
+    // Only send when buffer is not empty, avoid sending meaningless empty lines
+    if (this.buffer) {
+      this.enqueue(controller, this.buffer);
     }
   }
 }
@@ -86,48 +49,16 @@ export class TextLineTransformer implements Transformer<string, string> {
 /**
  * A TransformStream that splits text into lines.
  *
- * This class provides a convenient way to transform a stream of text chunks into a stream
- * of individual lines. It wraps the TextLineTransformer in a TransformStream for easy
- * integration with other stream processing pipelines.
- *
- * The stream processes text data and emits each line as a separate chunk, handling
- * lines that may span multiple input chunks automatically.
- *
  * @example
  * ```typescript
- * // Create a line-splitting stream
  * const lineStream = new TextLineTransformStream();
- *
- * // Pipe text through it
  * const lines = textStream.pipeThrough(lineStream);
- *
- * // Process each line
  * for await (const line of lines) {
  *   console.log('Line:', line);
  * }
  * ```
- *
- * @example
- * ```typescript
- * // Process SSE response line by line
- * const response = await fetch('/api/stream');
- * const lines = response.body!
- *   .pipeThrough(new TextDecoderStream())
- *   .pipeThrough(new TextLineTransformStream());
- *
- * for await (const line of lines) {
- *   if (line.startsWith('data: ')) {
- *     console.log('SSE data:', line.substring(6));
- *   }
- * }
- * ```
  */
 export class TextLineTransformStream extends TransformStream<string, string> {
-  /**
-   * Creates a new TextLineTransformStream instance.
-   *
-   * Initializes the stream with a TextLineTransformer that handles the line splitting logic.
-   */
   constructor() {
     super(new TextLineTransformer());
   }

--- a/packages/eventstream/test/serverSentEventTransformStream.test.ts
+++ b/packages/eventstream/test/serverSentEventTransformStream.test.ts
@@ -555,13 +555,8 @@ describe('serverSentEventTransformStream.ts', () => {
 
       transformer.transform(chunk, controller);
 
-      expect(controller.error).toHaveBeenCalledWith(expect.any(Error));
-      // The error should be converted to an Error object with enhanced message
-      const errorCall = (controller.error as any).mock.calls[0][0];
-      expect(errorCall).toBeInstanceOf(Error);
-      expect(errorCall.message).toBe(
-        'Failed to process chunk: "[object Object]". Test error string',
-      );
+      // SafeTransformer passes the original error through safeError
+      expect(controller.error).toHaveBeenCalledWith('Test error string');
     });
 
     it('should handle undefined event in flush', async () => {
@@ -589,28 +584,18 @@ describe('serverSentEventTransformStream.ts', () => {
     it('should handle non-Error object in flush error', async () => {
       const transformer = new ServerSentEventTransformer();
       const controller = {
-        enqueue: vi.fn(),
+        enqueue: vi.fn(() => {
+          throw 'Test error string';
+        }),
         error: vi.fn(),
       } as any;
 
-      // Mock controller.enqueue to throw a non-Error object
-      controller.enqueue.mockImplementationOnce(() => {
-        throw 'Test error string';
-      });
-
-      // Send data
+      // Accumulate data, then flush triggers enqueue which throws
       transformer.transform('data:test data', controller);
-
-      // Flush should handle the error
       transformer.flush(controller);
 
-      expect(controller.error).toHaveBeenCalledWith(expect.any(Error));
-      // The error should be converted to an Error object with enhanced message
-      const errorCall = (controller.error as any).mock.calls[0][0];
-      expect(errorCall).toBeInstanceOf(Error);
-      expect(errorCall.message).toBe(
-        'Failed to flush remaining data. Test error string',
-      );
+      // SafeTransformer catches the error and forwards via safeError
+      expect(controller.error).toHaveBeenCalledWith('Test error string');
     });
   });
 });


### PR DESCRIPTION
## Summary

Introduce `SafeTransformer<I, O>` abstract base class to eliminate duplicated error handling, termination guards, and safe controller operations across all three eventstream transformers.

## Changes

**New: `safeTransformer.ts`**
- `SafeTransformer<I, O>` implements `Transformer<I, O>` with:
  - `protected terminated` flag — subclasses access directly (no `isTerminated` getter)
  - `transform()` — drops chunks after termination; catch → `safeError()`
  - `flush()` — always calls `onFlush()` for cleanup, even after termination
  - `terminate()` / `enqueue()` — delegate to `safeTerminate` / `safeEnqueue`
  - `onTransform()` (abstract) / `onFlush()` (optional) — subclass hooks

**Refactored:**
- `TextLineTransformer` — extends `SafeTransformer`, removes manual try/catch and `safeEnqueue`/`safeError` calls
- `ServerSentEventTransformer` — extends `SafeTransformer`, `onFlush` uses `try/finally` for `resetEventState()`
- `JsonServerSentEventTransform` — extends `SafeTransformer`, removes private `terminated` flag and manual error handling

**Tests:** Updated error-propagation expectations to match SafeTransformer semantics.

## Stats

+219 / -395 lines (net -176)
