### PR TITLE
fix(viewer): sync filters and refresh subscriptions

### DIFF
--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -198,7 +198,7 @@ The `filterRegistry` maps filter type strings to their corresponding `TypedFilte
 - `'number'` - NumberFilter
 - `'select'` - SelectFilter
 - `'bool'` - BoolFilter
-- `'dateTime'` - DateTimeFilter
+- `'datetime'` - DateTimeFilter
 
 When a filter with an unknown type is encountered, `FallbackFilter` is rendered instead, displaying a warning message.
 

--- a/packages/viewer/README.zh-CN.md
+++ b/packages/viewer/README.zh-CN.md
@@ -198,7 +198,7 @@ function MyFilterComponent() {
 - `'number'` - NumberFilter
 - `'select'` - SelectFilter
 - `'bool'` - BoolFilter
-- `'dateTime'` - DateTimeFilter
+- `'datetime'` - DateTimeFilter
 
 当遇到未知类型的过滤器时，将渲染 `FallbackFilter` 并显示警告提示。
 

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -16,11 +16,11 @@
   ],
   "author": "Ahoo-Wang",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Ahoo-Wang/fetcher/tree/master/packages/fetcher-viewer",
+  "homepage": "https://github.com/Ahoo-Wang/fetcher/tree/main/packages/viewer",
   "repository": {
     "type": "git",
     "url": "https://github.com/Ahoo-Wang/fetcher.git",
-    "directory": "packages/fetcher-viewer"
+    "directory": "packages/viewer"
   },
   "bugs": {
     "url": "https://github.com/Ahoo-Wang/fetcher/issues"

--- a/packages/viewer/src/fetcherviewer/FetcherViewer.tsx
+++ b/packages/viewer/src/fetcherviewer/FetcherViewer.tsx
@@ -249,6 +249,11 @@ export function FetcherViewer<RecordType = any>({
   );
 
   const { publish, subscribe } = useRefreshDataEventBus(viewerDefinitionId);
+  const reloadRef = useRef(reload);
+
+  useEffect(() => {
+    reloadRef.current = reload;
+  }, [reload]);
 
   useImperativeHandle<FetcherViewerRef, FetcherViewerRef>(ref, () => ({
     refreshData: () => publish(viewerDefinitionId),
@@ -264,15 +269,17 @@ export function FetcherViewer<RecordType = any>({
     getViewerDefinition: () => viewerDefinition,
   }));
 
-  subscribe(
-    {
-      name: 'Viewer-Refresh-Data',
-      handle: async () => {
-        await reload();
+  useEffect(() => {
+    subscribe(
+      {
+        name: 'Viewer-Refresh-Data',
+        handle: async () => {
+          await reloadRef.current();
+        },
       },
-    },
-    viewerDefinitionId,
-  );
+      viewerDefinitionId,
+    );
+  }, [subscribe, viewerDefinitionId]);
 
   if (definitionLoading || viewsLoading) {
     return (

--- a/packages/viewer/src/filter/panel/EditableFilterPanel.tsx
+++ b/packages/viewer/src/filter/panel/EditableFilterPanel.tsx
@@ -12,7 +12,7 @@
  */
 
 import type { Key } from 'react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from 'antd';
 import type {
   AvailableFilterGroup,
@@ -47,6 +47,10 @@ export function EditableFilterPanel(props: EditableFilterPanelProps) {
   const [modalOpen, setModalOpen] = useState(false);
 
   const { locale } = useLocale();
+
+  useEffect(() => {
+    setActiveFilters(filters);
+  }, [filters]);
 
   const handleAddFilter = (selectedAvailableFilters: AvailableFilter[]) => {
     if (selectedAvailableFilters.length === 0) {

--- a/packages/viewer/src/hooks/useRefreshDataEventBus.ts
+++ b/packages/viewer/src/hooks/useRefreshDataEventBus.ts
@@ -3,7 +3,7 @@ import {
   BroadcastTypedEventBus,
   SerialTypedEventBus,
 } from '@ahoo-wang/fetcher-eventbus';
-import { useEffect, useId } from 'react';
+import { useCallback, useEffect, useId } from 'react';
 
 const RefreshDataEventType = 'REFRESH_DATA_EVENTS';
 
@@ -33,30 +33,30 @@ export function useRefreshDataEventBus(
 
   const targetSubscriberId = subscriberId ?? generatedId;
 
-  const publish = (_subscriberId?: string) => {
+  const publish = useCallback((_subscriberId?: string) => {
     return bus.emit({
       type: 'REFRESH',
       subscriberId: _subscriberId ?? targetSubscriberId,
     });
-  };
+  }, [targetSubscriberId]);
 
-  const subscribe = (
-    handler: EventHandler<RefreshDataEvent>,
-    _subscriberId?: string,
-  ) => {
-    const finalSubscriberId = _subscriberId ?? targetSubscriberId;
-    const wrappedHandler: EventHandler<RefreshDataEvent> = {
-      ...handler,
-      name: `${finalSubscriberId}:${handler.name}`,
-      order: handler.order,
-      handle: (event: RefreshDataEvent) => {
-        if (event.subscriberId === finalSubscriberId) {
-          return handler.handle(event);
-        }
-      },
-    };
-    return bus.on(wrappedHandler);
-  };
+  const subscribe = useCallback(
+    (handler: EventHandler<RefreshDataEvent>, _subscriberId?: string) => {
+      const finalSubscriberId = _subscriberId ?? targetSubscriberId;
+      const wrappedHandler: EventHandler<RefreshDataEvent> = {
+        ...handler,
+        name: `${finalSubscriberId}:${handler.name}`,
+        order: handler.order,
+        handle: (event: RefreshDataEvent) => {
+          if (event.subscriberId === finalSubscriberId) {
+            return handler.handle(event);
+          }
+        },
+      };
+      return bus.on(wrappedHandler);
+    },
+    [targetSubscriberId],
+  );
 
   useEffect(() => {
     return () => {

--- a/packages/viewer/test/fetcherviewer/FetcherViewer.test.tsx
+++ b/packages/viewer/test/fetcherviewer/FetcherViewer.test.tsx
@@ -19,6 +19,11 @@ import {
 } from '../../src/fetcherviewer/FetcherViewer';
 import type { PaginationProps } from 'antd';
 
+const refreshDataEventBusMock = vi.hoisted(() => ({
+  publish: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
 vi.mock('../../src/fetcherviewer/hooks/useViewerDefinition', () => ({
   useViewerDefinition: vi.fn(),
 }));
@@ -33,8 +38,8 @@ vi.mock('../../src/fetcherviewer/hooks/useFetchData', () => ({
 
 vi.mock('../../src/hooks/useRefreshDataEventBus', () => ({
   useRefreshDataEventBus: vi.fn(() => ({
-    publish: vi.fn().mockResolvedValue(undefined),
-    subscribe: vi.fn(() => true),
+    publish: refreshDataEventBusMock.publish,
+    subscribe: refreshDataEventBusMock.subscribe,
   })),
 }));
 
@@ -58,6 +63,8 @@ interface User {
 describe('FetcherViewer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    refreshDataEventBusMock.publish.mockResolvedValue(undefined);
+    refreshDataEventBusMock.subscribe.mockReturnValue(true);
   });
 
   const defaultProps = {
@@ -185,6 +192,16 @@ describe('FetcherViewer', () => {
       const { container } = render(<FetcherViewer<User> {...defaultProps} />);
 
       expect(container.textContent).toContain('未找到视图');
+    });
+  });
+
+  describe('refresh subscription', () => {
+    it('subscribes once across rerenders for the same viewer definition', () => {
+      const { rerender } = render(<FetcherViewer<User> {...defaultProps} />);
+
+      rerender(<FetcherViewer<User> {...defaultProps} />);
+
+      expect(refreshDataEventBusMock.subscribe).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/viewer/test/filter/panel/EditableFilterPanel.test.tsx
+++ b/packages/viewer/test/filter/panel/EditableFilterPanel.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Operator } from '@ahoo-wang/fetcher-wow';
+import { TEXT_FILTER } from '../../../src/filter/TextFilter';
+import type { ActiveFilter } from '../../../src/filter/panel/FilterPanel';
+import { EditableFilterPanel } from '../../../src/filter/panel/EditableFilterPanel';
+
+describe('EditableFilterPanel', () => {
+  const nameFilter: ActiveFilter = {
+    key: 'name',
+    type: TEXT_FILTER,
+    field: {
+      name: 'name',
+      label: 'Name',
+    },
+    operator: {
+      defaultValue: Operator.CONTAINS,
+    },
+    value: {
+      defaultValue: 'Alice',
+    },
+  };
+
+  it('syncs rendered filters when filters prop changes', () => {
+    const { rerender } = render(
+      <EditableFilterPanel
+        filters={[nameFilter]}
+        availableFilters={[]}
+        resetButton={false}
+      />,
+    );
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+
+    rerender(
+      <EditableFilterPanel
+        filters={[]}
+        availableFilters={[]}
+        resetButton={false}
+      />,
+    );
+
+    expect(screen.queryByText('Name')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Sync `EditableFilterPanel` internal active filters when parent `filters` props change.
- Move `FetcherViewer` refresh subscription into an effect and stabilize refresh event bus callbacks.
- Correct viewer docs/package metadata drift for the `datetime` filter type and package path.

## Root Cause
- `EditableFilterPanel` initialized local state from props once, so external resets or view switches could leave stale rendered filters.
- `FetcherViewer` subscribed during render, so rerenders attempted duplicate refresh handler registration.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-viewer exec vitest run test/filter/panel/EditableFilterPanel.test.tsx`
- `pnpm --filter @ahoo-wang/fetcher-viewer exec vitest run test/fetcherviewer/FetcherViewer.test.tsx`
- `pnpm --filter @ahoo-wang/fetcher-viewer exec vitest run test/hooks/useRefreshDataEventBus.test.ts`
- `pnpm --filter @ahoo-wang/fetcher-viewer test`
- `pnpm --filter @ahoo-wang/fetcher-viewer build`
- `pnpm --filter @ahoo-wang/fetcher-viewer exec eslint .`
- `git diff --check`