### PR TITLE
fix(wow): avoid empty and conditions

### DIFF
--- a/packages/wow/src/query/condition.ts
+++ b/packages/wow/src/query/condition.ts
@@ -210,6 +210,9 @@ export function and<FIELDS extends string = string>(
       andChildren.push(condition);
     }
   });
+  if (andChildren.length === 0) {
+    return all();
+  }
   return { operator: Operator.AND, children: andChildren };
 }
 

--- a/packages/wow/test/query/condition.test.ts
+++ b/packages/wow/test/query/condition.test.ts
@@ -171,6 +171,13 @@ describe('Condition', () => {
         });
       });
 
+      it('should return ALL when AND conditions are empty after filtering', () => {
+        const result = and(all(), undefined, null);
+        expect(result).toEqual({
+          operator: Operator.ALL,
+        });
+      });
+
       it('should create AND condition with no arguments and return ALL condition', () => {
         const result = and();
         expect(result).toEqual({


### PR DESCRIPTION
## Summary
- Return `ALL` when `and()` filters out every child condition.
- Add regression coverage for `and(all(), undefined, null)`.

## Why
The previous implementation could emit an `AND` condition with an empty children array, despite logical operators requiring non-empty children.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-wow build`
- `pnpm --filter @ahoo-wang/fetcher-wow test`