### PR TITLE
test(viewer): remove coverage exclude + silent-pass if(button) tests

### DIFF
--- a/packages/viewer/test/topbar/TopBar.test.tsx
+++ b/packages/viewer/test/topbar/TopBar.test.tsx
@@ -197,48 +197,13 @@ describe('TopBar', () => {
     });
   });
 
-  describe('onReset callback', () => {
-    it('should call onReset when reset button is clicked', () => {
-      const onReset = vi.fn();
-
-      const { container } = render(
-        <TopBar<RecordType>
-          {...requiredProps}
-          viewChanged={true}
-          onReset={onReset}
-        />,
-      );
-
-      const resetButton = Array.from(container.querySelectorAll('button')).find(
-        button => button.textContent === '重置',
-      );
-
-      if (resetButton) {
-        fireEvent.click(resetButton);
-        expect(onReset).toHaveBeenCalled();
-      }
-    });
-  });
-
-  describe('onShowViewPanelChange callback', () => {
-    it('should call onShowViewPanelChange when unfold button is clicked', () => {
-      const onShowViewPanelChange = vi.fn();
-
-      const { container } = render(
-        <TopBar<RecordType>
-          {...requiredProps}
-          showViewPanel={false}
-          onShowViewPanelChange={onShowViewPanelChange}
-        />,
-      );
-
-      const unfoldButton = container.querySelector('.anticon-menu-unfold');
-      if (unfoldButton) {
-        fireEvent.click(unfoldButton.parentElement!);
-        expect(onShowViewPanelChange).toHaveBeenCalledWith(true);
-      }
-    });
-  });
+  // The onReset / onShowViewPanelChange callback tests were removed: they
+  // used `if (button) { ... }` guards that silently passed when the button
+  // was absent (which it was, under these props). Verifying the fix showed
+  // the reset/unfold buttons do not render under the test's prop
+  // combination, so these tests never tested anything. Real interaction
+  // tests that render the buttons and assert the callbacks belong in a
+  // focused follow-up with the correct prop combinations.
 
   describe('batch actions', () => {
     it('should render batch actions when enabled', () => {

--- a/packages/viewer/vitest.config.ts
+++ b/packages/viewer/vitest.config.ts
@@ -28,11 +28,6 @@ export default mergeConfig(
         exclude: [
           ...configDefaults.exclude,
           '**/**.stories.tsx',
-          //TODO exclude
-          'src/filter/panel/**',
-          'src/viewer/**',
-          'src/fetcherviewer/**',
-          'src/view/**',
         ],
       },
     },


### PR DESCRIPTION
Phase 2.5 of the test refactor.

## Changes
- **Coverage**: removed the `//TODO exclude` that hid core components (filter/panel, viewer, fetcherviewer, view) from coverage stats. They now count.
- **Silent-pass fix**: removed 2 TopBar tests using `if (button)` guards. The buttons don't render under the test props, so the tests silently passed without testing anything.

The 205 `.ant-*` class assertions and View.test.tsx smoke tests remain for phase 3 (large mechanical replacement).

## Verification
viewer: 1125 tests pass (1 pre-existing skip). eslint clean.