### PR TITLE
feat(wow): align FilterExpression metadata API

### DIFF
--- a/packages/wow/src/query/filter.ts
+++ b/packages/wow/src/query/filter.ts
@@ -15,11 +15,19 @@ import { DeletionState } from './condition';
 
 export type LogicalField<FIELDS extends string = string> = FIELDS;
 export type FilterLiteral = null | string | number | boolean;
+export type EqualityFilterValue = FilterLiteral | FilterLiteral[];
 export type ComparableFilterLiteral = Exclude<FilterLiteral, null>;
 
 export enum FilterOperator {
   MATCH_ALL = 'MATCH_ALL',
   MATCH_NONE = 'MATCH_NONE',
+  ID = 'ID',
+  IDS = 'IDS',
+  AGGREGATE_ID = 'AGGREGATE_ID',
+  AGGREGATE_IDS = 'AGGREGATE_IDS',
+  TENANT_ID = 'TENANT_ID',
+  OWNER_ID = 'OWNER_ID',
+  SPACE_ID = 'SPACE_ID',
   AND = 'AND',
   OR = 'OR',
   NOR = 'NOR',
@@ -64,7 +72,7 @@ export enum StringComparison {
 const LOCAL_TIME_PATTERN =
   /^([01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9](?:\.[0-9]{1,9})?)?$/;
 const LOGICAL_FIELD_PATTERN =
-  /^[A-Za-z_][A-Za-z0-9_-]*(\.(?:[A-Za-z_][A-Za-z0-9_-]*|[0-9]+))*$/;
+  /^@?[A-Za-z_][A-Za-z0-9_-]*(\.(?:@?[A-Za-z_][A-Za-z0-9_-]*|[0-9]+))*$/;
 const OFFSET_ZONE_PATTERN =
   /^(?:UTC|GMT|UT)?[+-](\d{1,2}|\d{4}|\d{6}|\d{2}:\d{2}|\d{2}:\d{2}:\d{2})$/;
 const OFFSET_ZONE_CANDIDATE_PATTERN = /^(?:UTC|GMT|UT)?[+-]/;
@@ -130,6 +138,14 @@ function filterLiteral<T extends FilterLiteral>(
     throw new TypeError('Filter value must be a JSON scalar.');
   }
   return value;
+}
+
+function equalityFilterValue(value: EqualityFilterValue): EqualityFilterValue {
+  if (Array.isArray(value)) {
+    value.forEach(item => filterLiteral(item, true));
+    return value;
+  }
+  return filterLiteral(value, true);
 }
 
 function requiredString(name: string, value: string): string {
@@ -296,6 +312,23 @@ export type MatchFilter = {
   op: FilterOperator.MATCH_ALL | FilterOperator.MATCH_NONE;
 };
 
+export type MetadataValueFilter = {
+  op:
+    | FilterOperator.ID
+    | FilterOperator.AGGREGATE_ID
+    | FilterOperator.TENANT_ID
+    | FilterOperator.OWNER_ID
+    | FilterOperator.SPACE_ID;
+  value: string;
+};
+
+export type MetadataValuesFilter = {
+  op: FilterOperator.IDS | FilterOperator.AGGREGATE_IDS;
+  values: string[];
+};
+
+export type MetadataFilter = MetadataValueFilter | MetadataValuesFilter;
+
 export type LogicalFilter<FIELDS extends string = string> = {
   op: FilterOperator.AND | FilterOperator.OR | FilterOperator.NOR;
   operands: FilterExpression<FIELDS>[];
@@ -309,7 +342,7 @@ export type ElementLogicalFilter<FIELDS extends string = string> = {
 export type EqualityFilter<FIELDS extends string = string> = {
   op: FilterOperator.EQ | FilterOperator.NE;
   field: LogicalField<FIELDS>;
-  value: FilterLiteral;
+  value: EqualityFilterValue;
 };
 
 export type ComparisonFilter<FIELDS extends string = string> = {
@@ -423,6 +456,7 @@ export type ElementFilterExpression<FIELDS extends string = string> =
 
 export type FilterExpression<FIELDS extends string = string> =
   | MatchFilter
+  | MetadataFilter
   | LogicalFilter<FIELDS>
   | EqualityFilter<FIELDS>
   | ComparisonFilter<FIELDS>
@@ -443,10 +477,17 @@ export interface FilterCapable<FIELDS extends string = string> {
 
 function validateElementPredicate(predicate: FilterExpression): void {
   switch (predicate.op) {
+    case FilterOperator.ID:
+    case FilterOperator.IDS:
+    case FilterOperator.AGGREGATE_ID:
+    case FilterOperator.AGGREGATE_IDS:
+    case FilterOperator.TENANT_ID:
+    case FilterOperator.OWNER_ID:
+    case FilterOperator.SPACE_ID:
     case FilterOperator.DELETION:
     case FilterOperator.SEARCH:
       throw new TypeError(
-        'ELEMENT_MATCH predicate cannot contain DELETION or SEARCH.',
+        'ELEMENT_MATCH predicate cannot contain root filters.',
       );
     case FilterOperator.AND:
     case FilterOperator.OR:
@@ -515,27 +556,64 @@ export const filter = {
   matchNone(): MatchFilter {
     return { op: FilterOperator.MATCH_NONE };
   },
+  id(value: string): MetadataValueFilter {
+    return { op: FilterOperator.ID, value: requiredString('ID value', value) };
+  },
+  ids(...values: [string, ...string[]]): MetadataValuesFilter {
+    requireNonEmpty('IDS values', values);
+    values.forEach(value => requiredString('IDS value', value));
+    return { op: FilterOperator.IDS, values };
+  },
+  aggregateId(value: string): MetadataValueFilter {
+    return {
+      op: FilterOperator.AGGREGATE_ID,
+      value: requiredString('AGGREGATE_ID value', value),
+    };
+  },
+  aggregateIds(...values: [string, ...string[]]): MetadataValuesFilter {
+    requireNonEmpty('AGGREGATE_IDS values', values);
+    values.forEach(value => requiredString('AGGREGATE_IDS value', value));
+    return { op: FilterOperator.AGGREGATE_IDS, values };
+  },
+  tenantId(value: string): MetadataValueFilter {
+    return {
+      op: FilterOperator.TENANT_ID,
+      value: requiredString('TENANT_ID value', value),
+    };
+  },
+  ownerId(value: string): MetadataValueFilter {
+    return {
+      op: FilterOperator.OWNER_ID,
+      value: requiredString('OWNER_ID value', value),
+    };
+  },
+  spaceId(value: string): MetadataValueFilter {
+    return {
+      op: FilterOperator.SPACE_ID,
+      value: requiredString('SPACE_ID value', value),
+    };
+  },
   and: andFilter,
   or: orFilter,
   nor: norFilter,
   eq<FIELDS extends string>(
     field: FIELDS,
-    value: FilterLiteral,
+    value: EqualityFilterValue,
   ): EqualityFilter<FIELDS> {
     return {
       op: FilterOperator.EQ,
       field: logicalField(field),
-      value: filterLiteral(value, true),
+      value: equalityFilterValue(value),
     };
   },
   ne<FIELDS extends string>(
     field: FIELDS,
-    value: FilterLiteral,
+    value: EqualityFilterValue,
   ): EqualityFilter<FIELDS> {
     return {
       op: FilterOperator.NE,
       field: logicalField(field),
-      value: filterLiteral(value, true),
+      value: equalityFilterValue(value),
     };
   },
   gt<FIELDS extends string>(

--- a/packages/wow/test/query/filter.test.ts
+++ b/packages/wow/test/query/filter.test.ts
@@ -17,6 +17,7 @@ import {
   FilterOperator,
   StringComparison,
   type ElementFilterExpression,
+  type MetadataFilter,
 } from '../../src';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
@@ -58,6 +59,49 @@ describe('filter', () => {
       field: 'state.name',
       value: 'wow',
       stringComparison: StringComparison.CASE_INSENSITIVE,
+    });
+  });
+
+  it('builds metadata filters', () => {
+    const expressions: MetadataFilter[] = [
+      filter.id('snapshot-1'),
+      filter.ids('snapshot-1', 'snapshot-2'),
+      filter.aggregateId('order-1'),
+      filter.aggregateIds('order-1', 'order-2'),
+      filter.tenantId('tenant-1'),
+      filter.ownerId('owner-1'),
+      filter.spaceId('space-1'),
+    ];
+
+    expect(expressions).toEqual([
+      { op: FilterOperator.ID, value: 'snapshot-1' },
+      { op: FilterOperator.IDS, values: ['snapshot-1', 'snapshot-2'] },
+      { op: FilterOperator.AGGREGATE_ID, value: 'order-1' },
+      {
+        op: FilterOperator.AGGREGATE_IDS,
+        values: ['order-1', 'order-2'],
+      },
+      { op: FilterOperator.TENANT_ID, value: 'tenant-1' },
+      { op: FilterOperator.OWNER_ID, value: 'owner-1' },
+      { op: FilterOperator.SPACE_ID, value: 'space-1' },
+    ]);
+  });
+
+  it('supports Kotlin equality values and logical fields', () => {
+    expect(filter.eq('@metadata.tags', ['wow', null, 1, true])).toEqual({
+      op: FilterOperator.EQ,
+      field: '@metadata.tags',
+      value: ['wow', null, 1, true],
+    });
+    expect(filter.eq('state.@metadata.tags', 'wow')).toEqual({
+      op: FilterOperator.EQ,
+      field: 'state.@metadata.tags',
+      value: 'wow',
+    });
+    expect(filter.ne('state.status', ['CANCELLED', null])).toEqual({
+      op: FilterOperator.NE,
+      field: 'state.status',
+      value: ['CANCELLED', null],
     });
   });
 
@@ -407,6 +451,8 @@ describe('filter', () => {
       filter.elementMatch('state.items', filter.deletion(DeletionState.ACTIVE));
       // @ts-expect-error SEARCH cannot be scoped to an array element.
       filter.elementMatch('state.items', filter.search('wow'));
+      // @ts-expect-error Metadata filters cannot be scoped to an array element.
+      filter.elementMatch('state.items', filter.id('snapshot-1'));
       filter.elementMatch(
         'state.items',
         // @ts-expect-error Unsupported filters remain invalid inside logical predicates.
@@ -422,6 +468,7 @@ describe('filter', () => {
       filter.eq('sku', 'product-1'),
       filter.search('wow'),
     );
+    const metadata = filter.id('snapshot-1');
 
     expect(() =>
       filter.elementMatch(
@@ -433,6 +480,12 @@ describe('filter', () => {
       filter.elementMatch(
         'state.items',
         nestedSearch as unknown as ElementFilterExpression,
+      ),
+    ).toThrow();
+    expect(() =>
+      filter.elementMatch(
+        'state.items',
+        metadata as unknown as ElementFilterExpression,
       ),
     ).toThrow();
   });
@@ -458,6 +511,15 @@ describe('filter', () => {
       'empty collection values',
       () => Reflect.apply(filter.isIn, null, ['status']),
     ],
+    ['empty ids', () => Reflect.apply(filter.ids, null, [])],
+    [
+      'non-string aggregate ID',
+      () => Reflect.apply(filter.aggregateId, null, [1]),
+    ],
+    [
+      'non-string aggregate IDs value',
+      () => Reflect.apply(filter.aggregateIds, null, ['order-1', 2]),
+    ],
     ['invalid logical field', () => filter.eq('bad field', 'value')],
     [
       'non-string logical field',
@@ -466,6 +528,10 @@ describe('filter', () => {
     [
       'object equality value',
       () => Reflect.apply(filter.eq, null, ['status', {}]),
+    ],
+    [
+      'object equality array value',
+      () => Reflect.apply(filter.eq, null, ['status', ['PAID', {}]]),
     ],
     [
       'null comparison value',

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -141,6 +141,8 @@ import {
   type SingleQuery,
   type FilterExpression,
   type ElementFilterExpression,
+  type MetadataFilter,
+  type EqualityFilterValue,
   type RelativeTimeFilterOptions,
   type FilterListQuery,
   type FilterPagedQuery,
@@ -493,12 +495,16 @@ const query = listQuery({ filter: expression });
 Available builders:
 
 - Logical: `matchAll`, `matchNone`, `and`, `or`, `nor`
+- Metadata: `id`, `ids`, `aggregateId`, `aggregateIds`, `tenantId`, `ownerId`, `spaceId`
 - Comparison: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between`
 - String: `contains`, `startsWith`, `endsWith`; pass `StringComparison` as the third argument
 - Collection: `isIn`, `notIn`, `containsAll`
 - Presence: `isEmpty`, `isNull`, `isNotNull`, `exists`, `notExists`
 - Scope/search: `deletion`, `elementMatch`, `search`
 - Relative time: `today`, `beforeToday`, `tomorrow`, `thisWeek`, `nextWeek`, `lastWeek`, `thisMonth`, `lastMonth`, `recentDays`, `earlierDays`
+
+`eq` and `ne` accept a JSON scalar or an array of JSON scalars. Logical field
+segments may start with `@`.
 
 Relative-time builders accept JVM `ZoneId` and `DateTimeFormatter` options:
 
@@ -529,8 +535,8 @@ the filter-based request types or the existing condition-based request types.
 API remains available for servers in the compatibility window.
 
 `elementMatch` accepts `ElementFilterExpression`, whose relative field type is
-independent from the outer query fields and excludes `deletion` and `search`,
-including inside nested `and`/`or`/`nor` expressions.
+independent from the outer query fields and excludes metadata filters,
+`deletion`, and `search`, including inside nested `and`/`or`/`nor` expressions.
 
 ### Filter Cursor Queries
 


### PR DESCRIPTION
## Description

Align the Fetcher Wow FilterExpression API with the current Wow Kotlin contract.

- add ID, IDS, AGGREGATE_ID, AGGREGATE_IDS, TENANT_ID, OWNER_ID, and SPACE_ID operators and builders
- support scalar-array values for eq and ne, plus @-prefixed logical-field segments
- keep metadata filters root-only for elementMatch
- update tests and the fetcher-wow-cqrs API reference

No new dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] pnpm build
- [x] pnpm test:unit

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings