### PR TITLE
fix(eventstream): SSE spec compliance for id, retry, and field parsing

### DIFF
--- a/packages/eventstream/src/serverSentEventTransformStream.ts
+++ b/packages/eventstream/src/serverSentEventTransformStream.ts
@@ -52,12 +52,18 @@ function processFieldInternal(
       currentEvent.data.push(value);
       break;
     case ServerSentEventFields.ID:
-      currentEvent.id = value;
+      // Per W3C SSE spec: "If the field value does not contain U+0000 NULL,
+      // then set the last event ID buffer to the field value.
+      // Otherwise, ignore the field."
+      if (!value.includes('\0')) {
+        currentEvent.id = value;
+      }
       break;
     case ServerSentEventFields.RETRY: {
-      const retryValue = parseInt(value, 10);
-      if (!isNaN(retryValue)) {
-        currentEvent.retry = retryValue;
+      // Per W3C SSE spec: "If the field value consists of only ASCII digits,
+      // then interpret the field value as an integer in base ten."
+      if (/^\d+$/.test(value)) {
+        currentEvent.retry = parseInt(value, 10);
       }
       break;
     }
@@ -144,8 +150,6 @@ export class ServerSentEventTransformer extends SafeTransformer<
       }
     }
 
-    field = field.trim();
-    value = value.trim();
 
     processFieldInternal(field, value, currentEvent);
   }

--- a/packages/eventstream/test/serverSentEventTransformStream.test.ts
+++ b/packages/eventstream/test/serverSentEventTransformStream.test.ts
@@ -576,6 +576,50 @@ describe('serverSentEventTransformStream.ts', () => {
       );
     });
 
+    it('should preserve valid id when subsequent id contains NULL', async () => {
+      const transformer = new ServerSentEventTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      // First: valid id
+      transformer.transform('id:valid-1', controller);
+      // Then: invalid id with NULL (should be ignored, not clear previous)
+      transformer.transform('id:bad\0id', controller);
+      transformer.transform('data:test', controller);
+      transformer.transform('', controller);
+
+      // The valid id should be preserved
+      expect(controller.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'valid-1',
+        }),
+      );
+    });
+
+    it('should preserve valid retry when subsequent retry is invalid', async () => {
+      const transformer = new ServerSentEventTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      // First: valid retry
+      transformer.transform('retry:5000', controller);
+      // Then: invalid retry (should be ignored, not clear previous)
+      transformer.transform('retry:abc', controller);
+      transformer.transform('data:test', controller);
+      transformer.transform('', controller);
+
+      // The valid retry should be preserved
+      expect(controller.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          retry: 5000,
+        }),
+      );
+    });
+
     it('should handle empty data array in flush', async () => {
       const transformer = new ServerSentEventTransformer();
       const controller = {

--- a/packages/eventstream/test/serverSentEventTransformStream.test.ts
+++ b/packages/eventstream/test/serverSentEventTransformStream.test.ts
@@ -469,7 +469,7 @@ describe('serverSentEventTransformStream.ts', () => {
         error: vi.fn(),
       } as any;
 
-      // Send field with whitespace
+      // Per W3C SSE spec, field names are NOT trimmed, so "  event  " is an unknown field
       transformer.transform('  event  :test', controller);
 
       // Send data
@@ -480,7 +480,7 @@ describe('serverSentEventTransformStream.ts', () => {
 
       expect(controller.enqueue).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: 'test',
+          event: 'message',
           data: 'test data',
         }),
       );
@@ -493,7 +493,7 @@ describe('serverSentEventTransformStream.ts', () => {
         error: vi.fn(),
       } as any;
 
-      // Send field with whitespace in value
+      // Per W3C SSE spec, only a single leading space after colon is stripped, no trailing trim
       transformer.transform('data:  test data  ', controller);
 
       // Send empty line to trigger event
@@ -501,7 +501,77 @@ describe('serverSentEventTransformStream.ts', () => {
 
       expect(controller.enqueue).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: 'test data',
+          data: ' test data  ',
+        }),
+      );
+    });
+
+    it('should ignore id field with NULL character per SSE spec', async () => {
+      const transformer = new ServerSentEventTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      // Send id with NULL character (should be ignored per W3C spec)
+      transformer.transform('id:bad\0id', controller);
+      // Send data to trigger event
+      transformer.transform('data:test', controller);
+      transformer.transform('', controller);
+
+      // id should not be set because it contains NULL
+      const event = (controller.enqueue as any).mock.calls[0][0];
+      expect(event.id).toBe('');
+    });
+
+    it('should accept valid id without NULL character', async () => {
+      const transformer = new ServerSentEventTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      transformer.transform('id:valid-123', controller);
+      transformer.transform('data:test', controller);
+      transformer.transform('', controller);
+
+      expect(controller.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'valid-123',
+        }),
+      );
+    });
+
+    it('should reject retry value with non-digit characters per SSE spec', async () => {
+      const transformer = new ServerSentEventTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      // "5000abc" should be rejected per spec (must consist of only ASCII digits)
+      transformer.transform('retry:5000abc', controller);
+      transformer.transform('data:test', controller);
+      transformer.transform('', controller);
+
+      const event = (controller.enqueue as any).mock.calls[0][0];
+      expect(event.retry).toBeUndefined();
+    });
+
+    it('should accept retry value with only ASCII digits', async () => {
+      const transformer = new ServerSentEventTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      transformer.transform('retry:5000', controller);
+      transformer.transform('data:test', controller);
+      transformer.transform('', controller);
+
+      expect(controller.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          retry: 5000,
         }),
       );
     });


### PR DESCRIPTION
## Summary

W3C SSE 规范合规性修复，涉及 `ServerSentEventTransformer` 的三个字段解析问题。

## Changes

- **`id` 字段 NULL 字符检查** — 包含 `\0` (U+0000 NULL) 的 id 值现在会被忽略，符合 W3C SSE 规范要求
- **`retry` 严格数字验证** — 用 `/^\d+$/` 替代 `parseInt + isNaN`，拒绝 `"5000abc"` 等非纯数字值
- **移除 field/value 的额外 `trim()`** — 仅在冒号后剥离单个前导空格 (U+0020)，field name 不再做 trim，严格匹配 W3C 规范

## Spec References

- [W3C SSE - Parsing an event stream](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream)
- [W3C SSE - Interpreting an event stream](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation)

## Test Coverage

- 116 tests all passed
- 100% statement / line / function coverage