### PR TITLE
fix(cosec): bound 401 refresh-retry loop and avoid duplicate token removal

### DIFF
--- a/packages/cosec/src/authorizationResponseInterceptor.ts
+++ b/packages/cosec/src/authorizationResponseInterceptor.ts
@@ -15,6 +15,7 @@ import { ResponseCodes } from './types';
 import type { FetchExchange } from '@ahoo-wang/fetcher';
 import { type ResponseInterceptor } from '@ahoo-wang/fetcher';
 import type { AuthorizationInterceptorOptions } from './authorizationRequestInterceptor';
+import { RefreshTokenError } from './jwtTokenManager';
 
 /**
  * The name of the AuthorizationResponseInterceptor.
@@ -28,6 +29,20 @@ export const AUTHORIZATION_RESPONSE_INTERCEPTOR_NAME =
  */
 export const AUTHORIZATION_RESPONSE_INTERCEPTOR_ORDER =
   Number.MIN_SAFE_INTEGER + 1000;
+
+/**
+ * Maximum number of times a single exchange may be refreshed and retried on a
+ * 401 response. Retry re-runs the entire interceptor chain (including this
+ * interceptor), so without a bound a retried request that still returns 401
+ * would recurse refresh indefinitely.
+ */
+export const AUTHORIZATION_RESPONSE_MAX_RETRY = 1;
+
+/**
+ * Attribute key storing how many times an exchange has been refreshed and
+ * retried, used to bound the refresh-retry loop.
+ */
+const AUTHORIZATION_RETRY_COUNT_ATTRIBUTE = 'AuthorizationResponseRetryCount';
 
 /**
  * CoSecResponseInterceptor is responsible for handling unauthorized responses (401)
@@ -68,14 +83,40 @@ export class AuthorizationResponseInterceptor implements ResponseInterceptor {
     if (!this.options.tokenManager.isRefreshable) {
       return;
     }
+
+    // Guard against infinite refresh-retry loops: retrying re-runs the whole
+    // interceptor chain (including this interceptor), so a retried request that
+    // still returns 401 would otherwise recurse refresh until the refresh token
+    // expires or the server gives out.
+    const retryCount =
+      (exchange.attributes?.get(AUTHORIZATION_RETRY_COUNT_ATTRIBUTE) as
+        | number
+        | undefined) ?? 0;
+    if (retryCount >= AUTHORIZATION_RESPONSE_MAX_RETRY) {
+      return;
+    }
+    exchange.attributes?.set(
+      AUTHORIZATION_RETRY_COUNT_ATTRIBUTE,
+      retryCount + 1,
+    );
+
     try {
       await this.options.tokenManager.refresh();
-      // Retry the original request with the new token
-      await exchange.fetcher.interceptors.exchange(exchange);
     } catch (error) {
-      // If token refresh fails, clear stored tokens and re-throw the error
-      this.options.tokenManager.tokenStorage.remove();
+      // refresh() failed. JwtTokenManager.refresh() removes the token on a
+      // RefreshTokenError; for other refresh errors (e.g. no token present)
+      // clean up here and propagate.
+      if (!(error instanceof RefreshTokenError)) {
+        this.options.tokenManager.tokenStorage.remove();
+      }
       throw error;
     }
+
+    // Refresh succeeded — the token is valid. Retry the original request.
+    // Do NOT remove the token if the retry still fails: the endpoint may stay
+    // unauthorized despite a valid token (e.g. missing permission), and the
+    // token must be preserved for other requests. The persistent 401 flows to
+    // the downstream UnauthorizedErrorInterceptor as usual.
+    await exchange.fetcher.interceptors.exchange(exchange);
   }
 }

--- a/packages/cosec/src/unauthorizedErrorInterceptor.ts
+++ b/packages/cosec/src/unauthorizedErrorInterceptor.ts
@@ -28,6 +28,14 @@ export const UNAUTHORIZED_ERROR_INTERCEPTOR_NAME =
 export const UNAUTHORIZED_ERROR_INTERCEPTOR_ORDER = 0;
 
 /**
+ * Attribute key marking that `onUnauthorized` has already been invoked for an
+ * exchange. The 401 refresh-retry path re-enters the error phase (the nested
+ * retry exchange plus the outer exchange), which would otherwise fire
+ * `onUnauthorized` twice for a single request (double logout/redirect).
+ */
+const UNAUTHORIZED_HANDLED_ATTRIBUTE = 'UnauthorizedHandled';
+
+/**
  * Configuration options for the UnauthorizedErrorInterceptor.
  */
 export interface UnauthorizedErrorInterceptorOptions {
@@ -116,6 +124,12 @@ export class UnauthorizedErrorInterceptor implements ErrorInterceptor {
       exchange.response?.status === ResponseCodes.UNAUTHORIZED ||
       exchange.error instanceof RefreshTokenError
     ) {
+      // Fire at most once per exchange: the refresh-retry path re-enters the
+      // error phase and would otherwise invoke this callback a second time.
+      if (exchange.attributes.get(UNAUTHORIZED_HANDLED_ATTRIBUTE) === true) {
+        return;
+      }
+      exchange.attributes.set(UNAUTHORIZED_HANDLED_ATTRIBUTE, true);
       await this.options.onUnauthorized(exchange);
     }
   }

