### PR TITLE
docs(wiki): fix 'dateTime' filter type to real 'datetime' constant in viewer pages

### DIFF
--- a/wiki/packages/viewer.md
+++ b/wiki/packages/viewer.md
@@ -30,7 +30,7 @@ graph TB
         direction LR
         TF["TypedFilter<br>type-based dispatch"]
         FR["filterRegistry<br>type -> component map"]
-        FF["FilterField<br>id, text, number, select, bool, dateTime"]
+        FF["FilterField<br>id, text, number, select, bool, datetime"]
     end
 
     subgraph sg_3 ["Cell System"]
@@ -212,7 +212,7 @@ graph LR
         number["number -> NumberFilter"]
         select["select -> SelectFilter"]
         bool["bool -> BoolFilter"]
-        dateTime["dateTime -> DateTimeFilter"]
+        datetime["datetime -> DateTimeFilter"]
     end
 
     TF["TypedFilter<br>type-based dispatch"] --> filterRegistry
@@ -223,7 +223,7 @@ graph LR
     style number fill:#161b22,stroke:#30363d,color:#e6edf3
     style select fill:#161b22,stroke:#30363d,color:#e6edf3
     style bool fill:#161b22,stroke:#30363d,color:#e6edf3
-    style dateTime fill:#161b22,stroke:#30363d,color:#e6edf3
+    style datetime fill:#161b22,stroke:#30363d,color:#e6edf3
 ```
 
 | Filter Type | Component | Description |
@@ -233,7 +233,7 @@ graph LR
 | `number` | `NumberFilter` | Numeric input with range support |
 | `select` | `SelectFilter` | Dropdown select with options |
 | `bool` | `BoolFilter` | Boolean toggle/checkbox |
-| `dateTime` | `DateTimeFilter` | Date/time picker with range |
+| `datetime` | `DateTimeFilter` | Date/time picker with range |
 
 Source: [packages/viewer/src/filter/filterRegistry.ts:73-83](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/viewer/src/filter/filterRegistry.ts#L73-L83)
 

--- a/wiki/zh/packages/viewer.md
+++ b/wiki/zh/packages/viewer.md
@@ -30,7 +30,7 @@ graph TB
         direction LR
         TF["TypedFilter<br>type-based dispatch"]
         FR["filterRegistry<br>type -> component map"]
-        FF["FilterField<br>id, text, number, select, bool, dateTime"]
+        FF["FilterField<br>id, text, number, select, bool, datetime"]
     end
 
     subgraph sg_3 ["Cell System"]
@@ -212,7 +212,7 @@ graph LR
         number["number -> NumberFilter"]
         select["select -> SelectFilter"]
         bool["bool -> BoolFilter"]
-        dateTime["dateTime -> DateTimeFilter"]
+        datetime["datetime -> DateTimeFilter"]
     end
 
     TF["TypedFilter<br>type-based dispatch"] --> filterRegistry
@@ -223,7 +223,7 @@ graph LR
     style number fill:#161b22,stroke:#30363d,color:#e6edf3
     style select fill:#161b22,stroke:#30363d,color:#e6edf3
     style bool fill:#161b22,stroke:#30363d,color:#e6edf3
-    style dateTime fill:#161b22,stroke:#30363d,color:#e6edf3
+    style datetime fill:#161b22,stroke:#30363d,color:#e6edf3
 ```
 
 | 过滤器类型 | 组件 | 描述 |
@@ -233,7 +233,7 @@ graph LR
 | `number` | `NumberFilter` | 支持范围的数值输入 |
 | `select` | `SelectFilter` | 带选项的下拉选择 |
 | `bool` | `BoolFilter` | 布尔值开关/复选框 |
-| `dateTime` | `DateTimeFilter` | 支持范围的日期/时间选择器 |
+| `datetime` | `DateTimeFilter` | 支持范围的日期/时间选择器 |
 
 来源: [packages/viewer/src/filter/filterRegistry.ts:73-83](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/viewer/src/filter/filterRegistry.ts#L73-L83)
 


### PR DESCRIPTION
## Summary

Closes out the last remaining item from the wiki accuracy audit plan (`.zcode/plans/plan-sess_93ec5926`). A full re-verification of all 9 modules in that plan against the current wiki and v3.17.0 source found that #1334 had already fixed everything except one detail — the viewer filter type constant. Two items in the plan were also re-verified as **invalid against current source** (see below) and intentionally not applied.

## Changes

- `wiki/packages/viewer.md` + `wiki/zh/packages/viewer.md`: `dateTime` → `datetime` in 4 places each (FilterField type list, filter-system mermaid node, style reference, filter type table). `filterRegistry` registers `DateTimeFilter` under `DATE_TIME_FILTER_NAME = 'datetime'` (`packages/viewer/src/filter/DateTimeFilter.tsx:30`), so the camelCase spelling referenced a type value that does not exist.

## Audit outcome for the rest of the plan (no changes needed)

- **Already fixed by #1334**: fetcher `UrlTemplateStyle.Path`, wow (`Wow-*` headers, `condition()`, `LIKE`, `pagedQuery` shape, `CommandResult.contextAlias`, `_state` endpoints, `StreamCommandClient` diagram node), cosec `baseUrl`, eventbus (serial error-handling wording, optional `order`, DOM type in example), eventstream (`SafeTransformer` refactor docs, line references — 6 spot-checks all exact), openai (5 missing `ChatRequest` fields, `Message` index signature), generator (`Logger` example, internal-types table, eventstream dependency), react/decorator/storage low-priority items.
- **Plan items invalid against current source (wiki already correct, left as-is)**:
  - eventstream "id/retry do not persist across events" — source (`serverSentEventTransformStream.ts:111-113`) resets only `event`/`data` per dispatch; `resetEventState()` runs on error/final flush. Current wiki text matches source.
  - openai "`model` should be optional" — `ChatRequest.model: string` is required (`types.ts:40`); wiki already says required.

## Testing

- [x] `pnpm build` in `wiki/` — VitePress build passes (mermaid + markdown validated)
- [x] Grep sweep: no `dateTime` remnants; no other plan-item error patterns remain in wiki
- [x] Documentation-only change (2 files, +8/−8)
