### PR TITLE
fix(viewer): compare builtin object values

### DIFF
--- a/packages/viewer/src/utils.ts
+++ b/packages/viewer/src/utils.ts
@@ -22,7 +22,9 @@ import type { TableRecordType } from './types';
  * - Uses strict equality (===) for primitive comparisons.
  * - Handles null and undefined as unequal unless both are the same.
  * - For arrays, compares lengths first, then recursively compares each element.
- * - For objects, compares constructors, then keys, then recursively compares values.
+ * - For Date values, compares timestamps and treats two invalid dates as equal.
+ * - For RegExp values, compares pattern source, flags, and lastIndex.
+ * - For remaining objects, compares constructors, keys, then values.
  * - Does not handle circular references (would cause infinite recursion).
  * - Does not consider object prototypes beyond constructor comparison.
  * - Performance may be poor for very large or deeply nested structures.
@@ -39,6 +41,23 @@ export function deepEqual(left: any, right: any): boolean {
   // Note: null == undefined is true, but null === undefined is false
   if (left == null || right == null) {
     return false;
+  }
+
+  if (left instanceof Date && right instanceof Date) {
+    const leftTime = left.getTime();
+    const rightTime = right.getTime();
+    return (
+      leftTime === rightTime ||
+      (Number.isNaN(leftTime) && Number.isNaN(rightTime))
+    );
+  }
+
+  if (left instanceof RegExp && right instanceof RegExp) {
+    return (
+      left.source === right.source &&
+      left.flags === right.flags &&
+      left.lastIndex === right.lastIndex
+    );
   }
 
   // Handle array comparison

--- a/packages/viewer/test/utils.test.ts
+++ b/packages/viewer/test/utils.test.ts
@@ -140,6 +140,43 @@ describe('deepEqual', () => {
       expect(deepEqual(/test/, {})).toBe(false);
     });
 
+    it('should compare dates by timestamp', () => {
+      expect(
+        deepEqual(
+          new Date('2026-06-02T00:00:00.000Z'),
+          new Date('2026-06-02T00:00:00.000Z'),
+        ),
+      ).toBe(true);
+      expect(
+        deepEqual(
+          new Date('2026-06-02T00:00:00.000Z'),
+          new Date('2026-06-03T00:00:00.000Z'),
+        ),
+      ).toBe(false);
+      expect(deepEqual(new Date('invalid'), new Date(Number.NaN))).toBe(true);
+      expect(
+        deepEqual(
+          new Date('invalid'),
+          new Date('2026-06-02T00:00:00.000Z'),
+        ),
+      ).toBe(false);
+    });
+
+    it('should compare regular expressions by pattern, flags, and lastIndex', () => {
+      expect(deepEqual(/test/gi, /test/gi)).toBe(true);
+      expect(deepEqual(/test/g, /test/i)).toBe(false);
+      expect(deepEqual(/test/g, /other/g)).toBe(false);
+
+      const left = /test/g;
+      const right = /test/g;
+      left.lastIndex = 1;
+      right.lastIndex = 1;
+      expect(deepEqual(left, right)).toBe(true);
+
+      right.lastIndex = 2;
+      expect(deepEqual(left, right)).toBe(false);
+    });
+
     it('should handle objects with array values', () => {
       expect(deepEqual({ items: [1, 2, 3] }, { items: [1, 2, 3] })).toBe(true);
       expect(deepEqual({ items: [1, 2, 3] }, { items: [1, 2, 4] })).toBe(false);


### PR DESCRIPTION
## Summary
- Compare `Date` values by timestamp in `deepEqual`.
- Compare `RegExp` values by source and flags.
- Add regression coverage for both built-in object types.

## Why
Objects like `Date` and `RegExp` have no enumerable own keys, so different values could previously compare equal and hide viewer state changes.

## Test Plan
- `pnpm --filter @ahoo-wang/fetcher-viewer build`
- `pnpm --filter @ahoo-wang/fetcher-viewer test`