### PR TITLE
test(cosec): replace hand-rolled mocks, drop fake perf tests

### DIFF
--- a/packages/cosec/test/cosecRequestInterceptor.test.ts
+++ b/packages/cosec/test/cosecRequestInterceptor.test.ts
@@ -299,12 +299,13 @@ describe('CoSecRequestInterceptor', () => {
 
   describe('intercept multiple times', () => {
     it('should generate unique request IDs for each request', async () => {
-      const originalGenerateId = idGenerator.generateId;
+      // Use the module-level vi.mock (not a hand-rolled save/restore that
+      // leaks if the test fails). restoreMocks config resets after the test.
       let callCount = 0;
-      idGenerator.generateId = vi.fn(() => {
+      vi.mocked(idGenerator.generateId).mockImplementation(() => {
         callCount++;
         return `request-id-${callCount}`;
-      }) as typeof idGenerator.generateId;
+      });
 
       const testInterceptor = new CoSecRequestInterceptor({
         appId: 'test-app-id',
@@ -320,8 +321,6 @@ describe('CoSecRequestInterceptor', () => {
         mockExchange.requestHeaders[CoSecHeaders.REQUEST_ID];
 
       expect(firstRequestId).not.toBe(secondRequestId);
-
-      idGenerator.generateId = originalGenerateId;
     });
 
     it('should use same device ID for multiple requests', async () => {
@@ -420,10 +419,7 @@ describe('CoSecRequestInterceptor', () => {
 
     it('should handle very long request ID', async () => {
       const longRequestId = 'a'.repeat(100);
-      const originalGenerateId = idGenerator.generateId;
-      idGenerator.generateId = vi.fn(
-        () => longRequestId,
-      ) as typeof idGenerator.generateId;
+      vi.mocked(idGenerator.generateId).mockReturnValue(longRequestId);
 
       const interceptorWithLongId = new CoSecRequestInterceptor({
         appId: 'test-app',
@@ -440,8 +436,6 @@ describe('CoSecRequestInterceptor', () => {
       expect(mockExchange.requestHeaders[CoSecHeaders.REQUEST_ID].length).toBe(
         100,
       );
-
-      idGenerator.generateId = originalGenerateId;
     });
 
     it('should handle all HTTP methods', async () => {

--- a/packages/cosec/test/forbiddenErrorInterceptor.test.ts
+++ b/packages/cosec/test/forbiddenErrorInterceptor.test.ts
@@ -376,56 +376,6 @@ describe('ForbiddenErrorInterceptor', () => {
     });
   });
 
-  describe('intercept method - memory and performance', () => {
-    it('should not leak memory with repeated calls', async () => {
-      const interceptor = new ForbiddenErrorInterceptor({
-        onForbidden: onForbiddenMock,
-      });
-
-      // Create many exchanges to test for potential memory leaks
-      const exchanges = Array.from(
-        { length: 1000 },
-        () =>
-          new FetchExchange({
-            fetcher: mockFetcher,
-            request: mockRequest,
-            response: new Response('Forbidden', { status: 403 }),
-          }),
-      );
-
-      for (const exchange of exchanges) {
-        await interceptor.intercept(exchange);
-      }
-
-      expect(onForbiddenMock).toHaveBeenCalledTimes(1000);
-    });
-
-    it('should handle large response bodies', async () => {
-      const interceptor = new ForbiddenErrorInterceptor({
-        onForbidden: onForbiddenMock,
-      });
-
-      // Create a response with a large body
-      const largeBody = 'x'.repeat(1024 * 1024); // 1MB string
-      const response = new Response(largeBody, {
-        status: 403,
-        headers: { 'Content-Type': 'text/plain' },
-      });
-
-      const exchange = new FetchExchange({
-        fetcher: mockFetcher,
-        request: mockRequest,
-        response,
-      });
-
-      await interceptor.intercept(exchange);
-
-      expect(onForbiddenMock).toHaveBeenCalledTimes(1);
-      const calledExchange = onForbiddenMock.mock.calls[0][0];
-      expect(calledExchange.response).toBe(response);
-    });
-  });
-
   describe('intercept method - callback validation', () => {
     it('should validate callback is called with correct parameter types', async () => {
       let receivedExchange: FetchExchange | null = null;


### PR DESCRIPTION
Phase 2.6 of the test refactor.

## Changes
- Replaced 2 hand-rolled save/restore of idGenerator.generateId with vi.mocked (auto-restored by config).
- Removed 2 misnamed 'memory/performance' tests that only counted calls.

## Verification
cosec: 236 tests pass. eslint clean.