### PR TITLE
fix(eventbus): await async event handlers

### DIFF
--- a/packages/eventbus/src/abstractTypedEventBus.ts
+++ b/packages/eventbus/src/abstractTypedEventBus.ts
@@ -36,7 +36,7 @@ export abstract class AbstractTypedEventBus<
     event: EVENT,
   ): Promise<void> {
     try {
-      handler.handle(event);
+      await handler.handle(event);
     } catch (e) {
       console.warn(`Event handler error for ${handler.name}:`, e);
     }

--- a/packages/eventbus/test/parallelTypedEventBus.test.ts
+++ b/packages/eventbus/test/parallelTypedEventBus.test.ts
@@ -73,6 +73,38 @@ describe('ParallelTypedEventBus', () => {
     expect(h2.handle).toHaveBeenCalledWith('event');
   });
 
+  it('should wait for async handlers before resolving', async () => {
+    vi.useFakeTimers();
+    try {
+      const bus = new ParallelTypedEventBus<string>('test');
+      const handler = {
+        name: 'h1',
+        order: 1,
+        handle: vi.fn(async () => {
+          await new Promise<void>(resolve => {
+            setTimeout(resolve, 10);
+          });
+        }),
+      };
+      bus.on(handler);
+
+      let resolved = false;
+      const emitPromise = bus.emit('event').then(() => {
+        resolved = true;
+      });
+      await Promise.resolve();
+
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(10);
+      await emitPromise;
+
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('should handle once handlers', async () => {
     const bus = new ParallelTypedEventBus<string>('test');
     const handler = { name: 'once', order: 1, handle: vi.fn(), once: true };

--- a/packages/eventbus/test/serialTypedEventBus.test.ts
+++ b/packages/eventbus/test/serialTypedEventBus.test.ts
@@ -72,6 +72,48 @@ describe('SerialTypedEventBus', () => {
     expect(h2.handle).toHaveBeenCalledWith('event');
   });
 
+  it('should await async handlers before continuing serially', async () => {
+    vi.useFakeTimers();
+    try {
+      const bus = new SerialTypedEventBus<string>('test');
+      const calls: string[] = [];
+      const h1 = {
+        name: 'h1',
+        order: 1,
+        handle: vi.fn(async () => {
+          calls.push('h1-start');
+          await new Promise<void>(resolve => {
+            setTimeout(() => {
+              calls.push('h1-end');
+              resolve();
+            }, 10);
+          });
+        }),
+      };
+      const h2 = {
+        name: 'h2',
+        order: 2,
+        handle: vi.fn(() => {
+          calls.push('h2');
+        }),
+      };
+      bus.on(h1);
+      bus.on(h2);
+
+      const emitPromise = bus.emit('event');
+      await Promise.resolve();
+
+      expect(calls).toEqual(['h1-start']);
+
+      await vi.advanceTimersByTimeAsync(10);
+      await emitPromise;
+
+      expect(calls).toEqual(['h1-start', 'h1-end', 'h2']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('should handle once handlers', async () => {
     const bus = new SerialTypedEventBus<string>('test');
     const handler = { name: 'once', order: 1, handle: vi.fn(), once: true };
@@ -100,6 +142,31 @@ describe('SerialTypedEventBus', () => {
     );
     expect(h2.handle).toHaveBeenCalled();
     consoleWarn.mockRestore();
+  });
+
+  it('should log async handler rejections but continue', async () => {
+    const bus = new SerialTypedEventBus<string>('test');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = new Error('async error');
+    const h1 = {
+      name: 'h1',
+      order: 1,
+      handle: vi.fn(() => Promise.reject(error)),
+    };
+    const h2 = { name: 'h2', order: 2, handle: vi.fn() };
+    bus.on(h1);
+    bus.on(h2);
+
+    try {
+      await expect(bus.emit('event')).resolves.toBeUndefined();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'Event handler error for h1:',
+        error,
+      );
+      expect(h2.handle).toHaveBeenCalledWith('event');
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 
   it('should return sorted handlers', () => {


### PR DESCRIPTION
## Summary
- Await typed event bus handlers so serial dispatch actually waits for async work.
- Keep async handler rejections inside the existing error logging path.
- Add serial and parallel async handler regression tests.

## Why
Handler promises were started but not awaited, so serial dispatch could continue out of order and async rejections could escape the intended handling.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-eventbus build`
- `pnpm --filter @ahoo-wang/fetcher-eventbus test`