### PR TITLE
fix(fetcher): guard optional body globals

### DIFF
--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -29,6 +29,8 @@ export const REQUEST_BODY_INTERCEPTOR_NAME = 'RequestBodyInterceptor';
 export const REQUEST_BODY_INTERCEPTOR_ORDER =
   Number.MIN_SAFE_INTEGER + BUILT_IN_INTERCEPTOR_ORDER_STEP;
 
+type BodyTypeConstructor = abstract new (...args: any[]) => unknown;
+
 /**
  * Interceptor responsible for converting plain objects to JSON strings for HTTP request bodies.
  *
@@ -62,6 +64,19 @@ export class RequestBodyInterceptor implements RequestInterceptor {
    */
   readonly order = REQUEST_BODY_INTERCEPTOR_ORDER;
 
+  private isInstanceOfBodyType(body: any, typeName: string): boolean {
+    const bodyType = (globalThis as Record<string, unknown>)[typeName];
+    if (typeof bodyType !== 'function') {
+      return false;
+    }
+
+    try {
+      return body instanceof (bodyType as BodyTypeConstructor);
+    } catch {
+      return false;
+    }
+  }
+
   /**
    * Checks if the provided body is of a supported complex type that doesn't require JSON serialization.
    *
@@ -72,7 +87,7 @@ export class RequestBodyInterceptor implements RequestInterceptor {
     return (
       body instanceof ArrayBuffer ||
       ArrayBuffer.isView(body) ||
-      body instanceof ReadableStream
+      this.isInstanceOfBodyType(body, 'ReadableStream')
     );
   }
 
@@ -84,10 +99,10 @@ export class RequestBodyInterceptor implements RequestInterceptor {
    */
   private isAutoAppendContentType(body: any): boolean {
     return (
-      body instanceof Blob ||
-      body instanceof File ||
-      body instanceof FormData ||
-      body instanceof URLSearchParams
+      this.isInstanceOfBodyType(body, 'Blob') ||
+      this.isInstanceOfBodyType(body, 'File') ||
+      this.isInstanceOfBodyType(body, 'FormData') ||
+      this.isInstanceOfBodyType(body, 'URLSearchParams')
     );
   }
 

--- a/packages/fetcher/test/requestBodyInterceptor.test.ts
+++ b/packages/fetcher/test/requestBodyInterceptor.test.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Fetcher, FetchRequest } from '../src';
 import {
   CONTENT_TYPE_HEADER,
@@ -24,6 +24,10 @@ import {
 
 describe('RequestBodyInterceptor', () => {
   const mockFetcher = {} as Fetcher;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
 
   it('should have correct name and order', () => {
     const interceptor = new RequestBodyInterceptor();
@@ -129,6 +133,38 @@ describe('RequestBodyInterceptor', () => {
   });
 
   it('should convert plain object to JSON string and set Content-Type header', () => {
+    const interceptor = new RequestBodyInterceptor();
+    const requestBody = { name: 'test', value: 123 };
+    const request = { url: '/test', body: requestBody };
+    const exchange = new FetchExchange({ fetcher: mockFetcher, request });
+
+    interceptor.intercept(exchange);
+
+    expect(exchange.request.body).toBe('{"name":"test","value":123}');
+    expect(exchange.request.headers).toEqual({
+      'Content-Type': ContentTypeValues.APPLICATION_JSON,
+    });
+  });
+
+  it('should convert plain object when optional body globals are unavailable', () => {
+    vi.stubGlobal('File', undefined);
+
+    const interceptor = new RequestBodyInterceptor();
+    const requestBody = { name: 'test', value: 123 };
+    const request = { url: '/test', body: requestBody };
+    const exchange = new FetchExchange({ fetcher: mockFetcher, request });
+
+    interceptor.intercept(exchange);
+
+    expect(exchange.request.body).toBe('{"name":"test","value":123}');
+    expect(exchange.request.headers).toEqual({
+      'Content-Type': ContentTypeValues.APPLICATION_JSON,
+    });
+  });
+
+  it('should convert plain object when optional body globals are invalid constructors', () => {
+    vi.stubGlobal('File', () => undefined);
+
     const interceptor = new RequestBodyInterceptor();
     const requestBody = { name: 'test', value: 123 };
     const request = { url: '/test', body: requestBody };


### PR DESCRIPTION
## Summary
- Guard optional Web body constructors before `instanceof` checks in request body serialization.
- Add a regression test covering environments where `File` is not defined.

## Why
Some runtimes do not expose every browser `BodyInit` constructor globally. Referencing those constructors directly can throw before a request body is serialized.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher build`
- `pnpm --filter @ahoo-wang/fetcher test`