### PR TITLE
fix(generator): include node types

### DIFF
--- a/packages/generator/tsconfig.json
+++ b/packages/generator/tsconfig.json
@@ -7,6 +7,7 @@
     "emitDeclarationOnly": true,
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- Add Node ambient types to the generator package tsconfig.

## Why
Generator sources use Node globals and modules. Without Node types, direct TypeScript declaration/type checks report missing `process`, `fs`, and `path` types.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-generator exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @ahoo-wang/fetcher-generator build`
- `pnpm --filter @ahoo-wang/fetcher-generator test`