### PR TITLE
fix(decorator): stop subclass parameter decorators from corrupting parent metadata

### DIFF
--- a/packages/decorator/src/parameterDecorator.ts
+++ b/packages/decorator/src/parameterDecorator.ts
@@ -209,9 +209,16 @@ export function parameter(type: ParameterType, name: string = '') {
       name,
     );
 
+    // Copy-on-write: Reflect.getMetadata walks the prototype chain and may
+    // return a PARENT class's Map. Mutating it in place would silently
+    // corrupt the parent's metadata when a subclass re-decorates an
+    // inherited method, so only mutate an own Map; otherwise start from a
+    // copy of the inherited one.
+    const inheritedParameters: Map<number, ParameterMetadata> | undefined =
+      Reflect.getMetadata(PARAMETER_METADATA_KEY, target, propertyKey);
     const existingParameters: Map<number, ParameterMetadata> =
-      Reflect.getMetadata(PARAMETER_METADATA_KEY, target, propertyKey) ||
-      new Map();
+      Reflect.getOwnMetadata(PARAMETER_METADATA_KEY, target, propertyKey) ??
+      new Map(inheritedParameters ?? []);
     const parameterMetadata: ParameterMetadata = {
       type: type,
       name: paramName,

--- a/packages/decorator/test/parameterDecorator.test.ts
+++ b/packages/decorator/test/parameterDecorator.test.ts
@@ -319,4 +319,62 @@ describe('parameterDecorator', () => {
       expect(paramMetadata.name).toBe('attrParam');
     });
   });
+
+  describe('inheritance', () => {
+    // BUG: `parameter()` reads existing metadata via Reflect.getMetadata,
+    // which walks the prototype chain and returns the PARENT's Map object.
+    // When a subclass re-decorates an inherited method, `set()` then mutates
+    // that shared Map in place — silently corrupting the parent class's
+    // parameter metadata.
+    it('should not mutate parent class parameter metadata when a subclass re-decorates an inherited method', () => {
+      class BaseClass {
+        getUser(id: string, limit: number) {
+          return { id, limit };
+        }
+      }
+      class ChildClass extends BaseClass {}
+
+      // Base: single path parameter at index 0
+      parameter(ParameterType.PATH, 'id')(BaseClass.prototype, 'getUser', 0);
+
+      const baseBefore: Map<number, ParameterMetadata> =
+        Reflect.getOwnMetadata(
+          PARAMETER_METADATA_KEY,
+          BaseClass.prototype,
+          'getUser',
+        );
+      expect(baseBefore.size).toBe(1);
+
+      // Child re-decorates the SAME inherited method with an extra parameter
+      parameter(ParameterType.QUERY, 'limit')(
+        ChildClass.prototype,
+        'getUser',
+        1,
+      );
+
+      // Parent metadata must remain untouched
+      const baseAfter: Map<number, ParameterMetadata> = Reflect.getOwnMetadata(
+        PARAMETER_METADATA_KEY,
+        BaseClass.prototype,
+        'getUser',
+      );
+      expect(baseAfter.size).toBe(1);
+      expect(baseAfter.get(0)).toEqual({
+        type: ParameterType.PATH,
+        name: 'id',
+        index: 0,
+      });
+      expect(baseAfter.has(1)).toBe(false);
+
+      // Child resolves inherited + own parameters on its own copy
+      const childMetadata: Map<number, ParameterMetadata> = Reflect.getMetadata(
+        PARAMETER_METADATA_KEY,
+        ChildClass.prototype,
+        'getUser',
+      );
+      expect(childMetadata.size).toBe(2);
+      expect(childMetadata.get(0)?.type).toBe(ParameterType.PATH);
+      expect(childMetadata.get(1)?.type).toBe(ParameterType.QUERY);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`@ahoo-wang/fetcher-decorator` fix found in code review (split out from #1327): a subclass re-decorating an inherited method's parameters silently corrupted the **parent** class's parameter metadata.

## Root cause

`parameter()` read existing metadata via `Reflect.getMetadata`, which walks the prototype chain. When `Child extends Base` and both decorate the same method, the child decorator received the parent's actual `Map` instance and called `.set()` on it — mutating shared state in place. Verified with a failing reproduction test (parent metadata grew from 1 to 2 entries after child decoration).

## Fix

Copy-on-write in `src/parameterDecorator.ts`: mutate only an **own** metadata Map (`Reflect.getOwnMetadata`); when the metadata comes from the prototype chain, start from a copy. The subclass still resolves inherited + own parameters; the parent class is untouched.

## Testing

- New test: subclass re-decorating an inherited method leaves parent metadata intact, and the child sees inherited + own parameters on its own copy.
- Package suite: 133 tests pass.

## Compatibility

No public API change. The only behavior removed is the metadata pollution itself.
