### PR TITLE
docs(wow): document latest query APIs

### DIFF
--- a/packages/wow/README.md
+++ b/packages/wow/README.md
@@ -340,6 +340,7 @@ interface CartItem {
 }
 
 interface CartState extends Identifier {
+  status: string;
   items: CartItem[];
 }
 
@@ -417,29 +418,30 @@ const singleState = await cartSnapshotQueryClient.singleState(singleQuery);
 
 type ProductSummary = {
   product: string;
-  orderCount: number;
-  total: number;
+  itemCount: number;
+  totalQuantity: number;
 };
 
 const aggregationQuery: AggregationQuery = {
   filter: filter.eq('state.status', 'COMPLETED'),
+  elements: [{ path: 'state.items' }],
   groupBy: [
     {
       type: AggregationGroupType.TERMS,
-      field: 'state.items.productId',
+      field: 'productId',
       alias: 'product',
     },
   ],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
     {
       type: AggregationMetricType.NUMERIC,
       function: AggregationFunction.SUM,
-      expression: { field: 'state.total' },
-      alias: 'total',
+      expression: { field: 'quantity' },
+      alias: 'totalQuantity',
     },
   ],
-  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
   limit: 10,
 };
 

--- a/packages/wow/README.md
+++ b/packages/wow/README.md
@@ -449,6 +449,9 @@ const summaryStream =
   await cartSnapshotQueryClient.aggregateStream<ProductSummary>(
     aggregationQuery,
   );
+for await (const event of summaryStream) {
+  console.log(event.data);
+}
 ```
 
 ##### Methods

--- a/packages/wow/README.md
+++ b/packages/wow/README.md
@@ -24,6 +24,7 @@ working with the Wow CQRS/DDD framework.
 - **🚀 Command Client**: High-level client for sending commands to Wow services with both synchronous and streaming
   responses
 - **🔍 Powerful Query DSL**: Typed `FilterExpression` builders with comprehensive operator support
+- **📊 Snapshot Aggregation**: Group and aggregate snapshot data with typed queries
 - **🔍 Query Clients**: Specialized clients for querying snapshot and event stream data with comprehensive query
   operations:
   - Counting resources
@@ -320,7 +321,12 @@ import {
 } from '@ahoo-wang/fetcher';
 import '@ahoo-wang/fetcher-eventstream';
 import {
+  AggregationFunction,
+  AggregationGroupType,
+  AggregationMetricType,
+  AggregationQuery,
   SnapshotQueryClient,
+  SortDirection,
   filter,
   FilterListQuery,
   FilterPagedQuery,
@@ -408,6 +414,41 @@ const single = await cartSnapshotQueryClient.single(singleQuery);
 
 // Single snapshot state
 const singleState = await cartSnapshotQueryClient.singleState(singleQuery);
+
+type ProductSummary = {
+  product: string;
+  orderCount: number;
+  total: number;
+};
+
+const aggregationQuery: AggregationQuery = {
+  filter: filter.eq('state.status', 'COMPLETED'),
+  groupBy: [
+    {
+      type: AggregationGroupType.TERMS,
+      field: 'state.items.productId',
+      alias: 'product',
+    },
+  ],
+  metrics: [
+    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    {
+      type: AggregationMetricType.NUMERIC,
+      function: AggregationFunction.SUM,
+      expression: { field: 'state.total' },
+      alias: 'total',
+    },
+  ],
+  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  limit: 10,
+};
+
+const summaries =
+  await cartSnapshotQueryClient.aggregate<ProductSummary>(aggregationQuery);
+const summaryStream =
+  await cartSnapshotQueryClient.aggregateStream<ProductSummary>(
+    aggregationQuery,
+  );
 ```
 
 ##### Methods
@@ -426,6 +467,9 @@ const singleState = await cartSnapshotQueryClient.singleState(singleQuery);
 - `single(singleQuery: FilterSingleQuery): Promise<Partial<MaterializedSnapshot<S>>>` - Retrieves a single materialized
   snapshot.
 - `singleState(singleQuery: FilterSingleQuery): Promise<Partial<S>>` - Retrieves a single snapshot state.
+- `aggregate<Row extends DynamicDocument = DynamicDocument>(query: AggregationQuery<FIELDS>): Promise<Row[]>` - Runs a
+  snapshot aggregation and requests `snapshot/aggregation`.
+- `aggregateStream<Row extends DynamicDocument = DynamicDocument>(query: AggregationQuery<FIELDS>): Promise<ReadableStream<JsonServerSentEvent<Row>>>` - Runs a snapshot aggregation and requests `snapshot/aggregation` using Server-Sent Events (SSE).
 
 #### QueryClientFactory
 

--- a/packages/wow/README.zh-CN.md
+++ b/packages/wow/README.zh-CN.md
@@ -331,6 +331,7 @@ interface CartItem {
 }
 
 interface CartState extends Identifier {
+  status: string;
   items: CartItem[];
 }
 
@@ -408,29 +409,30 @@ const singleState = await cartSnapshotQueryClient.singleState(singleQuery);
 
 type ProductSummary = {
   product: string;
-  orderCount: number;
-  total: number;
+  itemCount: number;
+  totalQuantity: number;
 };
 
 const aggregationQuery: AggregationQuery = {
   filter: filter.eq('state.status', 'COMPLETED'),
+  elements: [{ path: 'state.items' }],
   groupBy: [
     {
       type: AggregationGroupType.TERMS,
-      field: 'state.items.productId',
+      field: 'productId',
       alias: 'product',
     },
   ],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
     {
       type: AggregationMetricType.NUMERIC,
       function: AggregationFunction.SUM,
-      expression: { field: 'state.total' },
-      alias: 'total',
+      expression: { field: 'quantity' },
+      alias: 'totalQuantity',
     },
   ],
-  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
   limit: 10,
 };
 

--- a/packages/wow/README.zh-CN.md
+++ b/packages/wow/README.zh-CN.md
@@ -16,6 +16,7 @@
 - **📦 完整的 TypeScript 支持**：为所有 Wow 框架实体提供完整的类型定义，包括命令、事件和查询
 - **🚀 命令客户端**：用于向 Wow 服务发送命令的高级客户端，支持同步和流式响应
 - **🔍 强大的查询 DSL**：类型安全的 `FilterExpression` 构建器，支持完整的查询操作符
+- **📊 快照聚合**：使用类型安全的查询对快照数据进行分组和聚合
 - **📡 实时事件流**：内置对服务器发送事件的支持，用于接收实时命令结果和数据更新
 - **🔄 CQRS 模式实现**：对命令查询责任分离架构模式的一流支持
 - **🧱 DDD 基础构件**：基本的领域驱动设计构建块，包括聚合、事件和值对象
