### PR TITLE
feat(viewer): 支持部分过滤器保存（操作符变更时保留）

### DIFF
--- a/packages/viewer/src/filter/FallbackFilter.tsx
+++ b/packages/viewer/src/filter/FallbackFilter.tsx
@@ -14,12 +14,19 @@
 import { Alert } from 'antd';
 import React, { useImperativeHandle } from 'react';
 import type { TypedFilterProps } from './TypedFilter';
-import type { FilterValue } from './types';
+import type { FilterState, FilterValue } from './types';
+import { ExtendedOperator } from './operator';
 
 export function FallbackFilter({ type, ref }: TypedFilterProps) {
   useImperativeHandle(ref, () => ({
     getValue(): FilterValue | undefined {
       return undefined;
+    },
+    getState(): FilterState {
+      return {
+        operator: ExtendedOperator.UNDEFINED,
+        value: undefined,
+      };
     },
     reset(): void {
       // No-op for fallback filter

--- a/packages/viewer/src/filter/panel/FilterPanel.tsx
+++ b/packages/viewer/src/filter/panel/FilterPanel.tsx
@@ -16,6 +16,7 @@ import React, { useImperativeHandle } from 'react';
 import type { TypedFilterProps } from '../TypedFilter';
 import type { FilterRef } from '../types';
 import type { Condition } from '@ahoo-wang/fetcher-wow';
+import type { FilterState } from '../types';
 import { and } from '@ahoo-wang/fetcher-wow';
 import type { ColProps, ButtonProps } from 'antd';
 import { Button, Col, Row, Space } from 'antd';
@@ -66,6 +67,7 @@ export interface FilterPanelProps extends RefAttributes<FilterPanelRef> {
   onSearch?: (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
+    filterStates: Map<Key, FilterState>,
   ) => void;
   resetButton?: boolean | Omit<ButtonProps, 'onClick'>;
   searchButton?: Omit<ButtonProps, 'onClick'>;
@@ -105,9 +107,12 @@ export function FilterPanel(props: FilterPanelProps) {
 
   const getCondition = () => {
     const conditions: Condition[] = [];
+    const filterStates = new Map<Key, FilterState>();
     const activeFilterValues = new Map<Key, Condition>();
     for (const entry of filterRefs.entries()) {
       const key = entry[0];
+      const filterState = entry[1].getState();
+      filterStates.set(key, filterState);
       const condition = entry[1].getValue()?.condition;
       if (condition) {
         conditions.push(condition);
@@ -118,6 +123,7 @@ export function FilterPanel(props: FilterPanelProps) {
     return {
       finalCondition,
       activeFilterValues,
+      filterStates,
     };
   };
 
@@ -125,8 +131,8 @@ export function FilterPanel(props: FilterPanelProps) {
     if (!onSearch) {
       return;
     }
-    const { finalCondition, activeFilterValues } = getCondition();
-    onSearch(finalCondition, activeFilterValues);
+    const { finalCondition, activeFilterValues, filterStates } = getCondition();
+    onSearch(finalCondition, activeFilterValues, filterStates);
   };
   const handleReset = () => {
     for (const filterRef of filterRefs.values()) {

--- a/packages/viewer/src/filter/types.ts
+++ b/packages/viewer/src/filter/types.ts
@@ -19,7 +19,7 @@ import type {
 import type { SelectProps } from 'antd/es/select';
 import type { RefAttributes } from 'react';
 import type React from 'react';
-import type { StyleCapable } from '../types';
+import type { Optional, StyleCapable } from '../types';
 import type { SelectOperator, SelectOperatorLocale } from './operator';
 
 /**
@@ -34,7 +34,14 @@ export interface FilterField extends NamedCapable {
 export interface FilterRef {
   getValue(): FilterValue | undefined;
 
+  getState(): FilterState;
+
   reset(): void;
+}
+
+export interface FilterState {
+  operator: SelectOperator;
+  value: Optional;
 }
 
 export interface FilterLabelProps extends StyleCapable {}

--- a/packages/viewer/src/filter/useFilterState.ts
+++ b/packages/viewer/src/filter/useFilterState.ts
@@ -15,7 +15,7 @@ import type { Condition, ConditionOptions } from '@ahoo-wang/fetcher-wow';
 import { EMPTY_VALUE_OPERATORS, Operator } from '@ahoo-wang/fetcher-wow';
 import type { RefAttributes } from 'react';
 import { useImperativeHandle, useState } from 'react';
-import type { FilterRef, FilterValue } from './types';
+import type { FilterRef, FilterState, FilterValue } from './types';
 import type { Optional } from '../types';
 import type { SelectOperator } from './operator';
 import { ExtendedOperator } from './operator';
@@ -154,6 +154,9 @@ export function useFilterState(
   useImperativeHandle<FilterRef, FilterRef>(options.ref, () => ({
     getValue(): FilterValue | undefined {
       return resolveFilterValue(operator, value);
+    },
+    getState(): FilterState {
+      return { operator, value };
     },
     reset: resetFn,
   }));

--- a/packages/viewer/src/view/View.tsx
+++ b/packages/viewer/src/view/View.tsx
@@ -23,6 +23,7 @@ import type {
 import { EditableFilterPanel, FilterPanel } from '../filter';
 import type * as React from 'react';
 import type { Condition, FieldSort, PagedList } from '@ahoo-wang/fetcher-wow';
+import type { FilterState } from '../filter/types';
 import type { Key, RefAttributes } from 'react';
 import { useCallback, useImperativeHandle, useRef } from 'react';
 import type { FieldDefinition, ViewColumn } from '../viewer';
@@ -162,6 +163,7 @@ export interface ViewProps<RecordType>
   externalUpdateCondition?: (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
+    filterStates: Map<Key, FilterState>,
   ) => void;
 
   /** Optional action column configuration for row-level operations */
@@ -251,12 +253,14 @@ export function View<RecordType>({
    * Updates internal condition state and triggers onChange callback.
    * @param finalCondition - The composed filter condition from filter panel.
    * @param activeFilterValues -
+   * @param filterStates -
    */
   const handleSearch = (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
+    filterStates: Map<Key, FilterState>,
   ) => {
-    setCondition(finalCondition, activeFilterValues);
+    setCondition(finalCondition, activeFilterValues, filterStates);
   };
 
   /**

--- a/packages/viewer/src/view/hooks/useViewState.ts
+++ b/packages/viewer/src/view/hooks/useViewState.ts
@@ -13,6 +13,7 @@
 
 import type { Condition, FieldSort } from '@ahoo-wang/fetcher-wow';
 import type { Key } from 'react';
+import type { FilterState } from '../../filter/types';
 import { useState } from 'react';
 import type { SizeType } from 'antd/es/config-provider/SizeContext';
 import type { ActiveFilter, ViewColumn } from '../../index';
@@ -96,6 +97,7 @@ export interface UseViewStateOptions {
   externalUpdateCondition?: (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
+    filterStates: Map<Key, FilterState>,
   ) => void;
   /** Default sort configuration (uncontrolled mode) */
   defaultSorter?: FieldSort[];
@@ -145,6 +147,7 @@ export interface UseViewStateReturn {
   setCondition: (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
+    filterStates: Map<Key, FilterState>,
   ) => void;
   /** Current sort configuration */
   sorter: FieldSort[];
@@ -328,12 +331,14 @@ export function useViewState({
    * Typically called when user applies a new filter.
    * @param finalCondition - New filter condition.
    * @param activeFilterValues - Map of active filter keys to their updated conditions.
+   * @param filterStates - Map of active filter keys to their current operator/value states.
    */
   const setConditionFn = (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
+    filterStates: Map<Key, FilterState>,
   ) => {
-    setCondition(finalCondition, activeFilterValues);
+    setCondition(finalCondition, activeFilterValues, filterStates);
     setPage(1);
     onChange?.(finalCondition, 1, pageSize, sorter);
   };

--- a/packages/viewer/src/viewer/hooks/useViewerState.ts
+++ b/packages/viewer/src/viewer/hooks/useViewerState.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import type { ActiveFilter } from '../../';
 import { deepEqual, useActiveViewState } from '../../';
 import type { Condition, FieldSort } from '@ahoo-wang/fetcher-wow';
+import type { FilterState } from '../../filter/types';
 import { all } from '@ahoo-wang/fetcher-wow';
 import type { SortOrder } from 'antd/es/table/interface';
 
@@ -54,6 +55,7 @@ export interface UseViewerStateReturn {
   setCondition: (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
+    filterStates: Map<Key, FilterState>,
   ) => void;
   page: number;
   setPage: (page: number) => void;
@@ -182,17 +184,32 @@ export function useViewerState({
   const setConditionFn = (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
+    filterStates: Map<Key, FilterState>,
   ) => {
     setCondition(finalCondition);
     const newActiveFilters = activeFilters.map(activeFilter => {
       const activeFilterValue = activeFilterValues.get(activeFilter.key);
+      const activeFilterState = filterStates.get(activeFilter.key);     
+       
       if (!activeFilterValue) {
+
+        if(activeFilterState?.operator) {
+          return {
+            ...activeFilter,
+            operator: { 
+              ...activeFilter.operator,
+              defaultValue: activeFilterState.operator
+             },
+            value: null,
+          };
+        }
+
         return {
           ...activeFilter,
           value: null,
         };
       }
-
+      
       return {
         ...activeFilter,
         value: { defaultValue: activeFilterValue.value },

--- a/packages/viewer/test/filter/FallbackFilter.test.tsx
+++ b/packages/viewer/test/filter/FallbackFilter.test.tsx
@@ -18,6 +18,7 @@ import { FallbackFilter } from '../../src';
 import { FilterRef, FilterValue } from '../../src';
 import { TypedFilterProps } from '../../src';
 import { Operator } from '@ahoo-wang/fetcher-wow';
+import { ExtendedOperator } from '../../src/filter/operator';
 
 // 测试辅助函数
 const createMockProps = (type: string): TypedFilterProps => ({
@@ -146,6 +147,56 @@ describe('FallbackFilter', () => {
         />,
       );
       expect(ref.current?.getValue()).toBeUndefined();
+    });
+
+    it('exposes getState method via ref', () => {
+      const ref = React.createRef<FilterRef | null>();
+      const props = createMockProps('test');
+
+      render(
+        <FallbackFilter ref={ref as React.RefObject<FilterRef>} {...props} />,
+      );
+
+      expect(ref.current).toHaveProperty('getState');
+      expect(typeof ref.current?.getState).toBe('function');
+    });
+
+    it('getState method returns UNDEFINED operator and undefined value', () => {
+      const ref = React.createRef<FilterRef | null>();
+      const props = createMockProps('any-type');
+
+      render(
+        <FallbackFilter ref={ref as React.RefObject<FilterRef>} {...props} />,
+      );
+
+      const state = ref.current?.getState();
+      expect(state).toEqual({
+        operator: ExtendedOperator.UNDEFINED,
+        value: undefined,
+      });
+    });
+
+    it('exposes reset method via ref', () => {
+      const ref = React.createRef<FilterRef | null>();
+      const props = createMockProps('test');
+
+      render(
+        <FallbackFilter ref={ref as React.RefObject<FilterRef>} {...props} />,
+      );
+
+      expect(ref.current).toHaveProperty('reset');
+      expect(typeof ref.current?.reset).toBe('function');
+    });
+
+    it('reset method does not throw', () => {
+      const ref = React.createRef<FilterRef | null>();
+      const props = createMockProps('test');
+
+      render(
+        <FallbackFilter ref={ref as React.RefObject<FilterRef>} {...props} />,
+      );
+
+      expect(() => ref.current?.reset()).not.toThrow();
     });
   });
 

--- a/packages/viewer/test/filter/useFilterState.test.ts
+++ b/packages/viewer/test/filter/useFilterState.test.ts
@@ -20,9 +20,9 @@ import { Operator } from '@ahoo-wang/fetcher-wow';
 
 // 测试辅助函数
 const createMockOptions = (
-  overrides: Partial<UseFilterStateOptions<string>> = {},
-): UseFilterStateOptions<string> => {
-  const defaultOptions: UseFilterStateOptions<string> = {
+  overrides: Partial<UseFilterStateOptions> = {},
+): UseFilterStateOptions => {
+  const defaultOptions: UseFilterStateOptions = {
     field: 'testField',
     operator: Operator.EQ,
     value: 'test value',
@@ -383,6 +383,123 @@ describe('useFilterState', () => {
 
       expect(ref.current).toHaveProperty('getValue');
       expect(typeof ref.current?.getValue).toBe('function');
+    });
+
+    it('exposes getState method via ref', () => {
+      const ref = React.createRef<FilterRef>();
+      const options = createMockOptions({
+        operator: Operator.EQ,
+        value: 'test value',
+        ref,
+      });
+
+      renderHook(() => useFilterState(options));
+
+      expect(ref.current).toHaveProperty('getState');
+      expect(typeof ref.current?.getState).toBe('function');
+    });
+
+    it('getState returns current operator and value', () => {
+      const ref = React.createRef<FilterRef>();
+      const options = createMockOptions({
+        operator: Operator.EQ,
+        value: 'test value',
+        ref,
+      });
+
+      renderHook(() => useFilterState(options));
+
+      const state = ref.current?.getState();
+      expect(state).toEqual({
+        operator: Operator.EQ,
+        value: 'test value',
+      });
+    });
+
+    it('getState reflects operator changes', () => {
+      const ref = React.createRef<FilterRef>();
+      const options = createMockOptions({
+        operator: Operator.EQ,
+        value: 'test value',
+        ref,
+      });
+
+      const { result } = renderHook(() => useFilterState(options));
+
+      act(() => {
+        result.current.setOperator(Operator.CONTAINS);
+      });
+
+      const state = ref.current?.getState();
+      expect(state?.operator).toBe(Operator.CONTAINS);
+      expect(state?.value).toBe('test value');
+    });
+
+    it('getState reflects value changes', () => {
+      const ref = React.createRef<FilterRef>();
+      const options = createMockOptions({
+        operator: Operator.EQ,
+        value: 'test value',
+        ref,
+      });
+
+      const { result } = renderHook(() => useFilterState(options));
+
+      act(() => {
+        result.current.setValue('new value');
+      });
+
+      const state = ref.current?.getState();
+      expect(state?.operator).toBe(Operator.EQ);
+      expect(state?.value).toBe('new value');
+    });
+
+    it('getState returns state regardless of validation status', () => {
+      const ref = React.createRef<FilterRef>();
+      const validate = vi.fn(() => false);
+      const options = createMockOptions({
+        operator: Operator.EQ,
+        value: 'test value',
+        ref,
+        validate,
+      });
+
+      renderHook(() => useFilterState(options));
+
+      // getValue returns undefined due to validation failure
+      expect(ref.current?.getValue()).toBeUndefined();
+
+      // getState still returns current state
+      const state = ref.current?.getState();
+      expect(state).toEqual({
+        operator: Operator.EQ,
+        value: 'test value',
+      });
+    });
+
+    it('getState returns operator even when value is empty (partial filter)', () => {
+      const ref = React.createRef<FilterRef>();
+      const options = createMockOptions({
+        operator: Operator.EQ,
+        value: undefined,
+        ref,
+      });
+
+      const { result } = renderHook(() => useFilterState(options));
+
+      act(() => {
+        result.current.setOperator(Operator.GTE);
+      });
+
+      // getValue returns undefined because validation fails for empty value
+      expect(ref.current?.getValue()).toBeUndefined();
+
+      // getState returns the operator (partial filter save support)
+      const state = ref.current?.getState();
+      expect(state).toEqual({
+        operator: Operator.GTE,
+        value: undefined,
+      });
     });
 
     it('getValue returns FilterValue when validation passes', () => {

--- a/packages/viewer/test/hooks/useViewerState.test.ts
+++ b/packages/viewer/test/hooks/useViewerState.test.ts
@@ -17,6 +17,7 @@ import { useViewerState } from '../../src/viewer/hooks';
 import { ViewState, ViewDefinition, ViewColumn } from '../../src/viewer/types';
 import { Operator, SortDirection, all } from '@ahoo-wang/fetcher-wow';
 import { SizeType } from 'antd/es/config-provider/SizeContext';
+import type { FilterState } from '../../src/filter/types';
 
 describe('useViewerState', () => {
   const defaultColumns: ViewColumn[] = [
@@ -141,10 +142,129 @@ describe('useViewerState', () => {
         value: '1',
       };
       act(() => {
-        result.current.setCondition(condition, new Map([['test', condition]]));
+        result.current.setCondition(condition, new Map([['test', condition]]), new Map());
       });
 
       expect(result.current.viewChanged).toBe(true);
+    });
+  });
+
+  describe('setCondition', () => {
+    it('should preserve operator when value is empty (partial filter save)', () => {
+      const view = createViewState({
+        filters: [
+          {
+            type: 'test',
+            key: 'test',
+            field: { name: 'test', label: 'test' },
+            operator: { defaultValue: Operator.EQ },
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useViewerState({
+          views: [view],
+          defaultView: view,
+          definition: viewDefinition,
+        }),
+      );
+
+      // Partial filter: operator changed to GTE but value is empty
+      const newOperator = Operator.GTE;
+      const filterState: FilterState = {
+        operator: newOperator,
+        value: undefined,
+      };
+
+      act(() => {
+        result.current.setCondition(
+          all(),
+          new Map(), // activeFilterValues is empty (validation fails for empty value)
+          new Map([['test', filterState]]), // filterStates has the operator
+        );
+      });
+
+      // Verify operator is preserved with value: null
+      const savedFilter = result.current.activeView.filters[0];
+      expect(savedFilter.operator?.defaultValue).toBe(newOperator);
+      expect(savedFilter.value).toBe(null);
+    });
+
+    it('should save full filter when both operator and value are provided', () => {
+      const view = createViewState({
+        filters: [
+          {
+            type: 'test',
+            key: 'test',
+            field: { name: 'test', label: 'test' },
+            operator: { defaultValue: Operator.EQ },
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useViewerState({
+          views: [view],
+          defaultView: view,
+          definition: viewDefinition,
+        }),
+      );
+
+      const newCondition = {
+        field: 'test',
+        operator: Operator.CONTAINS,
+        value: 'search term',
+      };
+      const filterState: FilterState = {
+        operator: Operator.CONTAINS,
+        value: 'search term',
+      };
+
+      act(() => {
+        result.current.setCondition(
+          all(),
+          new Map([['test', newCondition]]),
+          new Map([['test', filterState]]),
+        );
+      });
+
+      const savedFilter = result.current.activeView.filters[0];
+      expect(savedFilter.operator?.defaultValue).toBe(Operator.CONTAINS);
+      expect(savedFilter.value).toEqual({ defaultValue: 'search term' });
+    });
+
+    it('should reset value to null when no filterState exists', () => {
+      const view = createViewState({
+        filters: [
+          {
+            type: 'test',
+            key: 'test',
+            field: { name: 'test', label: 'test' },
+            operator: { defaultValue: Operator.EQ },
+            value: { defaultValue: 'old value' },
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useViewerState({
+          views: [view],
+          defaultView: view,
+          definition: viewDefinition,
+        }),
+      );
+
+      act(() => {
+        result.current.setCondition(
+          all(),
+          new Map(), // no activeFilterValues
+          new Map(), // no filterStates
+        );
+      });
+
+      const savedFilter = result.current.activeView.filters[0];
+      expect(savedFilter.value).toBe(null);
     });
   });
 


### PR DESCRIPTION
  ## Summary

  - 新增 `FilterRef.getState()` 方法，返回 `{ operator, value }` 始终包含当前状态
  - `FilterPanel.getCondition()` 现在返回 `filterStates` Map，用于保存操作符
  - `useViewerState.setConditionFn` 支持部分过滤器：操作符改变但值为空时，保存操作符

  ## Problem

  当 validation 开启且操作符改变但值为空时：
  - `resolveFilterValue` 返回 `undefined`
  - `onChange(undefined)` 被调用，父组件无法得知新操作符
  - 保存视图时操作符丢失

  ## Solution

  - **查询时**：跳过值为空的过滤器（保持 validation 开启）
  - **保存时**：即使值为空，也保存用户修改的操作符

  ## Test plan

  - [x] `useFilterState.getState()` 测试：返回当前状态、反映变化、验证失败时仍返回状态
  - [x] `useViewerState.setConditionFn` 测试：部分过滤器保存、完整过滤器保存、无 filterState 时重置

  ## Files changed

  - `packages/viewer/src/filter/types.ts` - 新增 `FilterState` 接口和 `getState()` 方法
  - `packages/viewer/src/filter/useFilterState.ts` - 实现 `getState()`
  - `packages/viewer/src/filter/panel/FilterPanel.tsx` - 收集 `filterStates`
  - `packages/viewer/src/viewer/hooks/useViewerState.ts` - 使用 `filterStates` 保存操作符
  - `packages/viewer/test/filter/useFilterState.test.ts` - 新增测试
  - `packages/viewer/test/hooks/useViewerState.test.ts` - 新增测试