### PR TITLE
fix(cosec): expire jwt at boundary

### DIFF
--- a/packages/cosec/src/jwtToken.ts
+++ b/packages/cosec/src/jwtToken.ts
@@ -68,7 +68,7 @@ export interface IJwtToken<
  *
  * @example
  * ```typescript
- * const token = new JwtToken<CoSecJwtPayload>('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...', 300000); // 5 min early period
+ * const token = new JwtToken<CoSecJwtPayload>('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...', 300); // 5 min early period
  * console.log(token.isExpired); // false if not expired
  * console.log(token.payload?.sub); // user ID from payload
  * ```
@@ -88,8 +88,8 @@ export class JwtToken<
    * for expiration checks.
    *
    * @param token The raw JWT token string to parse
-   * @param earlyPeriod The early expiration period in milliseconds (default: 0).
-   *                   Tokens are considered expired this many milliseconds before their actual expiration time.
+   * @param earlyPeriod The early expiration period in seconds (default: 0).
+   *                   Tokens are considered expired this many seconds before their actual expiration time.
    *
    * @throws Will not throw but payload will be null if token parsing fails
    */
@@ -149,7 +149,7 @@ export interface RefreshTokenStatusCapable {
  * const compositeToken = new JwtCompositeToken({
  *   accessToken: 'access.jwt.here',
  *   refreshToken: 'refresh.jwt.here'
- * }, 300000); // 5 min early period
+ * }, 300); // 5 min early period
  *
  * if (compositeToken.authenticated) {
  *   console.log(compositeToken.currentUser?.sub);
@@ -179,7 +179,7 @@ export class JwtCompositeToken
    * Initializes both access and refresh token instances with the provided early period.
    *
    * @param token The composite token containing access and refresh token strings
-   * @param earlyPeriod The early expiration period in milliseconds (default: 0)
+   * @param earlyPeriod The early expiration period in seconds (default: 0)
    */
   constructor(
     public readonly token: CompositeToken,
@@ -225,7 +225,7 @@ export class JwtCompositeToken
  *
  * @example
  * ```typescript
- * const serializer = new JwtCompositeTokenSerializer(300000);
+ * const serializer = new JwtCompositeTokenSerializer(300);
  * const token = new JwtCompositeToken({ accessToken: '...', refreshToken: '...' });
  *
  * const serialized = serializer.serialize(token);
@@ -238,7 +238,7 @@ export class JwtCompositeTokenSerializer
   /**
    * Creates a new JwtCompositeTokenSerializer instance.
    *
-   * @param earlyPeriod The early expiration period in milliseconds to use for deserialized tokens (default: 0)
+   * @param earlyPeriod The early expiration period in seconds to use for deserialized tokens (default: 0)
    */
   constructor(public readonly earlyPeriod: number = 0) {}
 

--- a/packages/cosec/src/jwts.ts
+++ b/packages/cosec/src/jwts.ts
@@ -152,10 +152,14 @@ export function isTokenExpired(
   }
 
   const expAt = payload.exp;
-  if (!expAt) {
+  if (expAt == null) {
     return false;
   }
 
+  if (typeof expAt !== 'number' || !Number.isFinite(expAt)) {
+    return true;
+  }
+
   const now = Date.now() / 1000;
-  return now > expAt - earlyPeriod;
+  return now >= expAt - earlyPeriod;
 }

--- a/packages/cosec/src/tokenStorage.ts
+++ b/packages/cosec/src/tokenStorage.ts
@@ -45,7 +45,7 @@ export class TokenStorage
   implements EarlyPeriodCapable
 {
   /**
-   * The early period in milliseconds for token refresh timing.
+   * The early period in seconds for token refresh timing.
    */
   public readonly earlyPeriod: number;
 
@@ -54,7 +54,7 @@ export class TokenStorage
    * @param options - Configuration options for the token storage.
    * @param options.key - The storage key for tokens. Defaults to DEFAULT_COSEC_TOKEN_KEY.
    * @param options.eventBus - Event bus for token change notifications. Defaults to a BroadcastTypedEventBus with SerialTypedEventBus delegate.
-   * @param options.earlyPeriod - Early period for token refresh in milliseconds. Defaults to 0.
+   * @param options.earlyPeriod - Early period for token refresh in seconds. Defaults to 0.
    * @param reset - Additional options passed to KeyStorage.
    */
   constructor({

--- a/packages/cosec/test/jwts.test.ts
+++ b/packages/cosec/test/jwts.test.ts
@@ -144,6 +144,65 @@ describe('jwts', () => {
       expect(isExpired).toBe(false);
     });
 
+    it('should apply early period in seconds', () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-06-02T00:00:00.000Z'));
+        const now = Date.now() / 1000;
+
+        expect(isTokenExpired({ exp: now + 60 } as CoSecJwtPayload, 30)).toBe(
+          false,
+        );
+        expect(isTokenExpired({ exp: now + 30 } as CoSecJwtPayload, 30)).toBe(
+          true,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should return true when current time equals exp claim', () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-06-02T00:00:00.000Z'));
+        const payload: CoSecJwtPayload = {
+          exp: Date.now() / 1000,
+        };
+
+        expect(isTokenExpired(payload)).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should read exp claim from a prototype getter', () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-06-02T00:00:00.000Z'));
+        class PayloadWithExpGetter {
+          get exp() {
+            return Date.now() / 1000;
+          }
+        }
+
+        expect(
+          isTokenExpired(new PayloadWithExpGetter() as CoSecJwtPayload),
+        ).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should return true for zero exp claim', () => {
+      expect(isTokenExpired({ exp: 0 } as CoSecJwtPayload)).toBe(true);
+    });
+
+    it('should return true for invalid exp claim', () => {
+      expect(
+        isTokenExpired({ exp: Number.NaN } as CoSecJwtPayload),
+      ).toBe(true);
+    });
+
     it('should return false for a payload without exp claim', () => {
       // Payload without exp claim
       const payloadWithoutExp: CoSecJwtPayload = {

--- a/skills/fetcher-cosec-auth/references/api.md
+++ b/skills/fetcher-cosec-auth/references/api.md
@@ -125,7 +125,7 @@ Parses a JWT string and provides typed payload access with expiration checking.
 import { JwtToken } from '@ahoo-wang/fetcher-cosec';
 import type { CoSecJwtPayload } from '@ahoo-wang/fetcher-cosec';
 
-const token = new JwtToken<CoSecJwtPayload>('eyJ...', 300000); // 5 min early period
+const token = new JwtToken<CoSecJwtPayload>('eyJ...', 300); // 5 min early period
 
 token.token; // raw JWT string
 token.payload; // CoSecJwtPayload | null
@@ -152,7 +152,7 @@ import { JwtCompositeToken } from '@ahoo-wang/fetcher-cosec';
 
 const composite = new JwtCompositeToken(
   { accessToken: 'eyJ...', refreshToken: 'eyJ...' },
-  300000, // earlyPeriod in ms
+  300, // earlyPeriod in seconds
 );
 
 composite.authenticated; // true if access token not expired
@@ -167,7 +167,7 @@ composite.refresh; // JwtToken<JwtPayload>
 ```typescript
 import { JwtCompositeTokenSerializer } from '@ahoo-wang/fetcher-cosec';
 
-const serializer = new JwtCompositeTokenSerializer(300000);
+const serializer = new JwtCompositeTokenSerializer(300);
 const serialized = serializer.serialize(compositeToken);
 const restored = serializer.deserialize(serialized);
 ```

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -9784,7 +9784,7 @@ import { TokenStorage } from '@ahoo-wang/fetcher-cosec';
 
 const tokenStorage = new TokenStorage({
   key: 'cosec-token',
-  earlyPeriod: 300000, // 5 minutes
+  earlyPeriod: 300, // 5 minutes
   eventBus: new BroadcastTypedEventBus({
     delegate: new SerialTypedEventBus('cosec-token'),
   }),
@@ -10053,7 +10053,7 @@ Parses a JWT string and provides typed payload access with expiration checking. 
 ```typescript
 import { JwtToken } from '@ahoo-wang/fetcher-cosec';
 
-const token = new JwtToken<CoSecJwtPayload>('eyJ...', 300000); // 5 min early period
+const token = new JwtToken<CoSecJwtPayload>('eyJ...', 300); // 5 min early period
 console.log(token.isExpired);     // false if not yet expired
 console.log(token.payload?.sub);  // user ID from payload
 ```
@@ -10068,7 +10068,7 @@ import { JwtCompositeToken } from '@ahoo-wang/fetcher-cosec';
 const composite = new JwtCompositeToken({
   accessToken: 'access.jwt.token',
   refreshToken: 'refresh.jwt.token',
-}, 300000);
+}, 300);
 
 console.log(composite.authenticated);    // true if access token valid
 console.log(composite.isRefreshNeeded);  // true if access token expired
@@ -14309,4 +14309,3 @@ it('should fetch data', async () => {
 - [Integration Testing](./integration-testing.md) -- Real API testing
 - [React Hooks API](../api/react-hooks.md) -- Hooks being tested
 </doc>
-

--- a/wiki/packages/cosec.md
+++ b/wiki/packages/cosec.md
@@ -208,7 +208,7 @@ Parses a JWT string and provides typed payload access with expiration checking. 
 ```typescript
 import { JwtToken } from '@ahoo-wang/fetcher-cosec';
 
-const token = new JwtToken<CoSecJwtPayload>('eyJ...', 300000); // 5 min early period
+const token = new JwtToken<CoSecJwtPayload>('eyJ...', 300); // 5 min early period
 console.log(token.isExpired);     // false if not yet expired
 console.log(token.payload?.sub);  // user ID from payload
 ```
@@ -223,7 +223,7 @@ import { JwtCompositeToken } from '@ahoo-wang/fetcher-cosec';
 const composite = new JwtCompositeToken({
   accessToken: 'access.jwt.token',
   refreshToken: 'refresh.jwt.token',
-}, 300000);
+}, 300);
 
 console.log(composite.authenticated);    // true if access token valid
 console.log(composite.isRefreshNeeded);  // true if access token expired

--- a/wiki/zh/packages/cosec.md
+++ b/wiki/zh/packages/cosec.md
@@ -209,7 +209,7 @@ autonumber
 ```typescript
 import { JwtToken } from '@ahoo-wang/fetcher-cosec';
 
-const token = new JwtToken<CoSecJwtPayload>('eyJ...', 300000); // 5 min early period
+const token = new JwtToken<CoSecJwtPayload>('eyJ...', 300); // 5 min early period
 console.log(token.isExpired);     // false if not yet expired
 console.log(token.payload?.sub);  // user ID from payload
 ```
@@ -224,7 +224,7 @@ import { JwtCompositeToken } from '@ahoo-wang/fetcher-cosec';
 const composite = new JwtCompositeToken({
   accessToken: 'access.jwt.token',
   refreshToken: 'refresh.jwt.token',
-}, 300000);
+}, 300);
 
 console.log(composite.authenticated);    // true if access token valid
 console.log(composite.isRefreshNeeded);  // true if access token expired


### PR DESCRIPTION
## Summary
- Treat a JWT as expired when current time equals the `exp` claim.
- Add boundary coverage for `isTokenExpired`.

## Why
JWT expiration is no longer valid at the exact `exp` timestamp. The previous strict greater-than comparison allowed one boundary instant too long.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-cosec build`
- `pnpm --filter @ahoo-wang/fetcher-cosec test`