@@ -311,7 +312,12 @@ import {
 } from '@ahoo-wang/fetcher';
 import '@ahoo-wang/fetcher-eventstream';
 import {
+  AggregationFunction,
+  AggregationGroupType,
+  AggregationMetricType,
+  AggregationQuery,
   SnapshotQueryClient,
+  SortDirection,
   filter,
   FilterListQuery,
   FilterPagedQuery,
@@ -399,6 +405,41 @@ const single = await cartSnapshotQueryClient.single(singleQuery);
 
 // 查询单个快照状态
 const singleState = await cartSnapshotQueryClient.singleState(singleQuery);
+
+type ProductSummary = {
+  product: string;
+  orderCount: number;
+  total: number;
+};
+
+const aggregationQuery: AggregationQuery = {
+  filter: filter.eq('state.status', 'COMPLETED'),
+  groupBy: [
+    {
+      type: AggregationGroupType.TERMS,
+      field: 'state.items.productId',
+      alias: 'product',
+    },
+  ],
+  metrics: [
+    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    {
+      type: AggregationMetricType.NUMERIC,
+      function: AggregationFunction.SUM,
+      expression: { field: 'state.total' },
+      alias: 'total',
+    },
+  ],
+  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  limit: 10,
+};
+
+const summaries =
+  await cartSnapshotQueryClient.aggregate<ProductSummary>(aggregationQuery);
+const summaryStream =
+  await cartSnapshotQueryClient.aggregateStream<ProductSummary>(
+    aggregationQuery,
+  );
 ```
 
 ##### 方法
@@ -414,6 +455,8 @@ const singleState = await cartSnapshotQueryClient.singleState(singleQuery);
 - `pagedState(pagedQuery: FilterPagedQuery): Promise<PagedList<Partial<S>>>` - 检索快照状态的分页列表。
 - `single(singleQuery: FilterSingleQuery): Promise<Partial<MaterializedSnapshot<S>>>` - 检索单个物化快照。
 - `singleState(singleQuery: FilterSingleQuery): Promise<Partial<S>>` - 检索单个快照状态。
+- `aggregate<Row extends DynamicDocument = DynamicDocument>(query: AggregationQuery<FIELDS>): Promise<Row[]>` - 执行快照聚合并请求 `snapshot/aggregation`。
+- `aggregateStream<Row extends DynamicDocument = DynamicDocument>(query: AggregationQuery<FIELDS>): Promise<ReadableStream<JsonServerSentEvent<Row>>>` - 执行快照聚合并通过服务器发送事件（SSE）请求 `snapshot/aggregation`。
 
 #### QueryClientFactory
 

--- a/packages/wow/README.zh-CN.md
+++ b/packages/wow/README.zh-CN.md
@@ -440,6 +440,9 @@ const summaryStream =
   await cartSnapshotQueryClient.aggregateStream<ProductSummary>(
     aggregationQuery,
   );
+for await (const event of summaryStream) {
+  console.log(event.data);
+}
 ```
 
 ##### 方法

--- a/packages/wow/docs/superpowers/plans/2026-08-25-wow-query-documentation.md
+++ b/packages/wow/docs/superpowers/plans/2026-08-25-wow-query-documentation.md
@@ -1,0 +1,236 @@
+# Fetcher Wow 查询文档同步 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 同步 `@ahoo-wang/fetcher-wow` 的中英文 README、Skill API reference 与 Wiki，使其准确记录 `FilterExpression` 和快照聚合查询。
+
+**Architecture:** 运行时代码是唯一事实来源，五个现有文档在原章节内做最小更新。README 与 Wiki 共享同一份常用聚合示例，完整类型清单只放 Skill API reference；旧 `Condition` 仅保留兼容说明。
+
+**Tech Stack:** Markdown、TypeScript 示例、VitePress、Prettier、pnpm。
+
+**Spec:** `packages/wow/docs/superpowers/specs/2026-08-25-wow-query-documentation-design.md`
+
+## Global Constraints
+
+- 只修改五个目标用户文档及本计划，不修改运行时代码、测试、生成器或依赖。
+- 英文与中文 README、Wiki 必须保持相同结构和 API 事实。
+- 不新增 `SnapshotAggregationQueryApi`；必须准确区分 `SnapshotQueryApi` 的可选成员与 `SnapshotQueryClient` 的必需方法。
+- 不修改 `llms-full.txt`、`llms.txt`、`.vitepress/dist`、Wiki 导航或站点配置。
+- 示例只使用 `packages/wow/src/index.ts` 最终可导出的公共符号。
+- 提交前运行根 `pnpm test:unit` 与 `git diff --check`。
+
+---
+
+## File Structure
+
+- Modify `packages/wow/README.md`: 英文包概览、快照聚合示例和方法签名。
+- Modify `packages/wow/README.zh-CN.md`: 与英文 README 对齐的中文内容。
+- Modify `skills/fetcher-wow-cqrs/references/api.md`: 完整聚合公共 API 参考和兼容边界。
+- Modify `wiki/packages/wow.md`: 英文 Wiki 的 FilterExpression 主路径、聚合用法与导出表。
+- Modify `wiki/zh/packages/wow.md`: 与英文 Wiki 对齐的中文内容。
+
+### Task 1: 同步包 README
+
+**Files:**
+- Modify: `packages/wow/README.md`
+- Modify: `packages/wow/README.zh-CN.md`
+
+**Interfaces:**
+- Consumes: `AggregationQuery<FIELDS>`, `AggregationGroupType`, `AggregationMetricType`, `AggregationFunction`, `SortDirection`, `SnapshotQueryClient.aggregate<Row>()`, `SnapshotQueryClient.aggregateStream<Row>()`.
+- Produces: 面向 npm 用户的中英文聚合查询入口。
+
+- [ ] **Step 1: 更新英文 README**
+
+在特性列表增加快照聚合，在 `SnapshotQueryClient` import 与示例中加入：
+
+```ts
+type ProductSummary = {
+  product: string;
+  orderCount: number;
+  total: number;
+};
+
+const aggregationQuery: AggregationQuery = {
+  filter: filter.eq('state.status', 'COMPLETED'),
+  groupBy: [
+    {
+      type: AggregationGroupType.TERMS,
+      field: 'state.items.productId',
+      alias: 'product',
+    },
+  ],
+  metrics: [
+    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    {
+      type: AggregationMetricType.NUMERIC,
+      function: AggregationFunction.SUM,
+      expression: { field: 'state.total' },
+      alias: 'total',
+    },
+  ],
+  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  limit: 10,
+};
+
+const summaries =
+  await cartSnapshotQueryClient.aggregate<ProductSummary>(aggregationQuery);
+const summaryStream =
+  await cartSnapshotQueryClient.aggregateStream<ProductSummary>(
+    aggregationQuery,
+  );
+```
+
+在方法列表加入精确返回类型，并说明两者都请求 `snapshot/aggregation`，流式方法使用 SSE。
+
+- [ ] **Step 2: 更新中文 README**
+
+逐项翻译 Task 1 Step 1 的说明，保留完全相同的 TypeScript 示例、alias 和签名，不额外扩展中文专属行为。
+
+- [ ] **Step 3: 格式检查 README**
+
+Run:
+
+```bash
+pnpm exec prettier --check packages/wow/README.md packages/wow/README.zh-CN.md
+```
+
+Expected: `All matched files use Prettier code style!`
+
+### Task 2: 同步 Skill API reference
+
+**Files:**
+- Modify: `skills/fetcher-wow-cqrs/references/api.md`
+
+**Interfaces:**
+- Consumes: `packages/wow/src/query/aggregation.ts`, `snapshot/snapshotQueryApi.ts`, `snapshot/snapshotQueryClient.ts`.
+- Produces: 面向代理的完整聚合类型、枚举、调用方式与兼容边界。
+
+- [ ] **Step 1: 更新目录与导入**
+
+在目录的 `SnapshotQueryClient` 子项下加入 `Aggregation Methods`，并新增 `AggregationQuery` 顶级章节。统一 import 示例加入五个聚合枚举以及 `AggregationQuery`、`AggregationElement`、`AggregationGroup`、`AggregationMetric`、`DynamicDocument` 类型。
+
+- [ ] **Step 2: 记录客户端方法**
+
+在 `SnapshotQueryClient` 查询示例中复用 Task 1 的 `ProductSummary` 与 `aggregationQuery`，记录：
+
+```ts
+aggregate<Row extends DynamicDocument = DynamicDocument>(
+  query: AggregationQuery<FIELDS>,
+  attributes?: Record<string, any>,
+  abortController?: AbortController,
+): Promise<Row[]>;
+
+aggregateStream<Row extends DynamicDocument = DynamicDocument>(
+  query: AggregationQuery<FIELDS>,
+  attributes?: Record<string, any>,
+  abortController?: AbortController,
+): Promise<ReadableStream<JsonServerSentEvent<Row>>>;
+```
+
+紧接签名说明 `SnapshotQueryApi` 上两成员可选以兼容既有实现，具体客户端方法必需。
+
+- [ ] **Step 3: 添加完整 AggregationQuery 参考**
+
+列出以下精确契约：
+
+- `filter?`, `elements?`, `groupBy?`, 非空 `metrics`, `sort?`, `limit?`
+- Group：`TERMS`, `HISTOGRAM(interval)`, `DATE_HISTOGRAM(unit, timeZone?)`
+- Metric：`COUNT`；`NUMERIC(function, expression)`
+- Function：`SUM`, `AVG`, `MIN`, `MAX`
+- Date unit：`YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`
+- Expression：可省略 `type` 的 `FIELD`
+
+说明 `elements[].filter` 使用 `ElementFilterExpression`，结果泛型不做运行时解码。
+
+- [ ] **Step 4: 格式检查 Skill reference**
+
+Run:
+
+```bash
+pnpm exec prettier --check skills/fetcher-wow-cqrs/references/api.md
+```
+
+Expected: `All matched files use Prettier code style!`
+
+### Task 3: 同步 Wiki 中英文页面
+
+**Files:**
+- Modify: `wiki/packages/wow.md`
+- Modify: `wiki/zh/packages/wow.md`
+
+**Interfaces:**
+- Consumes: Task 1 的常用示例、Task 2 的准确 API 事实。
+- Produces: 面向站点读者的当前查询主路径。
+
+- [ ] **Step 1: 更新英文快照查询章节**
+
+将 `all()` / `condition` 主示例替换为 `filter.matchAll()` / `filter` request；在方法表中加入：
+
+```md
+| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | Aggregate snapshots |
+| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | Aggregate snapshots as SSE |
+```
+
+在表后加入 Task 1 的精简聚合示例。
+
+- [ ] **Step 2: 更新英文 Query DSL 与导出表**
+
+把 `FilterExpression` 作为主章节，列出 `filter` 的 logical、metadata、comparison、string、collection、presence、scope/search 与 relative-time 分类。将旧 Condition 表缩为一段兼容说明；主要导出表加入 `filter`、`AggregationQuery`、聚合枚举和两个客户端方法的说明。
+
+- [ ] **Step 3: 更新中文 Wiki**
+
+逐项同步 Steps 1–2，保持代码、表格行、端点和返回类型与英文一致，只翻译说明文字。
+
+- [ ] **Step 4: 构建 Wiki**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Workdir: `wiki`
+
+Expected: VitePress build exits `0`; generated `llms*.txt` and `.vitepress/dist` changes must not be committed.
+
+### Task 4: 全量复核并提交
+
+**Files:**
+- Review: all files listed in File Structure plus this plan.
+
+**Interfaces:**
+- Consumes: Tasks 1–3 outputs.
+- Produces: 可提交、可构建、与运行时契约一致的完整文档变更。
+
+- [ ] **Step 1: 检查符号、禁用名和范围**
+
+Run:
+
+```bash
+rg -n "AggregationQuery|aggregateStream|snapshot/aggregation|FilterExpression" packages/wow/README.md packages/wow/README.zh-CN.md skills/fetcher-wow-cqrs/references/api.md wiki/packages/wow.md wiki/zh/packages/wow.md
+rg -n "SnapshotAggregationQueryApi" packages/wow/README.md packages/wow/README.zh-CN.md skills/fetcher-wow-cqrs/references/api.md wiki/packages/wow.md wiki/zh/packages/wow.md
+git status --short
+```
+
+Expected: 五个文档均命中当前 API；禁用名无命中；状态中没有构建产物或其他 package 变更。
+
+- [ ] **Step 2: 运行最终验证**
+
+Run:
+
+```bash
+pnpm test:unit
+git diff --check
+```
+
+Expected: 所有 package 单元测试通过，diff 无空白错误。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add packages/wow/README.md packages/wow/README.zh-CN.md \
+  packages/wow/docs/superpowers/plans/2026-08-25-wow-query-documentation.md \
+  skills/fetcher-wow-cqrs/references/api.md \
+  wiki/packages/wow.md wiki/zh/packages/wow.md
+git commit -m "docs(wow): document snapshot aggregation queries"
+```

--- a/packages/wow/docs/superpowers/plans/2026-08-25-wow-query-documentation.md
+++ b/packages/wow/docs/superpowers/plans/2026-08-25-wow-query-documentation.md
@@ -32,10 +32,12 @@
 ### Task 1: 同步包 README
 
 **Files:**
+
 - Modify: `packages/wow/README.md`
 - Modify: `packages/wow/README.zh-CN.md`
 
 **Interfaces:**
+
 - Consumes: `AggregationQuery<FIELDS>`, `AggregationGroupType`, `AggregationMetricType`, `AggregationFunction`, `SortDirection`, `SnapshotQueryClient.aggregate<Row>()`, `SnapshotQueryClient.aggregateStream<Row>()`.
 - Produces: 面向 npm 用户的中英文聚合查询入口。
 
@@ -46,29 +48,30 @@
 ```ts
 type ProductSummary = {
   product: string;
-  orderCount: number;
-  total: number;
+  itemCount: number;
+  totalQuantity: number;
 };
 
 const aggregationQuery: AggregationQuery = {
   filter: filter.eq('state.status', 'COMPLETED'),
+  elements: [{ path: 'state.items' }],
   groupBy: [
     {
       type: AggregationGroupType.TERMS,
-      field: 'state.items.productId',
+      field: 'productId',
       alias: 'product',
     },
   ],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
     {
       type: AggregationMetricType.NUMERIC,
       function: AggregationFunction.SUM,
-      expression: { field: 'state.total' },
-      alias: 'total',
+      expression: { field: 'quantity' },
+      alias: 'totalQuantity',
     },
   ],
-  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
   limit: 10,
 };
 
