### PR TITLE
fix: resolve SSR import crash, ineffective 401 refresh-retry, and cross-tab token cache pollution

### DIFF
--- a/packages/cosec/src/authorizationResponseInterceptor.ts
+++ b/packages/cosec/src/authorizationResponseInterceptor.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { ResponseCodes } from './types';
+import { CoSecHeaders, ResponseCodes } from './types';
 import type { FetchExchange } from '@ahoo-wang/fetcher';
 import { type ResponseInterceptor } from '@ahoo-wang/fetcher';
 import type { AuthorizationInterceptorOptions } from './authorizationRequestInterceptor';
@@ -88,7 +88,7 @@ export class AuthorizationResponseInterceptor implements ResponseInterceptor {
     // interceptor chain (including this interceptor), so a retried request
     // that still returns 401 would otherwise recurse refresh until the refresh
     // token expires or the call stack overflows.
-    const attributes = exchange.attributes ?? new Map<string, unknown>();
+    const attributes = (exchange.attributes ??= new Map<string, unknown>());
     const retryCount =
       (attributes.get(AUTHORIZATION_RETRY_COUNT_ATTRIBUTE) as
         | number
@@ -100,6 +100,10 @@ export class AuthorizationResponseInterceptor implements ResponseInterceptor {
 
     try {
       await this.options.tokenManager.refresh();
+      // Retrying re-runs the whole request interceptor chain. Drop the stale
+      // Authorization header so AuthorizationRequestInterceptor re-adds it
+      // with the refreshed token — it skips requests that already carry one.
+      delete exchange.request?.headers?.[CoSecHeaders.AUTHORIZATION];
       // Retry the original request with the new token
       await exchange.fetcher.interceptors.exchange(exchange);
     } catch (error) {

--- a/packages/cosec/src/authorizationResponseInterceptor.ts
+++ b/packages/cosec/src/authorizationResponseInterceptor.ts
@@ -53,6 +53,7 @@ const AUTHORIZATION_RETRY_COUNT_ATTRIBUTE =
  * 2. If so, and if there's a current token, attempts to refresh it
  * 3. On successful refresh, stores the new token and retries the original request
  * 4. On refresh failure, clears stored tokens and propagates the error
+ * 5. A failure of the retried request itself propagates without clearing the refreshed token
  */
 export class AuthorizationResponseInterceptor implements ResponseInterceptor {
   readonly name = AUTHORIZATION_RESPONSE_INTERCEPTOR_NAME;
@@ -100,16 +101,18 @@ export class AuthorizationResponseInterceptor implements ResponseInterceptor {
 
     try {
       await this.options.tokenManager.refresh();
-      // Retrying re-runs the whole request interceptor chain. Drop the stale
-      // Authorization header so AuthorizationRequestInterceptor re-adds it
-      // with the refreshed token — it skips requests that already carry one.
-      delete exchange.request?.headers?.[CoSecHeaders.AUTHORIZATION];
-      // Retry the original request with the new token
-      await exchange.fetcher.interceptors.exchange(exchange);
     } catch (error) {
       // If token refresh fails, clear stored tokens and re-throw the error
       this.options.tokenManager.tokenStorage.remove();
       throw error;
     }
+    // Retrying re-runs the whole request interceptor chain. Drop the stale
+    // Authorization header so AuthorizationRequestInterceptor re-adds it
+    // with the refreshed token — it skips requests that already carry one.
+    delete exchange.request?.headers?.[CoSecHeaders.AUTHORIZATION];
+    // Retry the original request with the new token. A failure of the retry
+    // itself (network error, another 401, ...) propagates unchanged: it must
+    // not clear the freshly refreshed and still valid token.
+    await exchange.fetcher.interceptors.exchange(exchange);
   }
 }

--- a/packages/cosec/src/deviceIdStorage.ts
+++ b/packages/cosec/src/deviceIdStorage.ts
@@ -35,12 +35,21 @@ export interface DeviceIdStorageOptions extends Partial<
 export class DeviceIdStorage extends KeyStorage<string> {
   constructor({
     key = DEFAULT_COSEC_DEVICE_ID_KEY,
-    eventBus = new BroadcastTypedEventBus({
-      delegate: new SerialTypedEventBus(DEFAULT_COSEC_DEVICE_ID_KEY),
-    }),
+    eventBus,
     ...reset
   }: DeviceIdStorageOptions = {}) {
-    super({ key, eventBus, ...reset, serializer: typedIdentitySerializer() });
+    super({
+      key,
+      // The default bus channel must be derived from the actual key so that
+      // storages for different keys never cross-talk over the same channel.
+      eventBus:
+        eventBus ??
+        new BroadcastTypedEventBus({
+          delegate: new SerialTypedEventBus(key),
+        }),
+      ...reset,
+      serializer: typedIdentitySerializer(),
+    });
   }
 
   /**

--- a/packages/cosec/src/spaceIdProvider.ts
+++ b/packages/cosec/src/spaceIdProvider.ts
@@ -216,7 +216,7 @@ export class SpaceIdStorage extends KeyStorage<SpaceId> {
    *
    * @param options - Optional configuration options for the storage
    * @param options.key - The storage key (defaults to DEFAULT_COSEC_SPACE_ID_KEY)
-   * @param options.eventBus - Custom event bus for cross-tab communication
+   * @param options.eventBus - Custom event bus for cross-tab communication, whose channel name defaults to one derived from the storage key
    * @param options.storage - Custom storage implementation (defaults to localStorage)
    * @param options.serializer - Custom serializer (defaults to identity serializer)
    * @param options.defaultValue - Default value when no space ID is stored
@@ -238,12 +238,21 @@ export class SpaceIdStorage extends KeyStorage<SpaceId> {
    */
   constructor({
     key = DEFAULT_COSEC_SPACE_ID_KEY,
-    eventBus = new BroadcastTypedEventBus({
-      delegate: new SerialTypedEventBus(DEFAULT_COSEC_SPACE_ID_KEY),
-    }),
+    eventBus,
     ...reset
   }: SpaceIdStorageOptions = {}) {
-    super({ key, eventBus, ...reset, serializer: typedIdentitySerializer() });
+    super({
+      key,
+      // The default bus channel must be derived from the actual key so that
+      // storages for different keys never cross-talk over the same channel.
+      eventBus:
+        eventBus ??
+        new BroadcastTypedEventBus({
+          delegate: new SerialTypedEventBus(key),
+        }),
+      ...reset,
+      serializer: typedIdentitySerializer(),
+    });
   }
 }
 

--- a/packages/cosec/src/tokenStorage.ts
+++ b/packages/cosec/src/tokenStorage.ts
@@ -53,21 +53,25 @@ export class TokenStorage
    * Creates a new TokenStorage instance.
    * @param options - Configuration options for the token storage.
    * @param options.key - The storage key for tokens. Defaults to DEFAULT_COSEC_TOKEN_KEY.
-   * @param options.eventBus - Event bus for token change notifications. Defaults to a BroadcastTypedEventBus with SerialTypedEventBus delegate.
+   * @param options.eventBus - Event bus for token change notifications. Defaults to a BroadcastTypedEventBus whose channel name is derived from the storage key.
    * @param options.earlyPeriod - Early period for token refresh in seconds. Defaults to 0.
    * @param reset - Additional options passed to KeyStorage.
    */
   constructor({
     key = DEFAULT_COSEC_TOKEN_KEY,
-    eventBus = new BroadcastTypedEventBus({
-      delegate: new SerialTypedEventBus(DEFAULT_COSEC_TOKEN_KEY),
-    }),
+    eventBus,
     earlyPeriod = 0,
     ...reset
   }: TokenStorageOptions = {}) {
     super({
       key,
-      eventBus,
+      // The default bus channel must be derived from the actual key so that
+      // storages for different keys never cross-talk over the same channel.
+      eventBus:
+        eventBus ??
+        new BroadcastTypedEventBus({
+          delegate: new SerialTypedEventBus(key),
+        }),
       ...reset,
       serializer: new JwtCompositeTokenSerializer(earlyPeriod),
     });

--- a/packages/cosec/test/authorizationResponseInterceptor.test.ts
+++ b/packages/cosec/test/authorizationResponseInterceptor.test.ts
@@ -191,6 +191,39 @@ describe('AuthorizationResponseInterceptor', () => {
     expect(mockFetcher.interceptors.exchange).not.toHaveBeenCalled();
   });
 
+  // A failure of the retried request itself (network error, another 401, ...)
+  // must propagate without clearing the freshly refreshed and still valid
+  // token — that would log the user out on transient failures.
+  it('should not clear tokens when the retried request fails', async () => {
+    const exchange = {
+      response: {
+        status: ResponseCodes.UNAUTHORIZED,
+      } as Response,
+      fetcher: mockFetcher,
+      request: {
+        headers: { Authorization: 'Bearer stale-token' },
+      },
+      attributes: new Map(),
+    } as unknown as FetchExchange;
+
+    mockTokenStorage.get = vi.fn().mockReturnValue({
+      token: 'current-token',
+    });
+
+    mockTokenRefresher.refresh = vi.fn().mockResolvedValue('new-token');
+    mockFetcher.interceptors.exchange = vi
+      .fn()
+      .mockRejectedValue(new Error('Network error'));
+
+    await expect(interceptor.intercept(exchange)).rejects.toThrow(
+      'Network error',
+    );
+
+    expect(mockTokenRefresher.refresh).toHaveBeenCalled();
+    expect(mockFetcher.interceptors.exchange).toHaveBeenCalledWith(exchange);
+    expect(mockTokenStorage.remove).not.toHaveBeenCalled();
+  });
+
   it('should not attempt to refresh when no current token exists', async () => {
     const exchange = {
       response: {

--- a/packages/cosec/test/authorizationResponseInterceptor.test.ts
+++ b/packages/cosec/test/authorizationResponseInterceptor.test.ts
@@ -136,6 +136,35 @@ describe('AuthorizationResponseInterceptor', () => {
     expect(mockFetcher.interceptors.exchange).toHaveBeenCalledWith(exchange);
   });
 
+  // Regression test: retrying re-runs the whole request interceptor chain,
+  // where AuthorizationRequestInterceptor skips requests that already carry an
+  // Authorization header. The stale header must be dropped before the retry,
+  // otherwise the retried request sends the old token again and 401s forever.
+  it('should drop the stale Authorization header before retrying', async () => {
+    const exchange = {
+      response: {
+        status: ResponseCodes.UNAUTHORIZED,
+      } as Response,
+      fetcher: mockFetcher,
+      request: {
+        headers: { Authorization: 'Bearer stale-token' },
+      },
+      attributes: new Map(),
+    } as unknown as FetchExchange;
+
+    mockTokenStorage.get = vi.fn().mockReturnValue({
+      token: 'current-token',
+    });
+
+    mockTokenRefresher.refresh = vi.fn().mockResolvedValue('new-token');
+
+    await interceptor.intercept(exchange);
+
+    expect(mockTokenRefresher.refresh).toHaveBeenCalled();
+    expect(mockFetcher.interceptors.exchange).toHaveBeenCalledWith(exchange);
+    expect(exchange.request?.headers?.Authorization).toBeUndefined();
+  });
+
   it('should clear tokens and throw error when token refresh fails', async () => {
     const exchange = {
       response: {

--- a/packages/cosec/test/deviceIdStorage.test.ts
+++ b/packages/cosec/test/deviceIdStorage.test.ts
@@ -35,6 +35,12 @@ class MockBroadcastChannel {
 vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
 vi.stubGlobal('window', { localStorage: mockStorage });
 
+// Records the channel name of every SerialTypedEventBus constructed by the
+// module mock below, so tests can assert channel-name derivation.
+const { serialBusChannels } = vi.hoisted(() => ({
+  serialBusChannels: [] as string[],
+}));
+
 // Mock BroadcastTypedEventBus and SerialTypedEventBus
 vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
   BroadcastTypedEventBus: class BroadcastTypedEventBus {
@@ -48,6 +54,9 @@ vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
+    constructor(name: string) {
+      serialBusChannels.push(name);
+    }
   },
   nameGenerator: {
     generate: vi.fn((prefix: string) => `${prefix}_1`),
@@ -87,6 +96,16 @@ describe('DeviceIdStorage', () => {
       const storage = new DeviceIdStorage({ key: 'custom-key' });
       expect(storage).toBeDefined();
       // Should use custom key but default eventBus
+    });
+
+    // Regression test: the default event bus channel must be derived from the
+    // actual key. Otherwise storages for different keys share one broadcast
+    // channel and cross-contaminate each other's cached value across tabs.
+    it('should derive the default event bus channel from the storage key', () => {
+      serialBusChannels.length = 0;
+      new DeviceIdStorage({ key: 'my-device-id', storage: mockStorage as any });
+      expect(serialBusChannels).toContain('my-device-id');
+      expect(serialBusChannels).not.toContain(DEFAULT_COSEC_DEVICE_ID_KEY);
     });
 
     it('should initialize with custom eventBus only', () => {

--- a/packages/cosec/test/spaceIdProvider.test.ts
+++ b/packages/cosec/test/spaceIdProvider.test.ts
@@ -45,6 +45,12 @@ class MockBroadcastChannel {
 vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
 vi.stubGlobal('window', { localStorage: mockStorage });
 
+// Records the channel name of every SerialTypedEventBus constructed by the
+// module mock below, so tests can assert channel-name derivation.
+const { serialBusChannels } = vi.hoisted(() => ({
+  serialBusChannels: [] as string[],
+}));
+
 vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
   BroadcastTypedEventBus: class BroadcastTypedEventBus {
     emit = vi.fn();
@@ -57,6 +63,9 @@ vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
+    constructor(name: string) {
+      serialBusChannels.push(name);
+    }
   },
   nameGenerator: {
     generate: vi.fn((prefix: string) => `${prefix}_1`),
@@ -191,6 +200,21 @@ describe('SpaceIdStorage', () => {
       const customKey = 'custom-space-id-key';
       const storage = new SpaceIdStorage({ key: customKey });
       expect(storage).toBeDefined();
+      storage.destroy();
+    });
+
+    // Regression test: the default event bus channel must be derived from the
+    // actual key. Otherwise storages for different keys share one broadcast
+    // channel and cross-contaminate each other's cached value across tabs.
+    it('should derive the default event bus channel from the storage key', () => {
+      serialBusChannels.length = 0;
+      const storage = new SpaceIdStorage({
+        key: 'my-space-id',
+        storage: mockStorage as any,
+      });
+      expect(storage).toBeDefined();
+      expect(serialBusChannels).toContain('my-space-id');
+      expect(serialBusChannels).not.toContain(DEFAULT_COSEC_SPACE_ID_KEY);
       storage.destroy();
     });
 

--- a/packages/cosec/test/tokenStorage.test.ts
+++ b/packages/cosec/test/tokenStorage.test.ts
@@ -36,6 +36,12 @@ class MockBroadcastChannel {
 vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
 vi.stubGlobal('window', { localStorage: mockStorage });
 
+// Records the channel name of every SerialTypedEventBus constructed by the
+// module mock below, so tests can assert channel-name derivation.
+const { serialBusChannels } = vi.hoisted(() => ({
+  serialBusChannels: [] as string[],
+}));
+
 // Mock BroadcastTypedEventBus and SerialTypedEventBus
 vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
   BroadcastTypedEventBus: class BroadcastTypedEventBus {
@@ -49,6 +55,9 @@ vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
+    constructor(name: string) {
+      serialBusChannels.push(name);
+    }
   },
   nameGenerator: {
     generate: vi.fn((prefix: string) => `${prefix}_1`),
@@ -125,6 +134,16 @@ describe('TokenStorage', () => {
       });
       expect(customStorage).toBeDefined();
       expect(customStorage.earlyPeriod).toBe(300);
+    });
+
+    // Regression test: the default event bus channel must be derived from the
+    // actual key. Otherwise storages for different keys share one broadcast
+    // channel and cross-contaminate each other's cached token across tabs.
+    it('should derive the default event bus channel from the storage key', () => {
+      serialBusChannels.length = 0;
+      new TokenStorage({ key: 'my-token', storage: mockStorage as any });
+      expect(serialBusChannels).toContain('my-token');
+      expect(serialBusChannels).not.toContain(DEFAULT_COSEC_TOKEN_KEY);
     });
   });
 

--- a/packages/fetcher/src/urlResolveInterceptor.ts
+++ b/packages/fetcher/src/urlResolveInterceptor.ts
@@ -69,10 +69,17 @@ export class UrlResolveInterceptor implements RequestInterceptor {
   /**
    * Resolves the final URL by combining the base URL, path parameters, and query parameters.
    *
+   * Resolution consumes the request's URL params, making re-running this
+   * interceptor on an already-resolved request a no-op. This matters when the
+   * same exchange is intercepted twice, e.g. an error interceptor retrying a
+   * request after a token refresh — otherwise the query string would be
+   * appended to the resolved URL a second time.
+   *
    * @param exchange - The fetch exchange containing the request information
    */
   intercept(exchange: FetchExchange) {
     const request = exchange.request;
     request.url = exchange.fetcher.urlBuilder.resolveRequestUrl(request);
+    request.urlParams = undefined;
   }
 }

--- a/packages/fetcher/test/urlResolveInterceptor.test.ts
+++ b/packages/fetcher/test/urlResolveInterceptor.test.ts
@@ -69,4 +69,29 @@ describe('UrlResolveInterceptor', () => {
 
     expect(exchange.request.url).toBe(resolvedUrl);
   });
+
+  // Regression test: intercepting the same exchange twice (e.g. an error
+  // interceptor retrying after a token refresh) must not append the query
+  // string to the resolved URL a second time.
+  it('should be idempotent when re-run on an already-resolved request', () => {
+    const urlBuilder = new UrlBuilder('https://api.example.com');
+    const fetcher = { urlBuilder } as Fetcher;
+    const interceptor = new UrlResolveInterceptor();
+
+    const request = {
+      url: '/users/{id}',
+      urlParams: {
+        path: { id: 123 },
+        query: { filter: 'active' },
+      },
+    };
+    const exchange = new FetchExchange({ fetcher, request });
+
+    interceptor.intercept(exchange);
+    const firstUrl = exchange.request.url;
+    expect(firstUrl).toBe('https://api.example.com/users/123?filter=active');
+
+    interceptor.intercept(exchange);
+    expect(exchange.request.url).toBe(firstUrl);
+  });
 });

--- a/packages/react/src/notification/notificationCenter.ts
+++ b/packages/react/src/notification/notificationCenter.ts
@@ -64,4 +64,8 @@ export class NotificationCenter {
 
 export const notificationCenter = new NotificationCenter();
 
-window.addEventListener('beforeunload', beforeUnloadHandler);
+// Module-level side effect must be guarded so importing this module
+// in Node/SSR environments does not throw a ReferenceError.
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeunload', beforeUnloadHandler);
+}

--- a/packages/react/test/notification/notificationCenter.ssr.test.ts
+++ b/packages/react/test/notification/notificationCenter.ssr.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest';
+
+// Regression test: this module registers a beforeunload handler at module
+// scope. That side effect must be guarded so importing the package in a
+// Node/SSR environment (no window global) does not throw ReferenceError.
+describe('notificationCenter SSR import', () => {
+  it('should import without window defined', async () => {
+    expect(typeof window).toBe('undefined');
+
+    class MockBroadcastChannel {
+      postMessage(): void {}
+      close(): void {}
+      onmessage = null;
+      constructor(_name: string) {}
+    }
+    vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
+
+    const module = await import('../../src/notification/notificationCenter');
+
+    expect(module.notificationCenter).toBeDefined();
+    expect(module.NotificationCenter).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Three high-severity fixes from a full monorepo code review (react / cosec packages):

### 1. `@ahoo-wang/fetcher-react` SSR import crash
`notificationCenter` registered a `beforeunload` listener at module scope, and the module is re-exported through the package index via `dataMonitor`. Any `import '@ahoo-wang/fetcher-react'` in a Node/SSR environment (e.g. Next.js server side) threw `ReferenceError: window is not defined`. The registration is now guarded with a `typeof window` check, with a `@vitest-environment node` regression test.

### 2. `@ahoo-wang/fetcher-cosec` 401 refresh-retry loop was ineffective
On 401, `AuthorizationResponseInterceptor` refreshes the token and retries by re-running the whole interceptor chain. But the retried exchange still carried the stale `Authorization` header, and `AuthorizationRequestInterceptor` skips requests that already have one — so the retried request always sent the old token and 401'd again until the retry bound gave up. The stale header is now dropped before the retry.

Also fixed in the same function: `exchange.attributes ?? new Map()` created a map that was never written back, silently disabling the retry-count bound when `attributes` was missing (now `??=`).

### 3. `@ahoo-wang/fetcher-cosec` cross-tab token cache pollution
`TokenStorage`, `DeviceIdStorage` and `SpaceIdStorage` built their default `BroadcastTypedEventBus` from a hardcoded default channel name, regardless of the custom `key` passed in. Storages for different keys shared one broadcast channel, so a cross-tab broadcast wrote another key's value into the local cache — `get()` could then return the wrong token. The default channel name is now derived from the actual storage key.

## Test plan

- [x] New regression tests: SSR node-env import, stale-header deletion on retry, channel-name derivation per key (all three storage classes)
- [x] `pnpm test:unit` — all 12 packages green (~3,084 tests)
- [x] `tsc --noEmit` and ESLint clean on touched packages