--- a/packages/cosec/test/authorizationResponseInterceptor.test.ts
+++ b/packages/cosec/test/authorizationResponseInterceptor.test.ts
@@ -183,4 +183,92 @@ describe('AuthorizationResponseInterceptor', () => {
     expect(mockTokenStorage.remove).toHaveBeenCalled();
     expect(mockFetcher.interceptors.exchange).not.toHaveBeenCalled();
   });
+
+  it('should not infinitely refresh when the retried request still returns 401', async () => {
+    // Regression: previously, a successful refresh followed by a retried request
+    // that STILL returns 401 caused the response interceptor to recurse
+    // (retry re-runs the whole chain, including this interceptor), looping
+    // refresh until the refresh token expired or the server gave out.
+    mockTokenStorage.get = vi.fn().mockReturnValue({ token: 'current-token' });
+
+    let refreshCount = 0;
+    mockTokenRefresher.refresh = vi.fn().mockImplementation(() => {
+      refreshCount++;
+      // Safety stop so the buggy implementation cannot hang the test runner.
+      if (refreshCount > 10) {
+        return Promise.reject(new Error('forced-stop'));
+      }
+      return Promise.resolve(`new-token-${refreshCount}`);
+    });
+
+    const exchange = {
+      response: {
+        status: ResponseCodes.UNAUTHORIZED,
+      } as Response,
+      fetcher: mockFetcher,
+      attributes: new Map(),
+    } as unknown as FetchExchange;
+
+    // Simulate the real interceptor chain: retrying re-runs response interceptors.
+    // The retried response is still 401.
+    mockFetcher.interceptors.exchange = vi.fn().mockImplementation(() =>
+      interceptor.intercept(exchange),
+    );
+
+    let threw = false;
+    try {
+      await interceptor.intercept(exchange);
+    } catch {
+      threw = true;
+    }
+
+    // Buggy code loops until forced-stop (refreshCount ≈ 11).
+    // Fixed code refreshes at most once for a given exchange.
+    expect(refreshCount).toBeLessThanOrEqual(1);
+  });
+
+  it('should remove the token exactly once when refresh fails (no duplicate signOut event)', async () => {
+    // Regression: JwtTokenManager.refresh() already removes the token on failure;
+    // the interceptor used to remove() again, emitting a duplicate signOut event.
+    mockTokenStorage.get = vi.fn().mockReturnValue({ token: 'current-token' });
+    mockTokenRefresher.refresh = vi.fn().mockRejectedValue(new Error('Refresh failed'));
+
+    const exchange = {
+      response: {
+        status: ResponseCodes.UNAUTHORIZED,
+      } as Response,
+      fetcher: mockFetcher,
+      attributes: new Map(),
+    } as unknown as FetchExchange;
+
+    await expect(interceptor.intercept(exchange)).rejects.toThrow(
+      RefreshTokenError,
+    );
+
+    expect(mockTokenStorage.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('should preserve the token when refresh succeeds but the retried request still fails', async () => {
+    // Regression: when refresh() succeeds the token is valid. A retry that
+    // still fails (e.g. the endpoint stays 401 despite a fresh token) must NOT
+    // sign the user out — only a refresh failure should clear the token.
+    mockTokenStorage.get = vi.fn().mockReturnValue({ token: 'current-token' });
+    mockTokenRefresher.refresh = vi.fn().mockResolvedValue('new-token');
+    mockFetcher.interceptors.exchange = vi
+      .fn()
+      .mockRejectedValue(new Error('still 401'));
+
+    const exchange = {
+      response: {
+        status: ResponseCodes.UNAUTHORIZED,
+      } as Response,
+      fetcher: mockFetcher,
+      attributes: new Map(),
+    } as unknown as FetchExchange;
+
+    await expect(interceptor.intercept(exchange)).rejects.toThrow('still 401');
+
+    // Token refreshed successfully — must not be removed.
+    expect(mockTokenStorage.remove).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cosec/test/unauthorizedErrorInterceptor.test.ts
+++ b/packages/cosec/test/unauthorizedErrorInterceptor.test.ts
@@ -281,5 +281,26 @@ describe('UnauthorizedErrorInterceptor', () => {
       expect(calledExchange.response).toBe(response);
       expect(calledExchange.fetcher).toBe(mockFetcher);
     });
+
+    it('should invoke onUnauthorized at most once for the same exchange', async () => {
+      // Regression: the 401 refresh-retry path re-runs the error phase (the
+      // nested retry exchange plus the outer exchange), which used to fire
+      // onUnauthorized twice for a single request (double logout/redirect).
+      const onUnauthorized = vi.fn();
+      const interceptor = new UnauthorizedErrorInterceptor({ onUnauthorized });
+
+      const exchange = new FetchExchange({
+        fetcher: mockFetcher,
+        request: mockRequest,
+        response: new Response('Unauthorized', {
+          status: ResponseCodes.UNAUTHORIZED,
+        }),
+      });
+
+      await interceptor.intercept(exchange); // first error phase (e.g. nested retry)
+      await interceptor.intercept(exchange); // second error phase (e.g. outer exchange)
+
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Problem

`AuthorizationResponseInterceptor` retried a 401 by re-running the **full interceptor chain** (`exchange.fetcher.interceptors.exchange(exchange)`), which re-invokes this same interceptor. Three coupled defects resulted:

1. **Infinite refresh loop.** With no retry bound, a retried request that still returned 401 recursed refresh indefinitely — each successful refresh reset `refreshInProgress` (the in-flight dedup guard), so every iteration was a fresh refresh call, hammering the refresh endpoint until the refresh token expired.
2. **Erroneous sign-out.** The catch block removed the token on any non-`RefreshTokenError`, so when refresh **succeeded** but the retry still 401'd (e.g. the endpoint lacks permission for a valid token), the freshly-refreshed, still-valid token was removed — signing the user out.
3. **Duplicate `onUnauthorized` / signOut.** The retry re-enters the error phase (nested retry exchange + outer exchange), which fired `onUnauthorized` twice per request (double logout/redirect). And `JwtTokenManager.refresh()` already removes on failure, so the catch's extra remove emitted a duplicate signOut event.

## Fix

- **Bound the loop** — track refresh-retry count on `exchange.attributes`; give up after `AUTHORIZATION_RESPONSE_MAX_RETRY` (`1`). The persistent 401 flows to the downstream `UnauthorizedErrorInterceptor`.
- **Preserve the token on retry failure** — split the retry into its own step outside the refresh `catch`, so a retry that still fails no longer removes the (valid) token. Removal happens only on refresh failure.
- **Deduplicate `onUnauthorized`** — `UnauthorizedErrorInterceptor` records an `attributes` flag when it fires and skips subsequent invocations on the same exchange.

## Tests

Regression tests for all three behaviours:
- `should not infinitely refresh when the retried request still returns 401`
- `should remove the token exactly once when refresh fails` (no duplicate signOut)
- `should preserve the token when refresh succeeds but the retried request still fails`
- `should invoke onUnauthorized at most once for the same exchange`

Full cosec suite: **241/241 ✅** (no regression).