### PR TITLE
fix(eventstream): skip ReadableStream polyfill when the global is unavailable

### DIFF
--- a/packages/eventstream/src/readableStreams.ts
+++ b/packages/eventstream/src/readableStreams.ts
@@ -38,8 +38,14 @@ export const isReadableStreamAsyncIterableSupported =
   typeof ReadableStream !== 'undefined' &&
   typeof ReadableStream.prototype[Symbol.asyncIterator] === 'function';
 
-// Add [Symbol.asyncIterator] to ReadableStream if not already implemented
-if (!isReadableStreamAsyncIterableSupported) {
+// Add [Symbol.asyncIterator] to ReadableStream if not already implemented.
+// Guard on the global itself first: in runtimes without ReadableStream at all
+// (legacy SSR / non-stream environments) there is nothing to polyfill, and
+// referencing ReadableStream.prototype here would crash the module import.
+if (
+  typeof ReadableStream !== 'undefined' &&
+  !isReadableStreamAsyncIterableSupported
+) {
   ReadableStream.prototype[Symbol.asyncIterator] = function <R = any>() {
     return new ReadableStreamAsyncIterable<R>(this as ReadableStream<R>);
   };

--- a/packages/eventstream/test/readableStreams.test.ts
+++ b/packages/eventstream/test/readableStreams.test.ts
@@ -92,4 +92,18 @@ describe('readableStreams', () => {
     // 验证原始实现没有被覆盖
     expect((iterator as any)[customSymbol]).toBe(true);
   });
+
+  // BUG: when the runtime has no ReadableStream global at all (legacy SSR /
+  // non-stream environments), `isReadableStreamAsyncIterableSupported` is
+  // false, so the polyfill branch is entered and references the non-existent
+  // `ReadableStream` global — the module import itself throws ReferenceError.
+  it('should not throw on import when ReadableStream is unavailable in the environment', async () => {
+    vi.stubGlobal('ReadableStream', undefined);
+    vi.resetModules();
+
+    await expect(import('../src/readableStreams')).resolves.toBeDefined();
+
+    const module = await import('../src/readableStreams');
+    expect(module.isReadableStreamAsyncIterableSupported).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

`@ahoo-wang/fetcher-eventstream` fix found in code review (split out from #1327): importing the package crashed in runtimes without a `ReadableStream` global (legacy SSR / non-stream environments).

## Root cause

The polyfill guard in `src/readableStreams.ts` was self-contradictory:

```ts
export const isReadableStreamAsyncIterableSupported =
  typeof ReadableStream !== 'undefined' && ...;
if (!isReadableStreamAsyncIterableSupported) {
  ReadableStream.prototype[Symbol.asyncIterator] = ...  // ReferenceError when ReadableStream is undefined
}
```

With no `ReadableStream` global, the flag is `false`, so the branch was entered and referenced the non-existent global — the import itself threw `ReferenceError`. Reproduced with a failing test that stubs the global away and dynamically imports the module.

## Fix

Guard on the global itself first: `typeof ReadableStream !== 'undefined' && !isReadableStreamAsyncIterableSupported`. Nothing to polyfill in such environments.

## Testing

- New test: import succeeds and the flag is `false` when `ReadableStream` is unavailable.
- Package suite: 122 tests pass.

## Compatibility

Pure fix: environments with `ReadableStream` are unaffected; environments without it go from import-time crash to working import.