@@ -99,9 +102,11 @@ Expected: `All matched files use Prettier code style!`
 ### Task 2: 同步 Skill API reference
 
 **Files:**
+
 - Modify: `skills/fetcher-wow-cqrs/references/api.md`
 
 **Interfaces:**
+
 - Consumes: `packages/wow/src/query/aggregation.ts`, `snapshot/snapshotQueryApi.ts`, `snapshot/snapshotQueryClient.ts`.
 - Produces: 面向代理的完整聚合类型、枚举、调用方式与兼容边界。
 
@@ -155,10 +160,12 @@ Expected: `All matched files use Prettier code style!`
 ### Task 3: 同步 Wiki 中英文页面
 
 **Files:**
+
 - Modify: `wiki/packages/wow.md`
 - Modify: `wiki/zh/packages/wow.md`
 
 **Interfaces:**
+
 - Consumes: Task 1 的常用示例、Task 2 的准确 API 事实。
 - Produces: 面向站点读者的当前查询主路径。
 
@@ -196,9 +203,11 @@ Expected: VitePress build exits `0`; generated `llms*.txt` and `.vitepress/dist`
 ### Task 4: 全量复核并提交
 
 **Files:**
+
 - Review: all files listed in File Structure plus this plan.
 
 **Interfaces:**
+
 - Consumes: Tasks 1–3 outputs.
 - Produces: 可提交、可构建、与运行时契约一致的完整文档变更。
 

--- a/packages/wow/docs/superpowers/specs/2026-08-25-wow-query-documentation-design.md
+++ b/packages/wow/docs/superpowers/specs/2026-08-25-wow-query-documentation-design.md
@@ -64,11 +64,13 @@
 统一示例使用：
 
 - 根过滤：`filter.eq('state.status', 'COMPLETED')`
-- 分组：`AggregationGroupType.TERMS`
+- Element 展开：`state.items`
+- 分组：相对 Element 的 `productId`，使用 `AggregationGroupType.TERMS`
 - 指标：`AggregationMetricType.COUNT` 与
-  `AggregationMetricType.NUMERIC` + `AggregationFunction.SUM`
+  `AggregationMetricType.NUMERIC` + `AggregationFunction.SUM`，后者汇总相对字段
+  `quantity`
 - 排序：`SortDirection.DESC`
-- 结果行：`{ product: string; orderCount: number; total: number }`
+- 结果行：`{ product: string; itemCount: number; totalQuantity: number }`
 
 README 与 Wiki 只展示常用结构，完整枚举清单只在 Skill API reference 展开，避免
 三处维护同一张大表。

