### PR TITLE
fix(viewer): stable table row keys, isolated refresh-bus cleanup, stable KeyStorage

### DIFF
--- a/packages/viewer/src/fetcherviewer/FetcherViewer.tsx
+++ b/packages/viewer/src/fetcherviewer/FetcherViewer.tsx
@@ -72,6 +72,13 @@ export interface FetcherViewerProps<RecordType>
 
 const viewCommandClient = new ViewCommandClient();
 
+// useKeyStorage requires a stable KeyStorage reference (see its docstring);
+// keep the instance at module scope instead of constructing it per render.
+const localDefaultViewIdStorage = new KeyStorage<string | undefined>({
+  key: 'fetcher-viewer-local-default-view-id',
+  defaultValue: undefined,
+});
+
 export function FetcherViewer<RecordType = any>({
   ownerId = '(0)',
   tenantId = '(0)',
@@ -92,10 +99,6 @@ export function FetcherViewer<RecordType = any>({
     secondaryActions,
     batchActions,
   } = props;
-  const localDefaultViewIdStorage = new KeyStorage<string | undefined>({
-    key: 'fetcher-viewer-local-default-view-id',
-    defaultValue: undefined,
-  });
   const [localDefaultViewId, setLocalDefaultViewId] = useKeyStorage<
     string | undefined
   >(localDefaultViewIdStorage);

--- a/packages/viewer/src/hooks/useRefreshDataEventBus.ts
+++ b/packages/viewer/src/hooks/useRefreshDataEventBus.ts
@@ -3,7 +3,7 @@ import {
   BroadcastTypedEventBus,
   SerialTypedEventBus,
 } from '@ahoo-wang/fetcher-eventbus';
-import { useCallback, useEffect, useId } from 'react';
+import { useCallback, useEffect, useId, useRef } from 'react';
 
 const RefreshDataEventType = 'REFRESH_DATA_EVENTS';
 
@@ -33,6 +33,12 @@ export function useRefreshDataEventBus(
 
   const targetSubscriberId = subscriberId ?? generatedId;
 
+  // Handler names registered through THIS hook instance. Multiple components
+  // may share the same subscriberId (e.g. FetcherViewer and the refresh bar
+  // items all use the viewerDefinitionId), so unmount cleanup must only
+  // remove this instance's own handlers — never the shared prefix.
+  const registeredHandlerNames = useRef<Set<string>>(new Set());
+
   const publish = useCallback((_subscriberId?: string) => {
     return bus.emit({
       type: 'REFRESH',
@@ -53,18 +59,22 @@ export function useRefreshDataEventBus(
           }
         },
       };
-      return bus.on(wrappedHandler);
+      const subscribed = bus.on(wrappedHandler);
+      if (subscribed) {
+        registeredHandlerNames.current.add(wrappedHandler.name);
+      }
+      return subscribed;
     },
     [targetSubscriberId],
   );
 
   useEffect(() => {
+    const ownHandlerNames = registeredHandlerNames.current;
     return () => {
-      bus.handlers
-        .filter(h => h.name.startsWith(`${targetSubscriberId}:`))
-        .forEach(handler => {
-          bus.off(handler.name);
-        });
+      ownHandlerNames.forEach(name => {
+        bus.off(name);
+      });
+      ownHandlerNames.clear();
     };
   }, [targetSubscriberId]);
 

--- a/packages/viewer/src/table/ViewTable.tsx
+++ b/packages/viewer/src/table/ViewTable.tsx
@@ -337,7 +337,10 @@ export function ViewTable<RecordType>(props: ViewTableProps<RecordType>) {
   return (
     <Table<RecordType>
       loading={loading}
-      dataSource={mapToTableRecord(dataSource)}
+      dataSource={mapToTableRecord(
+        dataSource,
+        fields.find(field => field.primaryKey)?.name,
+      )}
       rowSelection={rowSelection}
       columns={tableColumns}
       {...attributes}

--- a/packages/viewer/src/utils.ts
+++ b/packages/viewer/src/utils.ts
@@ -1,3 +1,4 @@
+import type { Key } from 'react';
 import type { TableRecordType } from './types';
 
 /**
@@ -93,14 +94,41 @@ export function deepEqual(left: any, right: any): boolean {
   return false;
 }
 
+/**
+ * Maps a data source array to table records with a `key` field used as antd's rowKey.
+ *
+ * Key precedence:
+ * 1. The value of the `primaryKey` field on the record (stable across data
+ *    refreshes, sorting, and paging — required for correct row selection).
+ * 2. The record's own `key` property, if present.
+ * 3. The array index (last resort: index keys are NOT stable across data
+ *    changes, so row selection may point at the wrong records).
+ *
+ * @param dataSource - The records to map
+ * @param primaryKey - Name of the record's primary key field, if known
+ * @returns Records with a `key` field added (or preserved)
+ */
 export function mapToTableRecord<RecordType = any>(
   dataSource: RecordType[] | undefined,
+  primaryKey?: string,
 ): TableRecordType<RecordType>[] {
   if (dataSource && dataSource.length > 0) {
-    return dataSource.map((record, index) => ({
-      ...record,
-      key: index,
-    }));
+    return dataSource.map((record, index) => {
+      let key: Key = (record as { key?: Key }).key ?? index;
+      if (primaryKey) {
+        // Computed destructuring reads the primary key field dynamically
+        // (the field name comes from the viewer's field metadata).
+        const { [primaryKey]: primaryKeyValue } = record as Record<
+          string,
+          Key | undefined
+        >;
+        key = primaryKeyValue ?? key;
+      }
+      return {
+        ...record,
+        key,
+      };
+    });
   }
   return [];
 }

--- a/packages/viewer/test/fetcherviewer/FetcherViewer.keyStorage.test.tsx
+++ b/packages/viewer/test/fetcherviewer/FetcherViewer.keyStorage.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { FetcherViewer } from '../../src/fetcherviewer/FetcherViewer';
+import type { PaginationProps } from 'antd';
+
+const keyStorageConstructorSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('@ahoo-wang/fetcher-storage', () => ({
+  KeyStorage: class {
+    constructor(options: unknown) {
+      keyStorageConstructorSpy(options);
+    }
+  },
+}));
+
+vi.mock('../../src/fetcherviewer/hooks/useViewerDefinition', () => ({
+  useViewerDefinition: vi.fn(),
+}));
+
+vi.mock('../../src/fetcherviewer/hooks/useViewerViews', () => ({
+  useViewerViews: vi.fn(),
+}));
+
+vi.mock('../../src/fetcherviewer/hooks/useFetchData', () => ({
+  useFetchData: vi.fn(),
+}));
+
+vi.mock('../../src/hooks/useRefreshDataEventBus', () => ({
+  useRefreshDataEventBus: vi.fn(() => ({
+    publish: vi.fn(),
+    subscribe: vi.fn(),
+  })),
+}));
+
+vi.mock('@ahoo-wang/fetcher-react', () => ({
+  useKeyStorage: vi.fn(() => [undefined, vi.fn()]),
+}));
+
+vi.mock('../../src/viewer/Viewer', () => ({
+  Viewer: vi.fn(() => <div data-testid="viewer">Viewer</div>),
+}));
+
+import { useViewerDefinition, useViewerViews, useFetchData } from '../../src';
+
+describe('FetcherViewer local default view KeyStorage', () => {
+  const defaultProps = {
+    viewerDefinitionId: 'test-view',
+    ownerId: 'test-owner',
+    tenantId: 'test-tenant',
+    pagination: {} as PaginationProps,
+    enableRowSelection: true,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useViewerDefinition).mockReturnValue({
+      viewerDefinition: {
+        id: 'test-view',
+        name: 'Test View',
+        fields: [{ name: 'id', label: 'ID', type: 'number', primaryKey: true }],
+        availableFilters: [],
+        dataUrl: '/api/test',
+        countUrl: '/api/test/count',
+      } as any,
+      loading: false,
+      error: undefined,
+    });
+
+    vi.mocked(useViewerViews).mockReturnValue({
+      views: [] as any,
+      loading: false,
+      error: undefined,
+    });
+
+    vi.mocked(useFetchData).mockReturnValue({
+      dataSource: { list: [], total: 0 } as any,
+      loading: false,
+      setQuery: vi.fn(),
+      reload: vi.fn().mockResolvedValue(undefined),
+      error: undefined,
+      getPageQuery: vi.fn(),
+    });
+  });
+
+  // The KeyStorage for the local default view id must have a render-invariant
+  // identity: useKeyStorage requires a stable reference, otherwise each new
+  // instance makes useSyncExternalStore tear down and re-subscribe, and every
+  // callback depending on it (e.g. onSwitchView) gets a fresh identity.
+  // NOTE: react-compiler currently masks the original `new KeyStorage(...)`
+  // in the component body by auto-memoizing it, so this test passes both
+  // before and after the source-level fix (hoisting to module scope). It is
+  // kept as a characterization test: if the compiler ever bails out on this
+  // component or the construction is moved back into the render path, this
+  // test turns red.
+  it('should not re-create the KeyStorage on re-renders', () => {
+    const { rerender } = render(<FetcherViewer {...defaultProps} />);
+    const callsAfterFirstRender = keyStorageConstructorSpy.mock.calls.length;
+
+    rerender(<FetcherViewer {...defaultProps} />);
+    rerender(<FetcherViewer {...defaultProps} />);
+
+    expect(keyStorageConstructorSpy.mock.calls.length).toBe(
+      callsAfterFirstRender,
+    );
+  });
+});

--- a/packages/viewer/test/hooks/useRefreshDataEventBus.test.ts
+++ b/packages/viewer/test/hooks/useRefreshDataEventBus.test.ts
@@ -181,6 +181,44 @@ describe('useRefreshDataEventBus', () => {
 
       expect(handler2).toHaveBeenCalledTimes(1);
     });
+
+    // BUG: FetcherViewer, AutoRefreshBarItem and RefreshDataBarItem all share
+    // the SAME viewerDefinitionId as subscriberId. The unmount cleanup removes
+    // every handler with the `${subscriberId}:` prefix, so when one component
+    // unmounts (e.g. a loading state swaps the Viewer subtree out), the
+    // FetcherViewer subscription is silently removed too — and never
+    // re-subscribed, leaving refresh dead.
+    it('should not remove handlers of other components sharing the same subscriberId when unmounting', async () => {
+      const sharedSubscriberId = 'shared-viewer-definition-id';
+
+      // FetcherViewer-like long-lived subscriber
+      const { result: viewerResult } = renderHook(() =>
+        useRefreshDataEventBus(sharedSubscriberId),
+      );
+      const viewerHandler = vi.fn();
+      viewerResult.current.subscribe({
+        name: 'Viewer-Refresh-Data',
+        handle: viewerHandler,
+      });
+
+      // AutoRefreshBarItem-like subscriber that unmounts first
+      const { result: barResult, unmount: unmountBar } = renderHook(() =>
+        useRefreshDataEventBus(sharedSubscriberId),
+      );
+      const barHandler = vi.fn();
+      barResult.current.subscribe({
+        name: 'Auto-Refresh',
+        handle: barHandler,
+      });
+
+      unmountBar();
+
+      await act(async () => {
+        await viewerResult.current.publish(sharedSubscriberId);
+      });
+
+      expect(viewerHandler).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('subscriber isolation', () => {

--- a/packages/viewer/test/utils.test.ts
+++ b/packages/viewer/test/utils.test.ts
@@ -361,7 +361,42 @@ describe('mapToTableRecord', () => {
     expect(result[1].tags).toEqual(['user']);
   });
 
-  it('should handle records with existing key property', () => {
+  // BUG: index-based keys make antd's rowKey an array subscript. After a data
+  // refresh, sort, or page change the same key points at a DIFFERENT record,
+  // so selectedRowKeys silently targets the wrong rows (the root cause behind
+  // the stale-selection symptom noted in FetcherViewer). When a primary key
+  // field is available, its value must be used as the key.
+  it('should use the primary key field value as key when primaryKey is provided', () => {
+    const dataSource = [
+      { id: 101, name: 'John' },
+      { id: 202, name: 'Jane' },
+    ];
+
+    const result = mapToTableRecord(dataSource, 'id');
+
+    expect(result[0]).toEqual({ id: 101, name: 'John', key: 101 });
+    expect(result[1]).toEqual({ id: 202, name: 'Jane', key: 202 });
+  });
+
+  it('should keep keys stable for the same record across refreshed/reordered data', () => {
+    const before = mapToTableRecord([{ id: 1 }, { id: 2 }], 'id');
+    const after = mapToTableRecord([{ id: 2 }, { id: 1 }], 'id');
+
+    const keyOf = (rows: { id: number; key: unknown }[], id: number) =>
+      rows.find(row => row.id === id)?.key;
+
+    expect(keyOf(after, 2)).toBe(keyOf(before, 2));
+    expect(keyOf(after, 1)).toBe(keyOf(before, 1));
+  });
+
+  it('should fall back to the index key when the record has no primary key value', () => {
+    const result = mapToTableRecord([{ name: 'John' }, { name: 'Jane' }], 'id');
+
+    expect(result[0].key).toBe(0);
+    expect(result[1].key).toBe(1);
+  });
+
+  it('should preserve an existing record key property instead of overwriting it with the index', () => {
     const dataSource = [
       { id: 1, name: 'John', key: 'existing-key' },
       { id: 2, name: 'Jane', key: 'another-key' },
@@ -369,9 +404,8 @@ describe('mapToTableRecord', () => {
 
     const result = mapToTableRecord(dataSource);
 
-    // The function should overwrite existing key with index-based key
-    expect(result[0]).toEqual({ id: 1, name: 'John', key: 0 });
-    expect(result[1]).toEqual({ id: 2, name: 'Jane', key: 1 });
+    expect(result[0]).toEqual({ id: 1, name: 'John', key: 'existing-key' });
+    expect(result[1]).toEqual({ id: 2, name: 'Jane', key: 'another-key' });
   });
 
   it('should handle single record array', () => {


### PR DESCRIPTION
## Summary

Three `viewer` fixes found in code review (split out from #1327), each with reproduction tests.

## Changes

1. **Stable table row keys** (`src/utils.ts`, `src/table/ViewTable.tsx`): `mapToTableRecord` used the array index as antd's rowKey, so after data refresh/sort/paging `selectedRowKeys` silently pointed at **different records** (batch operations would act on the wrong rows). Key precedence is now: the field's `primaryKey` value → the record's own `key` property → index (last resort). Also stops clobbering a record's own `key` field.

2. **Isolated refresh-bus cleanup** (`src/hooks/useRefreshDataEventBus.ts`): unmount cleanup removed every handler with the `${subscriberId}:` prefix. FetcherViewer, AutoRefreshBarItem and RefreshDataBarItem all share the same `viewerDefinitionId` as subscriberId, so one bar item unmounting (e.g. when a loading state swaps the Viewer subtree) deleted FetcherViewer's subscription too — and it never re-subscribed, leaving refresh dead. The hook now tracks and removes only its own registrations.

3. **Stable KeyStorage** (`src/fetcherviewer/FetcherViewer.tsx`): the local-default-view `KeyStorage` was constructed in the component body; hoisted to module scope per `useKeyStorage`'s documented stable-reference contract. Note: react-compiler currently auto-memoizes the construction, so the included test is a characterization guard (passes before/after; turns red if the compiler bail-out ever changes that).

## Testing

- New failing-first tests: key stability across refreshed/reordered data, primaryKey/fallback precedence, same-subscriberId survival across unmount.
- Package suite: 1130 tests pass.

## Compatibility

`selectedRowKeys` now contain primary-key values instead of row indices. The package's own `onSelectChange` contract passes records and is unaffected; external code reading antd's raw `selectedRowKeys` as array indices should migrate. Worth a release-note line.
