### PR TITLE
test(decorator): replace fake assertions and private-method coupling

### DIFF
--- a/packages/decorator/test/apiDecorator.test.ts
+++ b/packages/decorator/test/apiDecorator.test.ts
@@ -30,10 +30,6 @@ afterAll(() => {
   global.fetch = originalFetch;
 });
 
-afterAll(() => {
-  global.fetch = originalFetch;
-});
-
 // Mock class for testing decorators
 @api('/api/v1', {
   headers: { 'X-Default': 'value' },
@@ -507,18 +503,20 @@ describe('apiDecorator', () => {
   });
 
   describe('advanced metadata merging', () => {
-    it('should merge complex metadata correctly', () => {
-      const testApi: any = new TestApi();
+    // Helper: read the merged api metadata that buildRequestExecutor baked
+    // into the RequestExecutor. Previously these tests only asserted
+    // toBeInstanceOf(RequestExecutor) + a comment — verifying nothing.
+    function mergedApi(executor: RequestExecutor): ApiMetadata {
+      return (executor as any).metadata.api as ApiMetadata;
+    }
 
-      // Set complex instance metadata
+    it('should let instance apiMetadata override function apiMetadata', () => {
+      const testApi: any = new TestApi();
       testApi.apiMetadata = {
         basePath: '/instance',
         headers: { 'X-Instance': 'value' },
         timeout: 2000,
         fetcher: 'instanceFetcher',
-        resultExtractor: JsonResultExtractor,
-        attributes: { instanceAttr: 'value' },
-        urlParams: { instanceParam: 'value' },
       };
 
       const functionMetadata = new FunctionMetadata(
@@ -528,32 +526,32 @@ describe('apiDecorator', () => {
           headers: { 'X-Function': 'value' },
           timeout: 5000,
           fetcher: 'functionFetcher',
-          resultExtractor: JsonResultExtractor,
-          attributes: { functionAttr: 'value' },
-          urlParams: {},
         },
         { method: HttpMethod.GET, path: '/users' },
         new Map(),
       );
 
-      const requestExecutor = buildRequestExecutor(testApi, functionMetadata);
+      const executor = buildRequestExecutor(testApi, functionMetadata);
 
-      expect(requestExecutor).toBeInstanceOf(RequestExecutor);
-      // Instance metadata should override function metadata
+      // Instance metadata wins on conflict...
+      expect(mergedApi(executor).basePath).toBe('/instance');
+      expect(mergedApi(executor).timeout).toBe(2000);
+      expect(mergedApi(executor).fetcher).toBe('instanceFetcher');
+      // ...and fully replaces (not deep-merges) headers.
+      expect(mergedApi(executor).headers).toEqual({ 'X-Instance': 'value' });
     });
 
-    it('should handle undefined metadata fields', () => {
+    it('should keep function metadata fields when instance omits them', () => {
       const testApi: any = new TestApi();
-
-      // Set partial instance metadata
       testApi.apiMetadata = {
         basePath: '/instance',
-        // Other fields undefined
+        // timeout, headers, fetcher intentionally undefined
       };
 
       const functionMetadata = new FunctionMetadata(
         'getUsers',
         {
+          basePath: '/function',
           timeout: 5000,
           headers: { 'X-Function': 'value' },
         },
@@ -561,15 +559,17 @@ describe('apiDecorator', () => {
         new Map(),
       );
 
-      const requestExecutor = buildRequestExecutor(testApi, functionMetadata);
+      const executor = buildRequestExecutor(testApi, functionMetadata);
 
-      expect(requestExecutor).toBeInstanceOf(RequestExecutor);
-      // Should merge defined fields correctly
+      expect(mergedApi(executor).basePath).toBe('/instance');
+      // Fields only on the function side survive.
+      expect(mergedApi(executor).timeout).toBe(5000);
+      expect(mergedApi(executor).headers).toEqual({ 'X-Function': 'value' });
     });
   });
 
   describe('buildRequestExecutor', () => {
-    it('should create a new request executor when none exists', () => {
+    it('should cache the executor by method name and return the same instance', () => {
       const testApi = new TestApi();
       const functionMetadata = new FunctionMetadata(
         'getUsers',
@@ -578,33 +578,14 @@ describe('apiDecorator', () => {
         new Map(),
       );
 
-      const requestExecutor = buildRequestExecutor(testApi, functionMetadata);
+      const first = buildRequestExecutor(testApi, functionMetadata);
+      const second = buildRequestExecutor(testApi, functionMetadata);
 
-      expect(requestExecutor).toBeInstanceOf(RequestExecutor);
-      // Check that it's stored for reuse
-      const requestExecutor2 = buildRequestExecutor(testApi, functionMetadata);
-      expect(requestExecutor2).toBe(requestExecutor);
+      expect(second).toBe(first);
     });
 
-    it('should reuse existing request executor', () => {
-      const testApi = new TestApi();
-      const functionMetadata = new FunctionMetadata(
-        'getUser',
-        {},
-        { method: HttpMethod.GET, path: '/users/{id}' },
-        new Map(),
-      );
-
-      const requestExecutor1 = buildRequestExecutor(testApi, functionMetadata);
-      const requestExecutor2 = buildRequestExecutor(testApi, functionMetadata);
-
-      expect(requestExecutor1).toBeInstanceOf(RequestExecutor);
-      expect(requestExecutor1).toBe(requestExecutor2);
-    });
-
-    it('should merge api metadata correctly', () => {
+    it('should merge target apiMetadata over function apiMetadata', () => {
       const testApi: any = new TestApi();
-      // Add target api metadata
       testApi.apiMetadata = {
         basePath: '/target',
         headers: { 'X-Target': 'value' },
@@ -617,16 +598,18 @@ describe('apiDecorator', () => {
         new Map(),
       );
 
-      const requestExecutor = buildRequestExecutor(testApi, functionMetadata);
+      const executor = buildRequestExecutor(testApi, functionMetadata);
 
-      expect(requestExecutor).toBeInstanceOf(RequestExecutor);
-      // Should use target metadata where it exists, and function metadata where it doesn't
-      // In this case, target metadata should take precedence
+      // Target basePath wins; function-only timeout survives.
+      expect((executor as any).metadata.api.basePath).toBe('/target');
+      expect((executor as any).metadata.api.timeout).toBe(5000);
+      expect((executor as any).metadata.api.headers).toEqual({
+        'X-Target': 'value',
+      });
     });
 
-    it('should create new requestExecutors map when none exists', () => {
+    it('should create a requestExecutors map on the target when none exists', () => {
       const testApi: any = new TestApi();
-      // Remove any existing requestExecutors
       delete testApi.requestExecutors;
 
       const functionMetadata = new FunctionMetadata(
@@ -636,11 +619,10 @@ describe('apiDecorator', () => {
         new Map(),
       );
 
-      const requestExecutor = buildRequestExecutor(testApi, functionMetadata);
+      const executor = buildRequestExecutor(testApi, functionMetadata);
 
-      expect(requestExecutor).toBeInstanceOf(RequestExecutor);
       expect(testApi.requestExecutors).toBeInstanceOf(Map);
-      expect(testApi.requestExecutors.get('newMethod')).toBe(requestExecutor);
+      expect(testApi.requestExecutors.get('newMethod')).toBe(executor);
     });
   });
 });

--- a/packages/decorator/test/functionMetadata.test.ts
+++ b/packages/decorator/test/functionMetadata.test.ts
@@ -443,101 +443,55 @@ describe('FunctionMetadata', () => {
     });
   });
 
-  describe('processHttpParam', () => {
-    it('should not modify params when value is undefined', () => {
-      const functionMetadata = new FunctionMetadata(
+  // processHttpParam is a private implementation detail invoked from
+  // resolveExchangeInit for PATH/QUERY/HEADER parameters. The previous tests
+  // reached in via @ts-expect-error, locking the private signature. These now
+  // exercise the same branches through the public resolveExchangeInit entry
+  // point, asserting the observable request instead of the internal call.
+  describe('http param processing (via resolveExchangeInit)', () => {
+    function metadataWithParam(
+      param: Partial<ParameterMetadata> & { index: number },
+    ): FunctionMetadata {
+      return new FunctionMetadata(
         'test',
-        {},
-        { method: HttpMethod.GET },
-        new Map(),
+        { basePath: '' },
+        { method: HttpMethod.GET, path: '/' },
+        new Map([[param.index, { type: ParameterType.PATH, ...param }]]),
       );
+    }
 
-      const params: Record<string, any> = { existing: 'value' };
-      // @ts-expect-error - accessing private method for testing
-      functionMetadata.processHttpParam(
-        { name: 'test', index: 0 },
-        undefined,
-        params,
-      );
-
-      expect(params).toEqual({ existing: 'value' });
+    it('should not add a param when the argument is undefined', () => {
+      const fm = metadataWithParam({ name: 'id', index: 0 });
+      const { request } = fm.resolveExchangeInit([undefined]);
+      // pathParams should be empty (undefined value skipped).
+      expect(request.urlParams?.path).toEqual({});
     });
 
-    it('should expand object properties to params', () => {
-      const functionMetadata = new FunctionMetadata(
-        'test',
-        {},
-        { method: HttpMethod.GET },
-        new Map(),
-      );
-
-      const params: Record<string, any> = {};
-      // @ts-expect-error - accessing private method for testing
-      functionMetadata.processHttpParam(
-        { name: 'test', index: 0 },
-        { key1: 'value1', key2: 'value2' },
-        params,
-      );
-
-      expect(params).toEqual({ key1: 'value1', key2: 'value2' });
+    it('should expand a plain object argument into multiple path params', () => {
+      const fm = metadataWithParam({ name: 'filter', index: 0 });
+      const { request } = fm.resolveExchangeInit([{ a: 1, b: 2 }]);
+      expect(request.urlParams?.path).toEqual({ a: 1, b: 2 });
     });
 
-    it('should use param name when value is a primitive type', () => {
-      const functionMetadata = new FunctionMetadata(
-        'test',
-        {},
-        { method: HttpMethod.GET },
-        new Map(),
-      );
-
-      const params: Record<string, any> = {};
-      // @ts-expect-error - accessing private method for testing
-      functionMetadata.processHttpParam(
-        { name: 'customParam', index: 0 },
-        'testValue',
-        params,
-      );
-
-      expect(params).toEqual({ customParam: 'testValue' });
+    it('should bind a primitive argument to the declared param name', () => {
+      const fm = metadataWithParam({ name: 'userId', index: 0 });
+      const { request } = fm.resolveExchangeInit(['abc']);
+      expect(request.urlParams?.path).toEqual({ userId: 'abc' });
     });
 
-    it('should use param index when name is not available', () => {
-      const functionMetadata = new FunctionMetadata(
-        'test',
-        {},
-        { method: HttpMethod.GET },
-        new Map(),
-      );
-
-      const params: Record<string, any> = {};
-      // @ts-expect-error - accessing private method for testing
-      functionMetadata.processHttpParam(
-        { name: undefined, index: 2 },
-        42,
-        params,
-      );
-
-      expect(params).toEqual({ param2: 42 });
+    it('should fall back to param<index> when no name is resolvable', () => {
+      const fm = metadataWithParam({ name: undefined, index: 0 });
+      const { request } = fm.resolveExchangeInit([42]);
+      expect(request.urlParams?.path).toEqual({ param0: 42 });
     });
 
-    it('should handle array as object', () => {
-      const functionMetadata = new FunctionMetadata(
-        'test',
-        {},
-        { method: HttpMethod.GET },
-        new Map(),
-      );
-
-      const params: Record<string, any> = {};
-      // @ts-expect-error - accessing private method for testing
-      functionMetadata.processHttpParam(
-        { name: 'test', index: 0 },
-        ['item1', 'item2'],
-        params,
-      );
-
-      // Arrays are objects, so Object.entries will create entries for indices
-      expect(params).toEqual({ '0': 'item1', '1': 'item2' });
+    it('should expand an array argument into indexed path params', () => {
+      // Arrays are objects: Object.entries yields numeric-string keys. This
+      // documents current behavior (may warrant a future fix to use repeated
+      // query params instead).
+      const fm = metadataWithParam({ name: 'tags', index: 0 });
+      const { request } = fm.resolveExchangeInit([['x', 'y']]);
+      expect(request.urlParams?.path).toEqual({ '0': 'x', '1': 'y' });
     });
   });
 


### PR DESCRIPTION
Phase 2.2 of the test refactor.

## Changes
- **apiDecorator**: buildRequestExecutor tests asserted only toBeInstanceOf + comments. Now assert the actual merged api metadata (basePath/timeout/headers precedence).
- **functionMetadata**: 5 tests used @ts-expect-error to test private processHttpParam. Rewritten via public resolveExchangeInit, asserting request.urlParams.path.
- Removed duplicate afterAll block.

## Verification
- decorator: 132 tests pass. eslint clean.