### PR TITLE
fix(storage): preserve empty storage keys

### DIFF
--- a/packages/storage/src/inMemoryStorage.ts
+++ b/packages/storage/src/inMemoryStorage.ts
@@ -45,7 +45,7 @@ export class InMemoryStorage implements Storage {
    */
   key(index: number): string | null {
     const keys = Array.from(this.store.keys());
-    return keys[index] || null;
+    return keys[index] ?? null;
   }
 
   /**

--- a/packages/storage/test/inMemoryStorage.test.ts
+++ b/packages/storage/test/inMemoryStorage.test.ts
@@ -84,6 +84,11 @@ describe('InMemoryStorage', () => {
       expect(keys).toContain('key1');
       expect(keys).toContain('key2');
     });
+
+    it('should return empty string keys by index', () => {
+      storage.setItem('', 'value');
+      expect(storage.key(0)).toBe('');
+    });
   });
 
   describe('removeItem', () => {


### PR DESCRIPTION
## Summary
- Preserve empty-string keys when retrieving keys by index from `InMemoryStorage`.
- Add a regression test for `Storage.key(0)` with an empty key.

## Why
The storage shim used a truthy fallback, so a valid empty string key was returned as `null`.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-storage build`
- `pnpm --filter @ahoo-wang/fetcher-storage test`