--- a/packages/wow/docs/superpowers/specs/2026-08-25-wow-query-documentation-design.md
+++ b/packages/wow/docs/superpowers/specs/2026-08-25-wow-query-documentation-design.md
@@ -1,0 +1,106 @@
+# Fetcher Wow 查询文档同步设计
+
+## 状态
+
+已确认，待实施。
+
+## 背景
+
+`@ahoo-wang/fetcher-wow` 已完成两轮查询契约更新：查询条件以 Wow 8.11 的
+`FilterExpression` 为主，并新增快照聚合查询类型及
+`SnapshotQueryClient.aggregate()` / `aggregateStream()`。当前包 README 已介绍
+`FilterExpression`，但尚未记录聚合 API；Skill API reference 同样缺少聚合；Wiki
+仍以旧 `Condition` 示例为主。
+
+## 目标
+
+- 让包 README、Skill API reference 与 Wiki 同时覆盖最新快照聚合 API。
+- 将 Wiki 的主要查询示例切换为 `FilterExpression`，旧 `Condition` 仅作为兼容 API
+  说明。
+- 中英文文档保持相同结构、示例和 API 事实。
+- 所有签名、枚举值、端点和兼容性说明以 `packages/wow/src` 的当前导出为准。
+
+## 非目标
+
+- 不修改生成器文档、Wiki 导航、站点配置或构建产物。
+- 不重写整个 Wow 文档，也不新增教程页面。
+- 不修改任何运行时代码、类型、测试或依赖。
+- 不引入聚合 DSL 或未实现的便捷构建器。
+
+## 内容设计
+
+### 包 README（英文与中文）
+
+- 在特性列表中加入快照聚合查询。
+- 在 `SnapshotQueryClient` 示例中加入一份可直接复制的聚合查询：按商品
+  `TERMS` 分组，计算 `COUNT` 与 `SUM`，按合计值倒序并限制结果数。
+- 展示通过结果行泛型声明 alias 对应字段，以及 `aggregateStream()` 的 SSE
+  遍历方式。
+- 在方法列表中补充两个聚合方法及其返回类型。
+
+### Skill API reference
+
+- 在目录和统一导入示例中加入聚合公共枚举、类型与 `DynamicDocument`。
+- 在 `SnapshotQueryClient` 章节加入 JSON 与 SSE 调用示例。
+- 新增 `AggregationQuery` 参考小节，完整列出 query 字段、Group、Metric、日期单位、
+  数值函数与表达式类型。
+- 说明 `metrics` 在类型层非空、结果行默认是 `DynamicDocument`，泛型仅提供静态
+  类型，不做运行时解码。
+- 说明 `SnapshotQueryApi` 中聚合成员为可选以兼容既有 mock/adapter，而具体
+  `SnapshotQueryClient` 方法始终可调用；不引入 `SnapshotAggregationQueryApi`。
+
+### Wiki（英文与中文）
+
+- 将快照查询主示例改为 `filter.matchAll()` 与 filter-based request。
+- 在方法表中加入 `aggregate()` / `aggregateStream()` 和
+  `/snapshot/aggregation`。
+- 新增精简的聚合查询示例，复用 README 中相同的请求形状。
+- 将“查询 DSL”主章节改为 `FilterExpression`，列出当前 builder 分类；旧
+  `Condition` 运算符表缩为兼容说明，避免继续把弃用 API 作为首选入口。
+- 更新主要导出列表中的聚合类型与 `filter`。
+
+## 示例契约
+
+统一示例使用：
+
+- 根过滤：`filter.eq('state.status', 'COMPLETED')`
+- 分组：`AggregationGroupType.TERMS`
+- 指标：`AggregationMetricType.COUNT` 与
+  `AggregationMetricType.NUMERIC` + `AggregationFunction.SUM`
+- 排序：`SortDirection.DESC`
+- 结果行：`{ product: string; orderCount: number; total: number }`
+
+README 与 Wiki 只展示常用结构，完整枚举清单只在 Skill API reference 展开，避免
+三处维护同一张大表。
+
+## 兼容性边界
+
+- 推荐新代码使用 `FilterExpression` 与 `filter.*`。
+- 旧 `Condition` 仍可用于兼容旧 Wow 服务，不宣称已移除。
+- `SnapshotQueryApi.aggregate?` 与 `aggregateStream?` 是可选成员；
+  `SnapshotQueryClient.aggregate()` 与 `aggregateStream()` 是必需具体方法。
+- JSON 与 SSE 共用 `POST snapshot/aggregation`，SSE 由
+  `Accept: text/event-stream` 区分。
+
+## 修改范围
+
+- `packages/wow/README.md`
+- `packages/wow/README.zh-CN.md`
+- `skills/fetcher-wow-cqrs/references/api.md`
+- `wiki/packages/wow.md`
+- `wiki/zh/packages/wow.md`
+
+## 验证
+
+- 对照 `packages/wow/src/query/aggregation.ts`、`snapshotQueryApi.ts`、
+  `snapshotQueryClient.ts` 和公共导出复核所有符号与签名。
+- 运行 Prettier 检查、Wiki 构建、根 `pnpm test:unit` 与 `git diff --check`。
+- 确认未修改 `llms-full.txt`、`llms.txt`、`.vitepress/dist` 或生成器文档。
+
+## 完成标准
+
+- 五个目标文档准确覆盖 `FilterExpression` 与快照聚合查询。
+- 中英文示例语义一致，TypeScript 示例仅使用已导出的公共 API。
+- 不出现 `SnapshotAggregationQueryApi`，也不暗示聚合方法在
+  `SnapshotQueryApi` 上必需。
+- 文档构建、格式和现有单元测试全部通过。

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -16,6 +16,7 @@
 - [SnapshotQueryClient<S, FIELDS>](#snapshotqueryclients-fields)
   - [Setup](#setup-1)
   - [Query Methods](#query-methods)
+  - [Aggregation Methods](#aggregation-methods)
   - [ID-Based Lookup Methods](#id-based-lookup-methods)
 - [EventStreamQueryClient<DomainEventBody, FIELDS>](#eventstreamqueryclientdomaineventbody-fields)
   - [Setup](#setup-2)
@@ -28,6 +29,7 @@
   - [Factory Methods](#factory-methods)
 - [Filter Expressions](#filter-expressions)
   - [Filter Cursor Queries](#filter-cursor-queries)
+- [AggregationQuery](#aggregationquery)
 - [Query DSL Conditions](#query-dsl-conditions)
   - [Comparison Operators](#comparison-operators)
   - [String Operators](#string-operators)
@@ -75,6 +77,11 @@ import {
   LoadOwnerStateAggregateClient,
   ResourceAttributionPathSpec,
   SortDirection,
+  AggregationGroupType,
+  AggregationMetricType,
+  AggregationExpressionType,
+  AggregationDateUnit,
+  AggregationFunction,
   DeletionState,
   FilterOperator,
   StringComparison,
@@ -151,6 +158,11 @@ import {
   type ListQueryRequest,
   type PagedQueryRequest,
   type SingleQueryRequest,
+  type AggregationQuery,
+  type AggregationElement,
+  type AggregationGroup,
+  type AggregationMetric,
+  type DynamicDocument,
 } from '@ahoo-wang/fetcher-wow';
 ```
 
@@ -359,6 +371,62 @@ const state = await snapshotClient.singleState({
 });
 ```
 
+### Aggregation Methods
+
+```typescript
+type ProductSummary = {
+  product: string;
+  orderCount: number;
+  total: number;
+};
+
+const aggregationQuery: AggregationQuery = {
+  filter: filter.eq('state.status', 'COMPLETED'),
+  groupBy: [
+    {
+      type: AggregationGroupType.TERMS,
+      field: 'state.items.productId',
+      alias: 'product',
+    },
+  ],
+  metrics: [
+    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    {
+      type: AggregationMetricType.NUMERIC,
+      function: AggregationFunction.SUM,
+      expression: { field: 'state.items.price' },
+      alias: 'total',
+    },
+  ],
+  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  limit: 10,
+};
+
+const summaries =
+  await snapshotClient.aggregate<ProductSummary>(aggregationQuery);
+const summaryStream =
+  await snapshotClient.aggregateStream<ProductSummary>(aggregationQuery);
+```
+
+```typescript
+aggregate<Row extends DynamicDocument = DynamicDocument>(
+  query: AggregationQuery<FIELDS>,
+  attributes?: Record<string, any>,
+  abortController?: AbortController,
+): Promise<Row[]>;
+
+aggregateStream<Row extends DynamicDocument = DynamicDocument>(
+  query: AggregationQuery<FIELDS>,
+  attributes?: Record<string, any>,
+  abortController?: AbortController,
+): Promise<ReadableStream<JsonServerSentEvent<Row>>>;
+```
+
+`SnapshotQueryApi` makes these two members optional to remain compatible with
+existing implementations. `SnapshotQueryClient` implements both methods as
+required methods. Both submit to `snapshot/aggregation`; `aggregateStream`
+requests an SSE result stream.
+
 ### ID-Based Lookup Methods
 
 ```typescript
@@ -559,6 +627,45 @@ const predicate: FilterExpression<'id'> = cursorFilter({
   direction: SortDirection.ASC,
 });
 ```
+
+## AggregationQuery
+
+`AggregationQuery<FIELDS>` accepts these fields:
+
+- `filter?: FilterExpression<FIELDS>`
+- `elements?: AggregationElement[]`
+- `groupBy?: AggregationGroup[]`
+- `metrics: [AggregationMetric, ...AggregationMetric[]]` (non-empty)
+- `sort?: FieldSort[]`
+- `limit?: number`
+
+Each `AggregationElement` has a `path` and optional `filter`.
+`elements[].filter` is an `ElementFilterExpression`.
+
+`AggregationGroup` is one of:
+
+- `TERMS`: `field`, `alias`
+- `HISTOGRAM`: `field`, `alias`, `interval`
+- `DATE_HISTOGRAM`: `field`, `alias`, `unit`, optional `timeZone`
+
+`AggregationMetric` is one of:
+
+- `COUNT`: `alias`
+- `NUMERIC`: `function`, `expression`, `alias`
+
+`AggregationFunction` values are `SUM`, `AVG`, `MIN`, and `MAX`.
+`AggregationDateUnit` values are `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`,
+`HOUR`, `MINUTE`, and `SECOND`. The only aggregation expression is `FIELD`:
+
+```typescript
+const expression = {
+  // type: AggregationExpressionType.FIELD, // optional
+  field: 'state.items.price',
+};
+```
+
+The `Row` generic describes aggregation result rows only; Fetcher does not
+perform runtime decoding.
 
 ## Query DSL Conditions (Deprecated)
 

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -63,6 +63,7 @@ The Wow framework implements CQRS + Event Sourcing + DDD:
 
 ```typescript
 import '@ahoo-wang/fetcher-eventstream'; // Optional: SSE support loads transitively with fetcher-wow
+import type { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
 import { ContentTypeValues, HttpMethod } from '@ahoo-wang/fetcher';
 import {
   // Command
@@ -394,7 +395,7 @@ const aggregationQuery: AggregationQuery = {
     {
       type: AggregationMetricType.NUMERIC,
       function: AggregationFunction.SUM,
-      expression: { field: 'state.items.price' },
+      expression: { field: 'state.total' },
       alias: 'total',
     },
   ],

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -377,29 +377,30 @@ const state = await snapshotClient.singleState({
 ```typescript
 type ProductSummary = {
   product: string;
-  orderCount: number;
-  total: number;
+  itemCount: number;
+  totalQuantity: number;
 };
 
 const aggregationQuery: AggregationQuery = {
   filter: filter.eq('state.status', 'COMPLETED'),
+  elements: [{ path: 'state.items' }],
   groupBy: [
     {
       type: AggregationGroupType.TERMS,
-      field: 'state.items.productId',
+      field: 'productId',
       alias: 'product',
     },
   ],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
     {
       type: AggregationMetricType.NUMERIC,
       function: AggregationFunction.SUM,
-      expression: { field: 'state.total' },
-      alias: 'total',
+      expression: { field: 'quantity' },
+      alias: 'totalQuantity',
     },
   ],
-  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
   limit: 10,
 };
 
@@ -642,6 +643,9 @@ const predicate: FilterExpression<'id'> = cursorFilter({
 
 Each `AggregationElement` has a `path` and optional `filter`.
 `elements[].filter` is an `ElementFilterExpression`.
+Elements form an ordered expansion chain. The first path is root-relative;
+later element paths, group fields, and metric expression fields are relative
+to the current innermost element.
 
 `AggregationGroup` is one of:
 
@@ -661,7 +665,7 @@ Each `AggregationElement` has a `path` and optional `filter`.
 ```typescript
 const expression = {
   // type: AggregationExpressionType.FIELD, // optional
-  field: 'state.items.price',
+  field: 'quantity', // relative to state.items in the example above
 };
 ```
 

--- a/wiki/packages/wow.md
+++ b/wiki/packages/wow.md
@@ -5,7 +5,7 @@ description: "Wow framework integration for Fetcher providing DDD + Event Sourci
 
 # @ahoo-wang/fetcher-wow
 
-The `@ahoo-wang/fetcher-wow` package provides the client-side integration layer for the [Wow](https://github.com/Ahoo-Wang/wow) DDD + Event Sourcing + CQRS framework. It delivers typed command clients for sending domain commands, snapshot query clients for reading aggregate state, event stream query clients for replaying domain events, and a rich query DSL with conditions, sorting, and pagination.
+The `@ahoo-wang/fetcher-wow` package provides the client-side integration layer for the [Wow](https://github.com/Ahoo-Wang/wow) DDD + Event Sourcing + CQRS framework. It delivers typed command clients for sending domain commands, snapshot query clients for reading aggregate state, event stream query clients for replaying domain events, and a rich `FilterExpression` query DSL with sorting and pagination.
 
 ## Installation
 
@@ -29,10 +29,10 @@ graph TB
     end
 
     subgraph sg_3 ["Query DSL"]
-        COND["Condition<br>where / and / or"]
+        COND["FilterExpression<br>filter.and / filter.or"]
         SORT["FieldSort<br>sort by field"]
         PAGE["PagedQuery / ListQuery<br>pagination"]
-        OP["Operator<br>EQ, NE, IN, BETWEEN..."]
+        OP["FilterOperator<br>EQ, NE, IN, BETWEEN..."]
     end
 
     subgraph sg_4 ["Factories"]
@@ -203,24 +203,24 @@ autonumber
 The primary client for reading aggregate state. Supports counting, listing, paging, and streaming snapshot queries.
 
 ```typescript
-import { SnapshotQueryClient, all, listQuery, pagedQuery, singleQuery } from '@ahoo-wang/fetcher-wow';
+import { SnapshotQueryClient, filter } from '@ahoo-wang/fetcher-wow';
 
 const client = new SnapshotQueryClient<CartState>(apiMetadata);
 
 // Count
-const count = await client.count(all());
+const count = await client.count(filter.matchAll());
 
 // List
-const items = await client.list(listQuery({
-  condition: all(),
+const items = await client.list({
+  filter: filter.matchAll(),
   limit: 100,
-}));
+});
 
 // Paged
-const page = await client.paged(pagedQuery({
-  condition: all(),
+const page = await client.paged({
+  filter: filter.matchAll(),
   pagination: { index: 1, size: 10 },
-}));
+});
 
 // Single by ID
 const cart = await client.getStateById('cart-123');
@@ -233,7 +233,7 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 | Method | Endpoint | Returns | Description |
 |--------|----------|---------|-------------|
-| `count(condition)` | `/snapshot/count` | `Promise<number>` | Count matching aggregates |
+| `count(filter)` | `/snapshot/count` | `Promise<number>` | Count matching aggregates |
 | `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | List snapshots |
 | `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream |
 | `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | List state only |
@@ -246,8 +246,35 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 | `getStateById(id)` | -- | `Promise<S>` | Get state by ID |
 | `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | Get multiple by IDs |
 | `getStateByIds(ids)` | -- | `Promise<S[]>` | Get multiple states |
+| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | Aggregate snapshots |
+| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | Aggregate snapshots as SSE |
 
 Source: [packages/wow/src/query/snapshot/snapshotQueryClient.ts:119-516](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/snapshot/snapshotQueryClient.ts#L119-L516)
+
+#### Snapshot Aggregation
+
+```typescript
+import {
+  AggregationFunction, AggregationGroupType, AggregationMetricType,
+  type AggregationQuery, SortDirection, filter,
+} from '@ahoo-wang/fetcher-wow';
+
+type ProductSummary = { product: string; orderCount: number; total: number };
+
+const query: AggregationQuery = {
+  filter: filter.eq('state.status', 'COMPLETED'),
+  groupBy: [{ type: AggregationGroupType.TERMS, field: 'state.items.productId', alias: 'product' }],
+  metrics: [
+    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    { type: AggregationMetricType.NUMERIC, function: AggregationFunction.SUM, expression: { field: 'state.total' }, alias: 'total' },
+  ],
+  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  limit: 10,
+};
+
+const summaries = await client.aggregate<ProductSummary>(query);
+const summaryStream = await client.aggregateStream<ProductSummary>(query);
+```
 
 ### QueryClientFactory
 
@@ -271,7 +298,7 @@ const eventClient = factory.createEventStreamQueryClient();
 
 | Factory Method | Creates | Description |
 |----------------|---------|-------------|
-| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | Snapshot queries with conditions |
+| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | Snapshot queries with filters |
 | `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | Load by ID, version, or time |
 | `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state |
 | `createEventStreamQueryClient()` | `EventStreamQueryClient` | Domain event stream queries |
@@ -280,69 +307,60 @@ Source: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-
 
 ## Query DSL
 
-### Conditions
+### FilterExpression
 
-The condition system supports building complex query predicates:
+Use the `filter` builder for new queries. It creates typed
+`FilterExpression` values that are placed in a request's `filter` property.
 
 ```typescript
-import { all, and, isIn, between, aggregateId, aggregateIds } from '@ahoo-wang/fetcher-wow';
+import { filter, StringComparison } from '@ahoo-wang/fetcher-wow';
 
-// All records
-const allCondition = all();
-
-// By aggregate ID
-const byId = aggregateId('cart-123');
-
-// By multiple IDs
-const byIds = aggregateIds(['cart-1', 'cart-2', 'cart-3']);
-
-// Complex conditions composed with logical helpers.
-// Set helpers take rest args: isIn(field, ...values).
-// between takes (field, start, end).
-const complex = and(
-  isIn('status', 'ACTIVE', 'PENDING'),
-  between('createdAt', '2024-01-01', '2024-12-31'),
+const activeCarts = filter.and(
+  filter.isIn('state.status', 'ACTIVE', 'PENDING'),
+  filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
+  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
 );
+
+const request = { filter: activeCarts, limit: 100 };
 ```
 
-### Operators
+| Category | `filter` builders | Notes |
+|----------|-------------------|-------|
+| Logical | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)` | Logical builders require one or more operands. |
+| Metadata | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | Scope a root snapshot by Wow metadata. |
+| Comparison | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | Values are JSON scalar values; equality also accepts `null` and arrays. |
+| String | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`. |
+| Collection | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | Collection builders require at least one value. |
+| Presence | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`, `deletion(state)` | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`. |
+| Scope / search | `elementMatch(field, predicate)`, `search(query, ...fields)` | Element predicates cannot contain root metadata, deletion, or search filters. |
+| Relative time | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId` and `datePattern`; `days` must be a positive JVM `Int`. |
 
-| Operator | Description | Helper / Example |
-|----------|-------------|---------|
-| `EQ` | Equals | `eq('name', 'Alice')` |
-| `NE` | Not equals | `ne('status', 'DELETED')` |
-| `GT` / `GTE` | Greater than / or equal | `gt('price', 100)`, `gte('price', 100)` |
-| `LT` / `LTE` | Less than / or equal | `lt('price', 50)`, `lte('price', 50)` |
-| `IN` | In set | `isIn('type', 'A', 'B')` (rest args) |
-| `NOT_IN` | Not in set | `notIn('type', 'C')` (rest args) |
-| `ALL_IN` | Match all of set | `allIn('tags', 'a', 'b')` (rest args) |
-| `BETWEEN` | Range | `between('age', 18, 65)` (`(field, start, end)`) |
-| `CONTAINS` | Contains substring | `contains('name', 'john')` |
-| `STARTS_WITH` | Prefix match | `startsWith('name', 'john')` |
-| `ENDS_WITH` | Suffix match | `endsWith('name', 'son')` |
-| `MATCH` | Full-text match (backend-specific, e.g. MongoDB text / ES match) | `match('name', 'keyword')` |
-| `AND` / `OR` / `NOR` | Logical composition | `and(c1, c2)`, `or(c1, c2)` |
-| `ALL` | Match all records | `all()` (no field/value) |
+Source: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
-Source: [packages/wow/src/query/operator.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/operator.ts)
+### Legacy Conditions
+
+`Condition`, its helpers such as `all()` and `and(...)`, and `Operator` remain
+exported for compatibility but are deprecated. Existing client methods accept
+legacy conditions where their type permits; use `FilterExpression` and
+`filter.*` for new code. `raw()` has no `FilterExpression` replacement.
 
 ### Sorting and Pagination
 
 ```typescript
-import { pagedQuery, listQuery, SortDirection } from '@ahoo-wang/fetcher-wow';
+import { filter, SortDirection } from '@ahoo-wang/fetcher-wow';
 
 // Paged query with sorting (pagination.index starts at 1)
-const query = pagedQuery({
-  condition: all(),
+const query = {
+  filter: filter.matchAll(),
   pagination: { index: 1, size: 20 },
   sort: [{ field: 'createdAt', direction: SortDirection.DESC }],
-});
+};
 
 // List query (limit only, no pagination)
-const list = listQuery({
-  condition: all(),
+const list = {
+  filter: filter.matchAll(),
   limit: 100,
-});
+};
 ```
 
 ### Cursor Pagination
@@ -350,11 +368,11 @@ const list = listQuery({
 For large datasets, cursor-based pagination is more efficient than offset-based pagination. It avoids the performance degradation of deep offset queries by using a cursor ID to track position:
 
 ```typescript
-import { cursorQuery, CURSOR_ID_START, SortDirection } from '@ahoo-wang/fetcher-wow';
+import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
 
 // First page — start from the beginning
 const firstPage = cursorQuery({
-  query: { condition: all(), limit: 50, projection: { include: ['id', 'name'] } },
+  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
   cursorId: CURSOR_ID_START,  // '~' — start from the beginning
   field: 'id',
   direction: SortDirection.ASC,
@@ -362,7 +380,7 @@ const firstPage = cursorQuery({
 
 // Subsequent pages — use the last item's cursor ID from the previous result
 const nextPage = cursorQuery({
-  query: { condition: all(), limit: 50 },
+  query: { filter: filter.matchAll(), limit: 50 },
   cursorId: lastItemId,  // cursor ID from the previous page
   field: 'id',
   direction: SortDirection.ASC,
@@ -374,21 +392,21 @@ const nextPage = cursorQuery({
 Control which fields are returned by the query using `projection` — include only the fields you need to reduce payload size:
 
 ```typescript
-import { projection, pagedQuery } from '@ahoo-wang/fetcher-wow';
+import { filter, projection } from '@ahoo-wang/fetcher-wow';
 
 // Include only specific fields
-const query = pagedQuery({
-  condition: all(),
+const query = {
+  filter: filter.matchAll(),
   pagination: { index: 1, size: 20 },
   projection: projection({ include: ['id', 'name', 'status'] }),
-});
+};
 
 // Exclude fields
-const query2 = pagedQuery({
-  condition: all(),
+const query2 = {
+  filter: filter.matchAll(),
   pagination: { index: 1, size: 20 },
   projection: projection({ exclude: ['internalNotes', 'metadata'] }),
-});
+};
 ```
 
 Source: [packages/wow/src/query/cursorQuery.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/cursorQuery.ts), [packages/wow/src/query/projection.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/projection.ts)
@@ -443,14 +461,13 @@ Source: [packages/wow/src/index.ts](https://github.com/Ahoo-Wang/fetcher/blob/ma
 | `EventStreamQueryClient` | `query/event/` | Domain event stream queries |
 | `LoadStateAggregateClient` | `query/state/` | Load aggregate state by ID/version/time |
 | `LoadOwnerStateAggregateClient` | `query/state/` | Load owner's aggregate state |
-| `Condition` | `query/` | Query condition interface |
-| `all()` | `query/` | Match all records condition |
-| `and(...)` / `or(...)` / `nor(...)` | `query/` | Logical condition composition |
-| `eq/ne/gt/lt/gte/lte(...)` | `query/` | Comparison condition helpers |
-| `isIn/notIn/allIn(...)` | `query/` | Set membership helpers |
-| `between/contains/startsWith/endsWith/match(...)` | `query/` | Range & pattern helpers |
-| `aggregateId(id)` | `query/` | Condition matching a single aggregate ID |
-| `aggregateIds(ids)` | `query/` | Condition matching multiple aggregate IDs |
+| `FilterExpression` | `query/` | Typed query-filter union |
+| `filter` | `query/` | `FilterExpression` builders for new queries |
+| `AggregationQuery` | `query/` | Typed snapshot aggregation request |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationDateUnit`, `AggregationFunction` | `query/` | Aggregation schema enums |
+| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | Run an aggregation and return result rows |
+| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
+| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | Deprecated compatibility API |
 | `listQuery()` | `query/` | Create a list query |
 | `pagedQuery()` | `query/` | Create a paged query |
 | `singleQuery()` | `query/` | Create a single query |
@@ -472,9 +489,9 @@ const result = await commandClient.addCartItem({
 // Generated query client factory
 const factory = cartQueryClientFactory;
 const snapshotClient = factory.createSnapshotQueryClient();
-const cartState = await snapshotClient.singleState(singleQuery({
-  condition: aggregateId('cart-1'),
-}));
+const cartState = await snapshotClient.singleState({
+  filter: filter.aggregateId('cart-1'),
+});
 ```
 
 ## Cross-References

--- a/wiki/packages/wow.md
+++ b/wiki/packages/wow.md
@@ -263,16 +263,17 @@ import {
   type AggregationQuery, SortDirection, filter,
 } from '@ahoo-wang/fetcher-wow';
 
-type ProductSummary = { product: string; orderCount: number; total: number };
+type ProductSummary = { product: string; itemCount: number; totalQuantity: number };
 
 const query: AggregationQuery = {
   filter: filter.eq('state.status', 'COMPLETED'),
-  groupBy: [{ type: AggregationGroupType.TERMS, field: 'state.items.productId', alias: 'product' }],
+  elements: [{ path: 'state.items' }],
+  groupBy: [{ type: AggregationGroupType.TERMS, field: 'productId', alias: 'product' }],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
-    { type: AggregationMetricType.NUMERIC, function: AggregationFunction.SUM, expression: { field: 'state.total' }, alias: 'total' },
+    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
+    { type: AggregationMetricType.NUMERIC, function: AggregationFunction.SUM, expression: { field: 'quantity' }, alias: 'totalQuantity' },
   ],
-  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
   limit: 10,
 };
 

--- a/wiki/packages/wow.md
+++ b/wiki/packages/wow.md
@@ -249,6 +249,10 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 | `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | Aggregate snapshots |
 | `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | Aggregate snapshots as SSE |
 
+For compatibility with existing implementations, `SnapshotQueryApi` declares
+`aggregate?` and `aggregateStream?` as optional. `SnapshotQueryClient`
+implements both as required methods.
+
 Source: [packages/wow/src/query/snapshot/snapshotQueryClient.ts:119-516](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/snapshot/snapshotQueryClient.ts#L119-L516)
 
 #### Snapshot Aggregation
@@ -331,8 +335,8 @@ const request = { filter: activeCarts, limit: 100 };
 | Comparison | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | Values are JSON scalar values; equality also accepts `null` and arrays. |
 | String | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`. |
 | Collection | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | Collection builders require at least one value. |
-| Presence | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`, `deletion(state)` | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`. |
-| Scope / search | `elementMatch(field, predicate)`, `search(query, ...fields)` | Element predicates cannot contain root metadata, deletion, or search filters. |
+| Presence | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | Field presence builders. |
+| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, ...fields)` | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; element predicates cannot contain root metadata, deletion, or search filters. |
 | Relative time | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId` and `datePattern`; `days` must be a positive JVM `Int`. |
 
 Source: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
@@ -472,7 +476,6 @@ Source: [packages/wow/src/index.ts](https://github.com/Ahoo-Wang/fetcher/blob/ma
 | `pagedQuery()` | `query/` | Create a paged query |
 | `singleQuery()` | `query/` | Create a single query |
 | `FieldSort` | `query/` | Sort specification |
-| `Operator` | `query/` | Query operator enum |
 | `ResourceAttributionPathSpec` | `types/` | Path spec for tenant/owner scoping |
 
 ## Generated Clients

--- a/wiki/zh/packages/wow.md
+++ b/wiki/zh/packages/wow.md
@@ -249,6 +249,9 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 | `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | 聚合快照 |
 | `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | 以 SSE 聚合快照 |
 
+为兼容既有实现，`SnapshotQueryApi` 将 `aggregate?` 和 `aggregateStream?`
+声明为可选方法；`SnapshotQueryClient` 将两者实现为必需方法。
+
 来源: [packages/wow/src/query/snapshot/snapshotQueryClient.ts:119-516](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/snapshot/snapshotQueryClient.ts#L119-L516)
 
 #### 快照聚合
@@ -330,8 +333,8 @@ const request = { filter: activeCarts, limit: 100 };
 | 比较 | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | 值为 JSON 标量；相等比较也接受 `null` 和数组。 |
 | 字符串 | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。 |
 | 集合 | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | 集合构建器至少需要一个值。 |
-| 存在性 | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`, `deletion(state)` | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`。 |
-| 作用域 / 搜索 | `elementMatch(field, predicate)`, `search(query, ...fields)` | 元素谓词不能包含根元数据、删除或搜索筛选器。 |
+| 存在性 | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | 字段存在性构建器。 |
+| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, ...fields)` | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；元素谓词不能包含根元数据、删除或搜索筛选器。 |
 | 相对时间 | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId` 和 `datePattern`；`days` 必须为正的 JVM `Int`。 |
 
 来源: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
@@ -468,7 +471,6 @@ graph TB
 | `pagedQuery()` | `query/` | 创建分页查询 |
 | `singleQuery()` | `query/` | 创建单条查询 |
 | `FieldSort` | `query/` | 排序规范 |
-| `Operator` | `query/` | 查询运算符枚举 |
 | `ResourceAttributionPathSpec` | `types/` | 租户/所有者范围的路径规范 |
 
 ## 生成的客户端

--- a/wiki/zh/packages/wow.md
+++ b/wiki/zh/packages/wow.md
@@ -262,16 +262,17 @@ import {
   type AggregationQuery, SortDirection, filter,
 } from '@ahoo-wang/fetcher-wow';
 
-type ProductSummary = { product: string; orderCount: number; total: number };
+type ProductSummary = { product: string; itemCount: number; totalQuantity: number };
 
 const query: AggregationQuery = {
   filter: filter.eq('state.status', 'COMPLETED'),
-  groupBy: [{ type: AggregationGroupType.TERMS, field: 'state.items.productId', alias: 'product' }],
+  elements: [{ path: 'state.items' }],
+  groupBy: [{ type: AggregationGroupType.TERMS, field: 'productId', alias: 'product' }],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
-    { type: AggregationMetricType.NUMERIC, function: AggregationFunction.SUM, expression: { field: 'state.total' }, alias: 'total' },
+    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
+    { type: AggregationMetricType.NUMERIC, function: AggregationFunction.SUM, expression: { field: 'quantity' }, alias: 'totalQuantity' },
   ],
-  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
   limit: 10,
 };
 

--- a/wiki/zh/packages/wow.md
+++ b/wiki/zh/packages/wow.md
@@ -5,7 +5,7 @@ description: "Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS �
 
 # @ahoo-wang/fetcher-wow
 
-`@ahoo-wang/fetcher-wow` 包为 [Wow](https://github.com/Ahoo-Wang/wow) DDD + 事件溯源 + CQRS 框架提供客户端集成层。它提供了用于发送领域命令的类型化命令客户端、用于读取聚合状态的快照查询客户端、用于重放领域事件的事件流查询客户端，以及支持条件查询、排序和分页的丰富查询 DSL。
+`@ahoo-wang/fetcher-wow` 包为 [Wow](https://github.com/Ahoo-Wang/wow) DDD + 事件溯源 + CQRS 框架提供客户端集成层。它提供了用于发送领域命令的类型化命令客户端、用于读取聚合状态的快照查询客户端、用于重放领域事件的事件流查询客户端，以及支持排序和分页的丰富 `FilterExpression` 查询 DSL。
 
 ## 安装
 
@@ -29,10 +29,10 @@ graph TB
     end
 
     subgraph sg_3 ["Query DSL"]
-        COND["Condition<br>where / and / or"]
+        COND["FilterExpression<br>filter.and / filter.or"]
         SORT["FieldSort<br>sort by field"]
         PAGE["PagedQuery / ListQuery<br>pagination"]
-        OP["Operator<br>EQ, NE, IN, BETWEEN..."]
+        OP["FilterOperator<br>EQ, NE, IN, BETWEEN..."]
     end
 
     subgraph sg_4 ["Factories"]
@@ -203,24 +203,24 @@ autonumber
 读取聚合状态的主要客户端。支持计数、列表、分页和流式快照查询。
 
 ```typescript
-import { SnapshotQueryClient, all, listQuery, pagedQuery, singleQuery } from '@ahoo-wang/fetcher-wow';
+import { SnapshotQueryClient, filter } from '@ahoo-wang/fetcher-wow';
 
 const client = new SnapshotQueryClient<CartState>(apiMetadata);
 
 // Count
-const count = await client.count(all());
+const count = await client.count(filter.matchAll());
 
 // List
-const items = await client.list(listQuery({
-  condition: all(),
+const items = await client.list({
+  filter: filter.matchAll(),
   limit: 100,
-}));
+});
 
 // Paged
-const page = await client.paged(pagedQuery({
-  condition: all(),
+const page = await client.paged({
+  filter: filter.matchAll(),
   pagination: { index: 1, size: 10 },
-}));
+});
 
 // Single by ID
 const cart = await client.getStateById('cart-123');
@@ -233,7 +233,7 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 | 方法 | 端点 | 返回类型 | 描述 |
 |------|------|----------|------|
-| `count(condition)` | `/snapshot/count` | `Promise<number>` | 统计匹配的聚合数量 |
+| `count(filter)` | `/snapshot/count` | `Promise<number>` | 统计匹配的聚合数量 |
 | `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | 列表查询快照 |
 | `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
 | `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | 仅列出状态 |
@@ -246,8 +246,35 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 | `getStateById(id)` | -- | `Promise<S>` | 通过 ID 获取状态 |
 | `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | 通过多个 ID 获取 |
 | `getStateByIds(ids)` | -- | `Promise<S[]>` | 通过多个 ID 获取状态 |
+| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | 聚合快照 |
+| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | 以 SSE 聚合快照 |
 
 来源: [packages/wow/src/query/snapshot/snapshotQueryClient.ts:119-516](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/snapshot/snapshotQueryClient.ts#L119-L516)
+
+#### 快照聚合
+
+```typescript
+import {
+  AggregationFunction, AggregationGroupType, AggregationMetricType,
+  type AggregationQuery, SortDirection, filter,
+} from '@ahoo-wang/fetcher-wow';
+
+type ProductSummary = { product: string; orderCount: number; total: number };
+
+const query: AggregationQuery = {
+  filter: filter.eq('state.status', 'COMPLETED'),
+  groupBy: [{ type: AggregationGroupType.TERMS, field: 'state.items.productId', alias: 'product' }],
+  metrics: [
+    { type: AggregationMetricType.COUNT, alias: 'orderCount' },
+    { type: AggregationMetricType.NUMERIC, function: AggregationFunction.SUM, expression: { field: 'state.total' }, alias: 'total' },
+  ],
+  sort: [{ field: 'total', direction: SortDirection.DESC }],
+  limit: 10,
+};
+
+const summaries = await client.aggregate<ProductSummary>(query);
+const summaryStream = await client.aggregateStream<ProductSummary>(query);
+```
 
 ### QueryClientFactory
 
@@ -271,7 +298,7 @@ const eventClient = factory.createEventStreamQueryClient();
 
 | 工厂方法 | 创建的客户端 | 描述 |
 |----------|-------------|------|
-| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | 带条件的快照查询 |
+| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | 带筛选器的快照查询 |
 | `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | 通过 ID、版本或时间加载 |
 | `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态 |
 | `createEventStreamQueryClient()` | `EventStreamQueryClient` | 领域事件流查询 |
@@ -280,69 +307,56 @@ const eventClient = factory.createEventStreamQueryClient();
 
 ## 查询 DSL
 
-### 条件查询
+### FilterExpression
 
-条件系统支持构建复杂的查询谓词：
+新查询应使用 `filter` 构建器。它创建类型化的 `FilterExpression` 值，并放入请求的 `filter` 属性。
 
 ```typescript
-import { all, and, isIn, between, aggregateId, aggregateIds } from '@ahoo-wang/fetcher-wow';
+import { filter, StringComparison } from '@ahoo-wang/fetcher-wow';
 
-// All records
-const allCondition = all();
-
-// By aggregate ID
-const byId = aggregateId('cart-123');
-
-// By multiple IDs
-const byIds = aggregateIds(['cart-1', 'cart-2', 'cart-3']);
-
-// 使用逻辑辅助函数组合复杂条件。
-// 集合辅助函数使用剩余参数：isIn(field, ...values)。
-// between 接收 (field, start, end)。
-const complex = and(
-  isIn('status', 'ACTIVE', 'PENDING'),
-  between('createdAt', '2024-01-01', '2024-12-31'),
+const activeCarts = filter.and(
+  filter.isIn('state.status', 'ACTIVE', 'PENDING'),
+  filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
+  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
 );
+
+const request = { filter: activeCarts, limit: 100 };
 ```
 
-### 运算符
+| 分类 | `filter` 构建器 | 说明 |
+|------|-----------------|------|
+| 逻辑 | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)` | 逻辑构建器至少需要一个操作数。 |
+| 元数据 | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | 按 Wow 元数据约束根快照范围。 |
+| 比较 | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | 值为 JSON 标量；相等比较也接受 `null` 和数组。 |
+| 字符串 | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。 |
+| 集合 | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | 集合构建器至少需要一个值。 |
+| 存在性 | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`, `deletion(state)` | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`。 |
+| 作用域 / 搜索 | `elementMatch(field, predicate)`, `search(query, ...fields)` | 元素谓词不能包含根元数据、删除或搜索筛选器。 |
+| 相对时间 | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId` 和 `datePattern`；`days` 必须为正的 JVM `Int`。 |
 
-| 运算符 | 描述 | 辅助函数 / 示例 |
-|--------|------|------|
-| `EQ` | 等于 | `eq('name', 'Alice')` |
-| `NE` | 不等于 | `ne('status', 'DELETED')` |
-| `GT` / `GTE` | 大于 / 大于等于 | `gt('price', 100)`、`gte('price', 100)` |
-| `LT` / `LTE` | 小于 / 小于等于 | `lt('price', 50)`、`lte('price', 50)` |
-| `IN` | 在集合中 | `isIn('type', 'A', 'B')`（剩余参数） |
-| `NOT_IN` | 不在集合中 | `notIn('type', 'C')`（剩余参数） |
-| `ALL_IN` | 匹配集合中全部 | `allIn('tags', 'a', 'b')`（剩余参数） |
-| `BETWEEN` | 范围 | `between('age', 18, 65)`（`(field, start, end)`） |
-| `CONTAINS` | 包含子串 | `contains('name', 'john')` |
-| `STARTS_WITH` | 前缀匹配 | `startsWith('name', 'john')` |
-| `ENDS_WITH` | 后缀匹配 | `endsWith('name', 'son')` |
-| `MATCH` | 全文匹配（后端相关，如 MongoDB text / ES match） | `match('name', 'keyword')` |
-| `AND` / `OR` / `NOR` | 逻辑组合 | `and(c1, c2)`、`or(c1, c2)` |
-| `ALL` | 匹配全部记录 | `all()`（无需字段/值） |
+来源: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
-来源: [packages/wow/src/query/operator.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/operator.ts)
+### 旧版 Condition
+
+`Condition`、`all()` 和 `and(...)` 等辅助函数以及 `Operator` 仍为兼容性而导出，但已弃用。客户端方法在其类型允许处继续接受旧 Condition；新代码应使用 `FilterExpression` 和 `filter.*`。`raw()` 没有 `FilterExpression` 替代方案。
 
 ### 排序和分页
 
 ```typescript
-import { pagedQuery, listQuery, SortDirection } from '@ahoo-wang/fetcher-wow';
+import { filter, SortDirection } from '@ahoo-wang/fetcher-wow';
 
 // 带排序的分页查询（pagination.index 从 1 开始）
-const query = pagedQuery({
-  condition: all(),
+const query = {
+  filter: filter.matchAll(),
   pagination: { index: 1, size: 20 },
   sort: [{ field: 'createdAt', direction: SortDirection.DESC }],
-});
+};
 
 // 列表查询（仅 limit，无分页）
-const list = listQuery({
-  condition: all(),
+const list = {
+  filter: filter.matchAll(),
   limit: 100,
-});
+};
 ```
 
 ### 游标分页
@@ -350,11 +364,11 @@ const list = listQuery({
 对于大型数据集，基于游标的分页比基于偏移量的分页更高效。它通过使用游标 ID 跟踪位置，避免了深偏移查询的性能退化：
 
 ```typescript
-import { cursorQuery, CURSOR_ID_START, SortDirection } from '@ahoo-wang/fetcher-wow';
+import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
 
 // 第一页——从头开始
 const firstPage = cursorQuery({
-  query: { condition: all(), limit: 50, projection: { include: ['id', 'name'] } },
+  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
   cursorId: CURSOR_ID_START,  // '~'——从头开始
   field: 'id',
   direction: SortDirection.ASC,
@@ -362,7 +376,7 @@ const firstPage = cursorQuery({
 
 // 后续页——使用前一个结果的最后一条记录的游标 ID
 const nextPage = cursorQuery({
-  query: { condition: all(), limit: 50 },
+  query: { filter: filter.matchAll(), limit: 50 },
   cursorId: lastItemId,  // 上一页的游标 ID
   field: 'id',
   direction: SortDirection.ASC,
@@ -374,21 +388,21 @@ const nextPage = cursorQuery({
 使用 `projection` 控制查询返回哪些字段——只包含你需要的字段以减少载荷大小：
 
 ```typescript
-import { projection, pagedQuery } from '@ahoo-wang/fetcher-wow';
+import { filter, projection } from '@ahoo-wang/fetcher-wow';
 
 // 仅包含特定字段
-const query = pagedQuery({
-  condition: all(),
+const query = {
+  filter: filter.matchAll(),
   pagination: { index: 1, size: 20 },
   projection: projection({ include: ['id', 'name', 'status'] }),
-});
+};
 
 // 排除字段
-const query2 = pagedQuery({
-  condition: all(),
+const query2 = {
+  filter: filter.matchAll(),
   pagination: { index: 1, size: 20 },
   projection: projection({ exclude: ['internalNotes', 'metadata'] }),
-});
+};
 ```
 
 源码: [packages/wow/src/query/cursorQuery.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/cursorQuery.ts), [packages/wow/src/query/projection.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/projection.ts)
@@ -443,14 +457,13 @@ graph TB
 | `EventStreamQueryClient` | `query/event/` | 领域事件流查询 |
 | `LoadStateAggregateClient` | `query/state/` | 通过 ID/版本/时间加载聚合状态 |
 | `LoadOwnerStateAggregateClient` | `query/state/` | 加载所有者的聚合状态 |
-| `Condition` | `query/` | 查询条件接口 |
-| `all()` | `query/` | 匹配所有记录的条件 |
-| `and(...)` / `or(...)` / `nor(...)` | `query/` | 逻辑条件组合 |
-| `eq/ne/gt/lt/gte/lte(...)` | `query/` | 比较条件辅助函数 |
-| `isIn/notIn/allIn(...)` | `query/` | 集合成员判断辅助函数 |
-| `between/contains/startsWith/endsWith/match(...)` | `query/` | 范围与模式匹配辅助函数 |
-| `aggregateId(id)` | `query/` | 匹配单个聚合 ID 的条件 |
-| `aggregateIds(ids)` | `query/` | 匹配多个聚合 ID 的条件 |
+| `FilterExpression` | `query/` | 类型化查询筛选器联合类型 |
+| `filter` | `query/` | 用于新查询的 `FilterExpression` 构建器 |
+| `AggregationQuery` | `query/` | 类型化快照聚合请求 |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationDateUnit`, `AggregationFunction` | `query/` | 聚合结构枚举 |
+| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | 执行聚合并返回结果行 |
+| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行 |
+| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | 已弃用的兼容 API |
 | `listQuery()` | `query/` | 创建列表查询 |
 | `pagedQuery()` | `query/` | 创建分页查询 |
 | `singleQuery()` | `query/` | 创建单条查询 |
@@ -472,9 +485,9 @@ const result = await commandClient.addCartItem({
 // Generated query client factory
 const factory = cartQueryClientFactory;
 const snapshotClient = factory.createSnapshotQueryClient();
-const cartState = await snapshotClient.singleState(singleQuery({
-  condition: aggregateId('cart-1'),
-}));
+const cartState = await snapshotClient.singleState({
+  filter: filter.aggregateId('cart-1'),
+});
 ```
 
 ## 交叉引用


### PR DESCRIPTION
## Description

- document snapshot aggregation queries in the package READMEs, skill API reference, and bilingual Wiki pages
- make `FilterExpression` the primary Wiki query path while retaining the legacy `Condition` compatibility note
- clarify that aggregation methods are optional on `SnapshotQueryApi` but required on `SnapshotQueryClient`

No generator or runtime code changes are included.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `pnpm test:unit`
- [x] `pnpm --dir wiki build`
- [x] Prettier check for the package READMEs and skill API reference
- [x] `git diff --check origin/main...HEAD`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

Not applicable: code comments, new runtime tests, firmware/hardware configuration, or downstream dependencies.