### PR TITLE
fix(react): ignore stale abort errors

### DIFF
--- a/packages/react/src/core/useExecutePromise.ts
+++ b/packages/react/src/core/useExecutePromise.ts
@@ -259,7 +259,7 @@ export function useExecutePromise<R = unknown, E = FetcherError>(
         }
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') {
-          if (isMounted()) {
+          if (isMounted() && requestId.isLatest(currentRequestId)) {
             setIdle();
           }
           return;

--- a/packages/react/test/core/useExecutePromise.test.ts
+++ b/packages/react/test/core/useExecutePromise.test.ts
@@ -296,6 +296,43 @@ describe('useExecutePromise', () => {
     expect(result.current.result).toBe('second');
   });
 
+  it('should ignore stale abort errors after starting a new operation', async () => {
+    const firstProvider = vi.fn(
+      (abortController: AbortController) =>
+        new Promise<string>((_, reject) => {
+          abortController.signal.addEventListener('abort', () => {
+            setTimeout(() => {
+              const abortError = new Error('aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            }, 0);
+          });
+        }),
+    );
+    const secondProvider = vi.fn(() => new Promise<string>(() => {}));
+
+    const { result } = renderHook(() => useExecutePromise<string>());
+
+    await act(async () => {
+      result.current.execute(firstProvider);
+    });
+
+    expect(result.current.status).toBe(PromiseStatus.LOADING);
+
+    await act(async () => {
+      result.current.execute(secondProvider);
+    });
+
+    expect(result.current.status).toBe(PromiseStatus.LOADING);
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.status).toBe(PromiseStatus.LOADING);
+    expect(result.current.loading).toBe(true);
+  });
+
   it('should handle onAbort callback errors gracefully', async () => {
     const onAbortMock = vi.fn().mockRejectedValue(new Error('onAbort error'));
     const mockProvider = vi


### PR DESCRIPTION
## Summary
- Ignore stale `AbortError` results in `useExecutePromise` after a newer request has started.
- Add regression coverage for delayed abort rejection after a replacement operation.

## Why
An older aborted request could settle after a new request was already loading and reset the hook state back to idle.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-react build`
- `pnpm --filter @ahoo-wang/fetcher-react test`