### PR TITLE
fix(eventstream): normalize crlf lines

### DIFF
--- a/packages/eventstream/src/textLineTransformStream.ts
+++ b/packages/eventstream/src/textLineTransformStream.ts
@@ -23,6 +23,10 @@ import { SafeTransformer } from './safeTransformer';
 export class TextLineTransformer extends SafeTransformer<string, string> {
   private buffer = '';
 
+  private normalizeLine(line: string): string {
+    return line.endsWith('\r') ? line.slice(0, -1) : line;
+  }
+
   protected onTransform(
     chunk: string,
     controller: TransformStreamDefaultController<string>,
@@ -32,16 +36,17 @@ export class TextLineTransformer extends SafeTransformer<string, string> {
     this.buffer = lines.pop() || '';
 
     for (const line of lines) {
-      this.enqueue(controller, line);
+      this.enqueue(controller, this.normalizeLine(line));
     }
   }
 
   protected onFlush(
     controller: TransformStreamDefaultController<string>,
   ): void {
-    // Only send when buffer is not empty, avoid sending meaningless empty lines
-    if (this.buffer) {
-      this.enqueue(controller, this.buffer);
+    const line = this.normalizeLine(this.buffer);
+    // Only send when normalized buffer is not empty.
+    if (line) {
+      this.enqueue(controller, line);
     }
   }
 }

--- a/packages/eventstream/test/textLineTransformStream.test.ts
+++ b/packages/eventstream/test/textLineTransformStream.test.ts
@@ -40,10 +40,38 @@ describe('textLineTransformStream.ts', () => {
         error: vi.fn(),
       } as any;
 
-      transformer.transform('line1\nline2\n', controller);
+      await transformer.transform('line1\nline2\n', controller);
 
       expect(controller.enqueue).toHaveBeenCalledWith('line1');
       expect(controller.enqueue).toHaveBeenCalledWith('line2');
+    });
+
+    it('should strip carriage returns from CRLF lines', async () => {
+      const transformer = new TextLineTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      await transformer.transform('line1\r\nline2\r\n', controller);
+
+      expect(controller.enqueue).toHaveBeenNthCalledWith(1, 'line1');
+      expect(controller.enqueue).toHaveBeenNthCalledWith(2, 'line2');
+    });
+
+    it('should strip carriage returns when CRLF is split across chunks', async () => {
+      const transformer = new TextLineTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      await transformer.transform('line1\r', controller);
+      await transformer.transform('\nline2\r', controller);
+      await transformer.flush(controller);
+
+      expect(controller.enqueue).toHaveBeenNthCalledWith(1, 'line1');
+      expect(controller.enqueue).toHaveBeenNthCalledWith(2, 'line2');
     });
 
     it('should accumulate buffer for incomplete lines', async () => {
@@ -53,7 +81,7 @@ describe('textLineTransformStream.ts', () => {
         error: vi.fn(),
       } as any;
 
-      transformer.transform('line1\nline2', controller);
+      await transformer.transform('line1\nline2', controller);
 
       expect(controller.enqueue).toHaveBeenCalledWith('line1');
       expect(controller.enqueue).not.toHaveBeenCalledWith('line2');
@@ -66,8 +94,8 @@ describe('textLineTransformStream.ts', () => {
         error: vi.fn(),
       } as any;
 
-      transformer.transform('line1\nline2', controller);
-      transformer.flush(controller);
+      await transformer.transform('line1\nline2', controller);
+      await transformer.flush(controller);
 
       expect(controller.enqueue).toHaveBeenCalledWith('line1');
       expect(controller.enqueue).toHaveBeenCalledWith('line2');
@@ -80,7 +108,20 @@ describe('textLineTransformStream.ts', () => {
         error: vi.fn(),
       } as any;
 
-      transformer.flush(controller);
+      await transformer.flush(controller);
+
+      expect(controller.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('should not flush a trailing carriage return as an empty line', async () => {
+      const transformer = new TextLineTransformer();
+      const controller = {
+        enqueue: vi.fn(),
+        error: vi.fn(),
+      } as any;
+
+      await transformer.transform('\r', controller);
+      await transformer.flush(controller);
 
       expect(controller.enqueue).not.toHaveBeenCalled();
     });
@@ -99,7 +140,7 @@ describe('textLineTransformStream.ts', () => {
         },
       } as any;
 
-      transformer.transform(chunk, controller);
+      await transformer.transform(chunk, controller);
 
       expect(controller.error).toHaveBeenCalledWith(expect.any(Error));
     });
@@ -116,8 +157,8 @@ describe('textLineTransformStream.ts', () => {
         throw new Error('Test error');
       });
 
-      transformer.transform('test', controller);
-      transformer.flush(controller);
+      await transformer.transform('test', controller);
+      await transformer.flush(controller);
 
       expect(controller.error).toHaveBeenCalledWith(expect.any(Error));
     });
@@ -132,7 +173,7 @@ describe('textLineTransformStream.ts', () => {
       // Set buffer to empty string
       (transformer as any).buffer = '';
 
-      transformer.flush(controller);
+      await transformer.flush(controller);
 
       expect(controller.enqueue).not.toHaveBeenCalled();
     });
@@ -147,7 +188,7 @@ describe('textLineTransformStream.ts', () => {
       // Set buffer to whitespace
       (transformer as any).buffer = '   ';
 
-      transformer.flush(controller);
+      await transformer.flush(controller);
 
       expect(controller.enqueue).toHaveBeenCalledWith('   ');
     });


### PR DESCRIPTION
## Summary
- Strip trailing carriage returns from transformed text lines.
- Add CRLF coverage for text line stream splitting.

## Why
CRLF-delimited streams could surface payload lines with a trailing `\r`, which breaks consumers expecting normalized line content.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-eventstream build`
- `pnpm --filter @ahoo-wang/fetcher-eventstream test`