### PR TITLE
fix(decorator): preserve zero endpoint timeout

### DIFF
--- a/packages/decorator/src/functionMetadata.ts
+++ b/packages/decorator/src/functionMetadata.ts
@@ -24,6 +24,7 @@ import {
   JsonResultExtractor,
   mergeRecordToMap,
   mergeRequest,
+  resolveTimeout,
   type RequestHeaders,
   type UrlParams,
 } from '@ahoo-wang/fetcher';
@@ -127,7 +128,7 @@ export class FunctionMetadata implements NamedCapable {
    * @returns The timeout value in milliseconds, or undefined
    */
   resolveTimeout(): number | undefined {
-    return this.endpoint.timeout || this.api.timeout;
+    return resolveTimeout(this.endpoint.timeout, this.api.timeout);
   }
 
   /**

--- a/packages/decorator/test/functionMetadata.test.ts
+++ b/packages/decorator/test/functionMetadata.test.ts
@@ -167,6 +167,18 @@ describe('FunctionMetadata', () => {
       expect(timeout).toBe(5000);
     });
 
+    it('should return endpoint timeout when it is zero', () => {
+      const functionMetadata = new FunctionMetadata(
+        'test',
+        { timeout: 5000 },
+        { timeout: 0 },
+        new Map(),
+      );
+
+      const timeout = functionMetadata.resolveTimeout();
+      expect(timeout).toBe(0);
+    });
+
     it('should return undefined when neither endpoint nor api timeout is defined', () => {
       const functionMetadata = new FunctionMetadata(
         'test',
@@ -404,6 +416,18 @@ describe('FunctionMetadata', () => {
 
       const result = functionMetadata.resolveExchangeInit([]);
       expect(result.request.timeout).toBe(5000);
+    });
+
+    it('should resolve zero timeout from endpoint metadata', () => {
+      const functionMetadata = new FunctionMetadata(
+        'test',
+        { timeout: 5000 },
+        { method: HttpMethod.GET, timeout: 0 },
+        new Map(),
+      );
+
+      const result = functionMetadata.resolveExchangeInit([]);
+      expect(result.request.timeout).toBe(0);
     });
 
     it('should resolve complete URL', () => {


### PR DESCRIPTION
## Summary
- Preserve endpoint-level `timeout: 0` instead of falling back to API defaults.
- Add decorator metadata regression coverage for zero timeout resolution.

## Why
The decorator metadata path used a truthy fallback, so an explicit zero timeout was treated as absent.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-decorator build`
- `pnpm --filter @ahoo-wang/fetcher-decorator test`