### PR TITLE
feat(table): 添加仅设置操作列功能

### DIFF
--- a/packages/viewer/src/table/ViewTable.module.css
+++ b/packages/viewer/src/table/ViewTable.module.css
@@ -2,3 +2,8 @@
   display: flex;
   justify-content: space-between;
 }
+
+.onlySettingHeader {
+  display: flex;
+  justify-content: center;
+}

--- a/packages/viewer/src/table/ViewTable.tsx
+++ b/packages/viewer/src/table/ViewTable.tsx
@@ -220,16 +220,13 @@ export function ViewTable<RecordType>(props: ViewTableProps<RecordType>) {
       // Priority: explicit dataIndex > primary key column > fallback to 'id'
       const dataIndex =
         actionColumn.dataIndex || fields.find(x => x.primaryKey)?.name || 'id';
+      const isOnlySetting = actionColumn.onlySetting === true;
+      const showSetting = viewTableSetting || isOnlySetting;
 
       cols.push({
         key: 'action',
-        /**
-         * Action column title.
-         * If configurable is true, wraps title with settings popover.
-         */
         title: () => {
-          if (viewTableSetting) {
-            // Create the settings panel component
+          if (showSetting) {
             const settingPanel = (
               <TableSettingPanel
                 fields={fields}
@@ -237,13 +234,29 @@ export function ViewTable<RecordType>(props: ViewTableProps<RecordType>) {
                 onChange={onColumnsChange}
               />
             );
-
+            const popoverTitle = viewTableSetting
+              ? viewTableSetting.title
+              : undefined;
+            if (isOnlySetting) {
+              return (
+                <div className={styles.onlySettingHeader}>
+                  <Popover
+                    content={settingPanel}
+                    title={popoverTitle}
+                    placement="bottomRight"
+                    trigger="click"
+                  >
+                    <SettingOutlined aria-label="Table settings" />
+                  </Popover>
+                </div>
+              );
+            }
             return (
               <div className={styles.configurableColumnHeader}>
                 <span>{actionColumn.title}</span>
                 <Popover
                   content={settingPanel}
-                  title={viewTableSetting.title || 'Setting'}
+                  title={popoverTitle}
                   placement="bottomRight"
                   trigger="click"
                 >
@@ -256,20 +269,18 @@ export function ViewTable<RecordType>(props: ViewTableProps<RecordType>) {
         },
         dataIndex: dataIndex,
         fixed: 'end',
-        width: '200px',
-        /**
-         * Renders action buttons for each row.
-         * Uses ActionsCell for consistent action button styling.
-         */
-        render: (_: any, record: RecordType) => {
-          const actionsData = actionColumn!.actions(record);
-          const data = {
-            value: actionsData,
-            record: record,
-            index: columns.length + 1, // Use next available index
-          };
-          return <ActionsCell data={data} />;
-        },
+        width: isOnlySetting ? '48px' : '200px',
+        render: actionColumn.onlySetting
+          ? () => null
+          : (_: never, record: RecordType) => {
+              const actionsData = actionColumn.actions(record);
+              const data = {
+                value: actionsData,
+                record: record,
+                index: columns.length + 1,
+              };
+              return <ActionsCell data={data} />;
+            },
       });
     }
 

--- a/packages/viewer/src/table/stories/ViewTable.stories.tsx
+++ b/packages/viewer/src/table/stories/ViewTable.stories.tsx
@@ -393,3 +393,16 @@ export const WithActionColumnAndSettings: Story = {
   },
   render: args => <ViewTableWrapper {...args} />,
 };
+
+export const OnlySetting: Story = {
+  args: {
+    fields,
+    columns,
+    dataSource: mockData,
+    tableSize: 'middle',
+    enableRowSelection: false,
+    viewTableSetting: { title: 'Table Settings' },
+    actionColumn: { onlySetting: true },
+  },
+  render: args => <ViewTableWrapper {...args} />,
+};

--- a/packages/viewer/src/table/types.ts
+++ b/packages/viewer/src/table/types.ts
@@ -57,8 +57,15 @@ export interface ColumnsCell {
  * };
  * ```
  */
-export interface ViewTableActionColumn<RecordType = any> {
-  title: string;
-  dataIndex?: string;
-  actions: (record: RecordType) => ActionsData<RecordType>;
-}
+export type ViewTableActionColumn<RecordType = any> =
+  | {
+      title: string;
+      dataIndex?: string;
+      actions: (record: RecordType) => ActionsData<RecordType>;
+      onlySetting?: false;
+    }
+  | {
+      title?: string;
+      dataIndex?: string;
+      onlySetting: true;
+    };


### PR DESCRIPTION
- 将 ViewTableActionColumn 从接口改为联合类型，支持 onlySetting 属性
- 添加 onlySettingHeader 样式类用于居中显示设置图标
- 新增 OnlySetting 故事展示仅设置列的使用方式
- 实现仅设置模式下隐藏动作按钮并调整列宽度为 48px
- 在仅设置模式下使用设置图标替代标题文字
- 优化设置面板弹窗逻辑，支持仅设置场景下的独立触发