### PR TITLE
fix(fetcher): clean up timeout-written signal on success and stop Express template port misparse

### DIFF
--- a/packages/fetcher/src/timeout.ts
+++ b/packages/fetcher/src/timeout.ts
@@ -143,10 +143,11 @@ export async function timeoutFetch(request: FetchRequest): Promise<Response> {
   // immediately instead of performing the request, so a retry after a timeout
   // could never succeed.
   const existingController = request.abortController;
-  const controller =
-    existingController && !existingController.signal.aborted
-      ? existingController
-      : new AbortController();
+  const reuseExistingController =
+    existingController && !existingController.signal.aborted;
+  const controller = reuseExistingController
+    ? existingController
+    : new AbortController();
   request.abortController = controller;
   requestInit.signal = controller.signal;
 
@@ -182,6 +183,16 @@ export async function timeoutFetch(request: FetchRequest): Promise<Response> {
     aborted = true;
     if (timerId) {
       clearTimeout(timerId);
+    }
+    // Remove the controller/signal written onto the caller's request above,
+    // on BOTH the success and failure paths. Otherwise a later call reusing
+    // this same request object would mistake them for caller-provided values
+    // and delegate to plain fetch — silently ignoring the timeout. A
+    // caller-supplied (reused) controller is the caller's own property and
+    // is left in place.
+    delete requestInit.signal;
+    if (!reuseExistingController) {
+      request.abortController = undefined;
     }
   }
 }

