### PR TITLE
test(viewer): query tag close icon by aria-label for cross-version stability

### DIFF
--- a/packages/viewer/test/table/cell/TagCell.test.tsx
+++ b/packages/viewer/test/table/cell/TagCell.test.tsx
@@ -247,7 +247,9 @@ describe('TagCell Component', () => {
       };
 
       render(<TagCell {...props} />);
-      const closeButton = screen.getByRole('img', { hidden: true });
+      // Ant Design renders the tag close icon with role="img" (v6.3.5) or
+      // role="button" (v6.3.7+). Query by its stable accessible name instead.
+      const closeButton = screen.getByLabelText('Close');
       expect(closeButton).toBeInTheDocument();
     });
 
@@ -308,7 +310,9 @@ describe('TagCell Component', () => {
       expect(tag).toHaveClass('multi-class');
       expect(tag).toHaveAttribute('title', 'Tooltip text');
 
-      const closeButton = screen.getByRole('img', { hidden: true });
+      // Ant Design renders the tag close icon with role="img" (v6.3.5) or
+      // role="button" (v6.3.7+). Query by its stable accessible name instead.
+      const closeButton = screen.getByLabelText('Close');
       expect(closeButton).toBeInTheDocument();
     });
 
@@ -587,7 +591,9 @@ describe('TagCell Component', () => {
       };
 
       render(<TagCell {...props} />);
-      const closeButton = screen.getByRole('img', { hidden: true });
+      // Ant Design renders the tag close icon with role="img" (v6.3.5) or
+      // role="button" (v6.3.7+). Query by its stable accessible name instead.
+      const closeButton = screen.getByLabelText('Close');
       expect(closeButton).toBeInTheDocument();
       // The close button should have proper accessibility attributes
       expect(closeButton).toHaveAttribute('aria-label', 'Close');

--- a/packages/viewer/test/table/cell/TagsCell.test.tsx
+++ b/packages/viewer/test/table/cell/TagsCell.test.tsx
@@ -586,7 +586,9 @@ describe('TagsCell Component', () => {
       };
 
       render(<TagsCell {...props} />);
-      const closeButton = screen.getByRole('img', { hidden: true });
+      // Ant Design renders the tag close icon with role="img" (v6.3.5) or
+      // role="button" (v6.3.7+). Query by its stable accessible name instead.
+      const closeButton = screen.getByLabelText('Close');
       expect(closeButton).toBeInTheDocument();
       expect(closeButton).toHaveAttribute('aria-label', 'Close');
     });


### PR DESCRIPTION
## Problem

The closable \`TagCell\` / \`TagsCell\` tests query the Ant Design tag close icon by `getByRole('img', { hidden: true })`. Ant Design v6 renders that icon with `role="img"` in **6.3.5** but `role="button"` in **6.3.7+**, so the tests fail on any dependency-update PR that bumps the antd patch version. This is currently blocking **7** open dependency-update PRs in this repo (#1053, #1250, #1251, #1262, #1263, #1265, #1266).

## Fix

Query the close icon by its stable accessible name (`aria-label="Close"`) via `getByLabelText('Close')` instead of the version-specific `role`. The assertion semantics are unchanged — the tests still verify the close control is present and accessible.

## Verification

- ✅ Full `@ahoo-wang/fetcher-viewer` suite: **1125 passed**, 1 skipped (59 files)
- ✅ `eslint .` in the viewer package: 0 errors
- Confirmed against both antd behaviors (6.3.5 `role="img"`, 6.3.7+ `role="button"`)