### PR TITLE
fix(generator): support legacy and latest Wow query fields

### DIFF
--- a/.github/workflows/generator-test.yml
+++ b/.github/workflows/generator-test.yml
@@ -9,7 +9,12 @@ on:
 
 jobs:
   generator-test:
+    name: generator-test (Wow ${{ matrix.wow-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        wow-version: ['8.10.8', '8.11.5']
     services:
       mongo:
         image: mongo:8.3.8
@@ -25,7 +30,7 @@ jobs:
           --health-timeout=5s
           --health-retries=5
       wow:
-        image: ghcr.io/ahoo-wang/wow-example-server:8.10.8
+        image: ghcr.io/ahoo-wang/wow-example-server:${{ matrix.wow-version }}
         ports:
           - 8080:8080
         env:
@@ -50,12 +55,13 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: 'pnpm'
 
-      - name: Install fetcher-generator
-        run: pnpm add -g @ahoo-wang/fetcher-generator
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build fetcher-generator
+        run: pnpm --filter @ahoo-wang/fetcher-generator... build
 
       - name: Generate URL
-        run: fetcher-generator generate -i http://localhost:8080/v3/api-docs
-
-      - name: Generate Local File
-        run: fetcher-generator generate -i ./packages/generator/test/demo.spec.json
+        run: node packages/generator/dist/cli.js generate -i http://localhost:8080/v3/api-docs -o /tmp/generated

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,7 +26,7 @@ jobs:
           --health-timeout=5s
           --health-retries=5
       wow:
-        image: ghcr.io/ahoo-wang/wow-example-server:8.10.8
+        image: ghcr.io/ahoo-wang/wow-example-server:8.11.5
         ports:
           - 8080:8080
         env:

--- a/integration-test/test/wow/cart/cartEventStreamQueryClient.test.ts
+++ b/integration-test/test/wow/cart/cartEventStreamQueryClient.test.ts
@@ -16,6 +16,7 @@ import {
   aggregateId,
   CommandHeaders,
   CommandStage,
+  DEFAULT_PAGINATION,
   DomainEventStream,
   ErrorCodes,
   ListQuery,
@@ -85,6 +86,7 @@ describe('cartEventStreamQueryClient Integration Test', () => {
   it('should list', async () => {
     const listQuery: ListQuery = {
       condition: aggregateId(commandResult.aggregateId),
+      limit: DEFAULT_PAGINATION.size,
     };
     const list = await cartEventStreamQueryClient.list(listQuery);
     for (const domainEventStream of list) {
@@ -96,6 +98,7 @@ describe('cartEventStreamQueryClient Integration Test', () => {
   it('should list stream', async () => {
     const listQuery: ListQuery = {
       condition: aggregateId(commandResult.aggregateId),
+      limit: DEFAULT_PAGINATION.size,
     };
     const listStream = await cartEventStreamQueryClient.listStream(listQuery);
     for await (const event of listStream) {

--- a/integration-test/test/wow/cart/cartSnapshotQueryClient.test.ts
+++ b/integration-test/test/wow/cart/cartSnapshotQueryClient.test.ts
@@ -18,6 +18,7 @@ import {
   all,
   CommandHeaders,
   CommandStage,
+  DEFAULT_PAGINATION,
   ErrorCodes,
   id,
   ListQuery,
@@ -103,6 +104,7 @@ describe('cartSnapshotQueryClient Integration Test', () => {
   it('should list', async () => {
     const listQuery: ListQuery = {
       condition: all(),
+      limit: DEFAULT_PAGINATION.size,
     };
     const list = await cartSnapshotQueryClient.list(listQuery);
     for (const snapshot of list) {
@@ -113,6 +115,7 @@ describe('cartSnapshotQueryClient Integration Test', () => {
   it('should list stream', async () => {
     const listQuery: ListQuery = {
       condition: all(),
+      limit: DEFAULT_PAGINATION.size,
     };
     const listStream = await cartSnapshotQueryClient.listStream(listQuery);
     for await (const event of listStream) {
@@ -123,6 +126,7 @@ describe('cartSnapshotQueryClient Integration Test', () => {
   it('should list state', async () => {
     const listQuery: ListQuery = {
       condition: all(),
+      limit: DEFAULT_PAGINATION.size,
     };
     const list = await cartSnapshotQueryClient.listState(listQuery);
     for (const state of list) {
@@ -133,6 +137,7 @@ describe('cartSnapshotQueryClient Integration Test', () => {
   it('should list state stream', async () => {
     const listQuery: ListQuery = {
       condition: all(),
+      limit: DEFAULT_PAGINATION.size,
     };
     const listStream = await cartSnapshotQueryClient.listStateStream(listQuery);
     for await (const event of listStream) {

--- a/packages/generator/src/aggregate/aggregateResolver.ts
+++ b/packages/generator/src/aggregate/aggregateResolver.ts
@@ -269,14 +269,23 @@ export class AggregateResolver {
       operation.requestBody as Reference,
       this.openAPI.components,
     ) as RequestBody;
-    const conditionRefSchema = requestBody.content[
-      ContentTypeValues.APPLICATION_JSON
-    ].schema as Reference;
-    const conditionSchema = extractSchema(
-      conditionRefSchema,
-      this.openAPI.components,
-    ) as Schema;
-    const fieldRefSchema = conditionSchema.properties?.field as Reference;
+    const queryFields = requestBody['x-wow-query-fields'];
+    let fieldRefSchema: Reference;
+    if (queryFields !== undefined) {
+      if (!isReference(queryFields)) {
+        throw new TypeError('x-wow-query-fields must be a schema reference');
+      }
+      fieldRefSchema = queryFields;
+    } else {
+      const conditionRefSchema = requestBody.content[
+        ContentTypeValues.APPLICATION_JSON
+      ].schema as Reference;
+      const conditionSchema = extractSchema(
+        conditionRefSchema,
+        this.openAPI.components,
+      ) as Schema;
+      fieldRefSchema = conditionSchema.properties?.field as Reference;
+    }
     const fieldKeyedSchema = keySchema(fieldRefSchema, this.openAPI.components);
     operation.tags?.forEach(tag => {
       const aggregate = this.aggregates.get(tag);

--- a/packages/generator/test/aggregate/aggregateResolver.test.ts
+++ b/packages/generator/test/aggregate/aggregateResolver.test.ts
@@ -556,6 +556,60 @@ describe('AggregateResolver', () => {
       expect(mockAggregate.fields).toBeUndefined();
     });
 
+    it('should use the query fields schema reference', () => {
+      const operation = {
+        operationId: 'test.snapshot.count',
+        tags: ['tag1'],
+        requestBody: { $ref: '#/components/requestBodies/FilterExpression' },
+      };
+      const queryFieldsRef = {
+        $ref: '#/components/schemas/TestAggregatedFields',
+      };
+      const mockFieldSchema = { schema: { type: 'string' } };
+
+      (extractRequestBody as any).mockReturnValue({
+        'x-wow-query-fields': queryFieldsRef,
+        content: {},
+      });
+      (isReference as any).mockReturnValue(true);
+      (keySchema as any).mockReturnValue(mockFieldSchema);
+
+      (aggregateResolver as any).fields(operation);
+
+      expect(keySchema).toHaveBeenCalledWith(
+        queryFieldsRef,
+        mockOpenAPI.components,
+      );
+      expect(mockAggregate.fields).toBe(mockFieldSchema);
+    });
+
+    it('should reject the temporary query fields array protocol', () => {
+      const operation = {
+        operationId: 'test.snapshot.count',
+        tags: ['tag1'],
+        requestBody: { $ref: '#/components/requestBodies/FilterExpression' },
+      };
+
+      (extractRequestBody as any).mockReturnValue({
+        'x-wow-query-fields': ['state.id'],
+        content: {
+          'application/json': {
+            schema: { $ref: '#/components/schemas/Condition' },
+          },
+        },
+      });
+      (extractSchema as any).mockReturnValue({
+        properties: {
+          field: { $ref: '#/components/schemas/LegacyAggregatedFields' },
+        },
+      });
+      (isReference as any).mockReturnValue(false);
+
+      expect(() => (aggregateResolver as any).fields(operation)).toThrow(
+        'x-wow-query-fields must be a schema reference',
+      );
+    });
+
     it('should set fields for count operations', () => {
       const operation = {
         operationId: 'test.snapshot.count',


### PR DESCRIPTION
## Description

Support Wow's final aggregate query-fields protocol while preserving generation for legacy Wow services:

- resolve `x-wow-query-fields` when it is a schema reference (Wow 8.11.5)
- fall back to `Condition.properties.field` when the extension is absent (Wow 8.10.8)
- reject the temporary Wow 8.11.1-8.11.3 array protocol explicitly
- run Generator Test against both Wow 8.10.8 and 8.11.5 using the generator built from this PR
- move Integration Test to Wow 8.11.5
- give integration list queries an explicit positive limit required by Wow's HTTP query guard

Supersedes #1351. The Renovate PR is intentionally left untouched.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test:unit`
- [x] `actionlint .github/workflows/generator-test.yml .github/workflows/integration-test.yml`
- [x] Local generator run against Wow 8.10.8 and 8.11.5 OpenAPI documents

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] The dependent Wow change has been merged and published
- [x] I have checked my code and corrected any misspellings