--- a/packages/fetcher/src/urlTemplateResolver.ts
+++ b/packages/fetcher/src/urlTemplateResolver.ts
@@ -316,8 +316,13 @@ export const uriTemplateResolver = new UriTemplateResolver();
 export class ExpressUrlTemplateResolver implements UrlTemplateResolver {
   /**
    * Regular expression pattern to match Express-style path parameters in the format :paramName
+   *
+   * The lookbehind restricts matches to parameter placeholders that start a
+   * path segment (at the beginning of the template or right after `/`), so
+   * colons belonging to the URL itself — the scheme (`http:`) or an authority
+   * port (`host:8080`) — are never mistaken for parameters.
    */
-  private static PATH_PARAM_REGEX = /:([^/]+)/g;
+  private static PATH_PARAM_REGEX = /(?<=^|\/):([^/]+)/g;
 
   /**
    * Extracts path parameters from an Express-style URL string.

--- a/packages/fetcher/test/fetcher.test.ts
+++ b/packages/fetcher/test/fetcher.test.ts
@@ -68,7 +68,11 @@ describe('Fetcher', () => {
   function stubFetchReturning(body = 'ok', status = 200) {
     const calls: RequestInit[] = [];
     const stub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      calls.push(init ?? ({ url: String(input) } as RequestInit));
+      // Snapshot the init at call time: timeoutFetch cleans up the internal
+      // signal/abortController it wrote onto the request once the call
+      // settles, so reading the shared object afterwards would observe the
+      // cleaned state instead of what fetch actually received.
+      calls.push({ ...(init ?? ({ url: String(input) } as RequestInit)) });
       return new Response(body, { status });
     });
     vi.stubGlobal('fetch', stub);

--- a/packages/fetcher/test/timeout.test.ts
+++ b/packages/fetcher/test/timeout.test.ts
@@ -195,6 +195,48 @@ describe('timeoutFetch', () => {
     expect(await response.text()).toBe('ok');
   });
 
+  // BUG (mirror of the timeout-failure pollution fixed above): on the SUCCESS
+  // path the internal AbortController and its signal stay written on the
+  // caller's request object. A later call reusing the SAME request object then
+  // hits the `if (request.signal)` delegation branch and the timeout is
+  // silently ignored.
+  it('should not leave an internal controller/signal on the request after a successful call', async () => {
+    const request: FetchRequest = {
+      url: 'https://api.example.com/test',
+      method: 'GET',
+      timeout: 100,
+    };
+
+    const response = await timeoutFetch(request);
+    expect(response.status).toBe(200);
+
+    expect(request.signal).toBeUndefined();
+    expect(request.abortController).toBeUndefined();
+  });
+
+  it('should still enforce the timeout when reusing a request object after a successful call', async () => {
+    const request: FetchRequest = {
+      url: 'https://api.example.com/test',
+      method: 'GET',
+      timeout: 100,
+    };
+
+    // First attempt: fast endpoint → succeeds.
+    const response = await timeoutFetch(request);
+    expect(response.status).toBe(200);
+
+    // Second call reusing the SAME request object against a slow endpoint
+    // must still enforce the timeout — NOT delegate to plain fetch because of
+    // a signal left behind by the first call.
+    server.use(
+      http.get('https://api.example.com/test', async () => {
+        await delay(150);
+        return HttpResponse.text('slow');
+      }),
+    );
+    await expect(timeoutFetch(request)).rejects.toThrow(FetchTimeoutError);
+  });
+
   it('should reuse a caller-supplied, non-aborted AbortController', async () => {
     const userController = new AbortController();
     const request: FetchRequest = {

--- a/packages/fetcher/test/urlTemplateResolver.test.ts
+++ b/packages/fetcher/test/urlTemplateResolver.test.ts
@@ -163,5 +163,32 @@ describe('ExpressUrlTemplateResolver', () => {
         expressUrlTemplateResolver.resolve('/users/:id', { name: 'john' });
       }).toThrow('Missing required path parameter: id');
     });
+
+    // BUG: the pattern /:([^/]+)/ matches any colon followed by non-slash
+    // chars, so the port of an absolute baseURL (e.g. http://localhost:8080)
+    // is mistaken for a path parameter and resolution throws
+    // "Missing required path parameter: 8080".
+    it('should not treat the port of an absolute URL as a path parameter', () => {
+      const result = expressUrlTemplateResolver.resolve(
+        'http://localhost:8080/users/:id',
+        { id: 1 },
+      );
+      expect(result).toBe('http://localhost:8080/users/1');
+    });
+
+    it('should not extract the port of an absolute URL as a path parameter', () => {
+      const result = expressUrlTemplateResolver.extractPathParams(
+        'https://api.example.com:8443/users/:id/posts/:postId',
+      );
+      expect(result).toEqual(['id', 'postId']);
+    });
+
+    it('should not replace the port even when pathParams contains a numeric-matching key', () => {
+      const result = expressUrlTemplateResolver.resolve(
+        'http://localhost:8080/users/:id',
+        { id: 1, '8080': 'HACKED' },
+      );
+      expect(result).toBe('http://localhost:8080/users/1');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Two independent `fetcher` core fixes found in a module-by-module code review, each driven by a failing reproduction test first (TDD). Split out from #1327.

## Changes

- **`timeoutFetch` success-path pollution** (`src/timeout.ts`): the internal `AbortController`/`signal` written onto the caller's request object was only cleaned up on timeout. On success it stayed behind, so the next call reusing the same request object (polling, cosec 401 refresh-retry) hit the "caller supplied a signal" delegation branch and **the timeout was silently ignored**. Cleanup now happens in `finally`; a caller-supplied controller is left untouched.
- **Express URL template port misparse** (`src/urlTemplateResolver.ts`): the pattern `/:([^/]+)/g` matched any colon followed by non-slash chars, so an absolute baseURL with a port (`http://localhost:8080/users/:id`) threw `Missing required path parameter: 8080`. The lookbehind `(?<=^|/)` restricts matches to parameter placeholders that start a path segment.
- `test/fetcher.test.ts`: the fetch stub now snapshots `init` at call time — the old by-reference capture observed the post-cleanup state, which is exactly the pollution being removed.

## Testing

- New failing-first tests: no controller/signal left after a successful call; timeout still enforced when reusing the request; port not treated as a path parameter (resolve + extract + numeric-key attack).
- Package suite: 233 tests pass.

## Compatibility

No public API change. One internal behavior change: `request.signal`/`request.abortController` written by the timeout mechanism are no longer observable after a successful call — verified that no in-repo consumer (react/cosec/wow) reads them; caller-supplied controllers are preserved.
