### PR TITLE
feat(wow): add TypeScript-first query DSL 3.18

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-integration-test",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "private": true,
   "description": "Integration Test Fetcher",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcher",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "A modern HTTP client library based on fetch API",
   "private": true,
   "type": "module",

--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-cosec",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "Enterprise-grade CoSec authentication integration for the Fetcher HTTP client with comprehensive security features including automatic token management, device tracking, and request attribution.",
   "keywords": [
     "fetch",

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-decorator",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "TypeScript decorators for clean, declarative API service definitions with Fetcher HTTP client. Enables automatic parameter binding, method mapping, and type-safe API interactions.",
   "keywords": [
     "fetch",

--- a/packages/eventbus/package.json
+++ b/packages/eventbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventbus",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "A TypeScript event bus library with serial, parallel, and broadcast implementations",
   "keywords": [
     "eventbus",

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventstream",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "Server-Sent Events (SSE) support for Fetcher HTTP client with native LLM streaming API support. Enables real-time data streaming and token-by-token LLM response handling.",
   "keywords": [
     "fetch",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "Fetcher is not just another HTTP client—it's a complete ecosystem designed for modern web development with native LLM\nstreaming API support. Built on the native Fetch API, Fetcher provides an Axios-like experience with powerful features\nwhile maintaining an incredibly small footprint.",
   "keywords": [
     "fetch",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-generator",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "A powerful TypeScript code generation tool that automatically generates type-safe API client code based on OpenAPI specifications. It is designed for general use cases and is also deeply optimized for the [Wow](https://github.com/Ahoo-Wang/Wow) Domain-Driven Design framework, providing native support for the CQRS architectural pattern.",
   "keywords": [
     "fetch",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-openai",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "Type-safe OpenAI API client for Fetcher ecosystem. Provides seamless integration with OpenAI's Chat Completions API, supporting both streaming and non-streaming responses with full TypeScript support.",
   "keywords": [
     "openai",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-openapi",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "OpenAPI Specification TypeScript types for Fetcher - A modern, ultra-lightweight HTTP client for browsers and Node.js. Provides complete TypeScript support with type inference for OpenAPI 3.x schemas.",
   "keywords": [
     "fetch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-react",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "React integration for Fetcher HTTP client. Provides React Hooks and components for seamless data fetching with automatic re-rendering and loading states.",
   "keywords": [
     "fetch",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-storage",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "A lightweight, cross-environment storage library with key-based storage and automatic environment detection. Provides consistent API for browser localStorage and in-memory storage with change notifications.",
   "keywords": [
     "storage",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-viewer",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "A comprehensive React component library for API documentation viewing and data filtering, built on top of Ant Design and the Fetcher ecosystem. Provides reusable UI components for building rich data-driven applications with advanced filtering capabilities and remote data selection.",
   "keywords": [
     "react",

--- a/packages/wow/README.md
+++ b/packages/wow/README.md
@@ -165,13 +165,25 @@ for await (const commandResultEvent of commandResultStream) {
 Wow 8.11+ queries use `FilterExpression`:
 
 ```typescript
-import { DeletionState, filter } from '@ahoo-wang/fetcher-wow';
+import {
+  DeletionState,
+  filter,
+  SearchMode,
+  TimeUnit,
+} from '@ahoo-wang/fetcher-wow';
 
 const expression = filter.and(
   filter.deletion(DeletionState.ACTIVE),
   filter.eq('state.status', 'PAID'),
   filter.elementMatch('state.items', filter.gt('quantity', 0)),
-  filter.search('wow', 'state.name'),
+  filter.search('event sourcing', {
+    mode: SearchMode.PHRASE,
+    fields: ['state.title', 'state.description'],
+  }),
+  filter.yesterday('state.createdAt', {
+    zoneId: 'Asia/Shanghai',
+    timeUnit: TimeUnit.MILLISECONDS,
+  }),
 );
 ```
 
@@ -321,21 +333,20 @@ import {
 } from '@ahoo-wang/fetcher';
 import '@ahoo-wang/fetcher-eventstream';
 import {
-  AggregationFunction,
-  AggregationGroupType,
-  AggregationMetricType,
-  AggregationQuery,
+  aggregation,
   SnapshotQueryClient,
-  SortDirection,
   filter,
   FilterListQuery,
   FilterPagedQuery,
   FilterSingleQuery,
+  type AggregationQuery,
+  Identifier,
 } from '@ahoo-wang/fetcher-wow';
 import { idGenerator } from '@ahoo-wang/fetcher-cosec';
 
 interface CartItem {
   productId: string;
+  price: number;
   quantity: number;
 }
 
@@ -416,33 +427,28 @@ const single = await cartSnapshotQueryClient.single(singleQuery);
 // Single snapshot state
 const singleState = await cartSnapshotQueryClient.singleState(singleQuery);
 
+type CartFields = 'state.status' | 'state.items';
+type ItemFields = 'productId' | 'price' | 'quantity';
+
 type ProductSummary = {
   product: string;
   itemCount: number;
-  totalQuantity: number;
+  revenue: number;
 };
 
-const aggregationQuery: AggregationQuery = {
+const revenue = aggregation.multiply(
+  aggregation.field<ItemFields>('price'),
+  aggregation.field<ItemFields>('quantity'),
+);
+
+const aggregationQuery: AggregationQuery<CartFields, ItemFields> = {
   filter: filter.eq('state.status', 'COMPLETED'),
-  elements: [{ path: 'state.items' }],
-  groupBy: [
-    {
-      type: AggregationGroupType.TERMS,
-      field: 'productId',
-      alias: 'product',
-    },
-  ],
+  elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
+  groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
-    {
-      type: AggregationMetricType.NUMERIC,
-      function: AggregationFunction.SUM,
-      expression: { field: 'quantity' },
-      alias: 'totalQuantity',
-    },
+    aggregation.count('itemCount'),
+    aggregation.sum(revenue, 'revenue'),
   ],
-  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
-  limit: 10,
 };
 
 const summaries =
@@ -472,9 +478,9 @@ for await (const event of summaryStream) {
 - `single(singleQuery: FilterSingleQuery): Promise<Partial<MaterializedSnapshot<S>>>` - Retrieves a single materialized
   snapshot.
 - `singleState(singleQuery: FilterSingleQuery): Promise<Partial<S>>` - Retrieves a single snapshot state.
-- `aggregate<Row extends DynamicDocument = DynamicDocument>(query: AggregationQuery<FIELDS>): Promise<Row[]>` - Runs a
+- `aggregate<Row extends DynamicDocument = DynamicDocument, AGGREGATION_FIELDS extends string = string>(query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>): Promise<Row[]>` - Runs a
   snapshot aggregation and requests `snapshot/aggregation`.
-- `aggregateStream<Row extends DynamicDocument = DynamicDocument>(query: AggregationQuery<FIELDS>): Promise<ReadableStream<JsonServerSentEvent<Row>>>` - Runs a snapshot aggregation and requests `snapshot/aggregation` using Server-Sent Events (SSE).
+- `aggregateStream<Row extends DynamicDocument = DynamicDocument, AGGREGATION_FIELDS extends string = string>(query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>): Promise<ReadableStream<JsonServerSentEvent<Row>>>` - Runs a snapshot aggregation and requests `snapshot/aggregation` using Server-Sent Events (SSE).
 
 #### QueryClientFactory
 

--- a/packages/wow/README.zh-CN.md
+++ b/packages/wow/README.zh-CN.md
@@ -157,13 +157,25 @@ for await (const commandResultEvent of commandResultStream) {
 Wow 8.11+ 查询使用 `FilterExpression`：
 
 ```typescript
-import { DeletionState, filter } from '@ahoo-wang/fetcher-wow';
+import {
+  DeletionState,
+  filter,
+  SearchMode,
+  TimeUnit,
+} from '@ahoo-wang/fetcher-wow';
 
 const expression = filter.and(
   filter.deletion(DeletionState.ACTIVE),
   filter.eq('state.status', 'PAID'),
   filter.elementMatch('state.items', filter.gt('quantity', 0)),
-  filter.search('wow', 'state.name'),
+  filter.search('event sourcing', {
+    mode: SearchMode.PHRASE,
+    fields: ['state.title', 'state.description'],
+  }),
+  filter.yesterday('state.createdAt', {
+    zoneId: 'Asia/Shanghai',
+    timeUnit: TimeUnit.MILLISECONDS,
+  }),
 );
 ```
 
@@ -312,21 +324,20 @@ import {
 } from '@ahoo-wang/fetcher';
 import '@ahoo-wang/fetcher-eventstream';
 import {
-  AggregationFunction,
-  AggregationGroupType,
-  AggregationMetricType,
-  AggregationQuery,
+  aggregation,
   SnapshotQueryClient,
-  SortDirection,
   filter,
   FilterListQuery,
   FilterPagedQuery,
   FilterSingleQuery,
+  type AggregationQuery,
+  Identifier,
 } from '@ahoo-wang/fetcher-wow';
 import { idGenerator } from '@ahoo-wang/fetcher-cosec';
 
 interface CartItem {
   productId: string;
+  price: number;
   quantity: number;
 }
 
@@ -407,33 +418,28 @@ const single = await cartSnapshotQueryClient.single(singleQuery);
 // 查询单个快照状态
 const singleState = await cartSnapshotQueryClient.singleState(singleQuery);
 
+type CartFields = 'state.status' | 'state.items';
+type ItemFields = 'productId' | 'price' | 'quantity';
+
 type ProductSummary = {
   product: string;
   itemCount: number;
-  totalQuantity: number;
+  revenue: number;
 };
 
-const aggregationQuery: AggregationQuery = {
+const revenue = aggregation.multiply(
+  aggregation.field<ItemFields>('price'),
+  aggregation.field<ItemFields>('quantity'),
+);
+
+const aggregationQuery: AggregationQuery<CartFields, ItemFields> = {
   filter: filter.eq('state.status', 'COMPLETED'),
-  elements: [{ path: 'state.items' }],
-  groupBy: [
-    {
-      type: AggregationGroupType.TERMS,
-      field: 'productId',
-      alias: 'product',
-    },
-  ],
+  elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
+  groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
-    {
-      type: AggregationMetricType.NUMERIC,
-      function: AggregationFunction.SUM,
-      expression: { field: 'quantity' },
-      alias: 'totalQuantity',
-    },
+    aggregation.count('itemCount'),
+    aggregation.sum(revenue, 'revenue'),
   ],
-  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
-  limit: 10,
 };
 
 const summaries =
@@ -460,8 +466,8 @@ for await (const event of summaryStream) {
 - `pagedState(pagedQuery: FilterPagedQuery): Promise<PagedList<Partial<S>>>` - 检索快照状态的分页列表。
 - `single(singleQuery: FilterSingleQuery): Promise<Partial<MaterializedSnapshot<S>>>` - 检索单个物化快照。
 - `singleState(singleQuery: FilterSingleQuery): Promise<Partial<S>>` - 检索单个快照状态。
-- `aggregate<Row extends DynamicDocument = DynamicDocument>(query: AggregationQuery<FIELDS>): Promise<Row[]>` - 执行快照聚合并请求 `snapshot/aggregation`。
-- `aggregateStream<Row extends DynamicDocument = DynamicDocument>(query: AggregationQuery<FIELDS>): Promise<ReadableStream<JsonServerSentEvent<Row>>>` - 执行快照聚合并通过服务器发送事件（SSE）请求 `snapshot/aggregation`。
+- `aggregate<Row extends DynamicDocument = DynamicDocument, AGGREGATION_FIELDS extends string = string>(query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>): Promise<Row[]>` - 执行快照聚合并请求 `snapshot/aggregation`。
+- `aggregateStream<Row extends DynamicDocument = DynamicDocument, AGGREGATION_FIELDS extends string = string>(query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>): Promise<ReadableStream<JsonServerSentEvent<Row>>>` - 执行快照聚合并通过服务器发送事件（SSE）请求 `snapshot/aggregation`。
 
 #### QueryClientFactory
 

--- a/packages/wow/docs/superpowers/plans/2026-08-27-wow-query-dsl.md
+++ b/packages/wow/docs/superpowers/plans/2026-08-27-wow-query-dsl.md
@@ -1,0 +1,1209 @@
+# Fetcher Wow 查询 DSL 3.18 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 `@ahoo-wang/fetcher-wow` 中交付与 Wow 当前线协议一致、对 TypeScript 友好的函数式 Filter 与 Aggregation DSL，并将 monorepo 锁步更新到 `3.18.0`。
+
+**Architecture:** 保留现有 `Condition` 体系不变，只在 `filter.ts` 与 `aggregation.ts` 上提供无状态纯函数。DSL 直接生成 Wow 请求 JSON；SnapshotQueryClient 只扩展类型签名以接收根字段与聚合字段分离的请求，不增加转换或验证层。
+
+**Tech Stack:** TypeScript 6、Vitest 4、Vite 8、ESLint、Prettier、VitePress、pnpm 10。
+
+**Spec:** `packages/wow/docs/superpowers/specs/2026-08-27-wow-query-dsl-design.md`
+
+## Global Constraints
+
+- 目标版本固定为 `3.18.0`，使用 `pnpm update-version 3.18.0` 更新版本。
+- `Condition`、legacy `Operator` 与 operator locale 必须保持原样。
+- `filter.ts` 与 `aggregation.ts` 不保留旧签名、兼容重载或兼容别名。
+- 不新增 `snapshot/schema` 或 `snapshot/schema/refresh` 客户端。
+- 不修改 generator、viewer、react 的运行时代码。
+- 不新增依赖、package、根 TypeScript 配置或构建配置。
+- 不实现链式 Builder、字段 Schema 图、查询解析器或完整客户端聚合验证器。
+- 中英文 README 与 Wiki 必须同步；Skill API reference 必须与公共导出一致。
+
+---
+
+## 文件职责
+
+- `packages/wow/src/query/filter.ts`：Wow FilterExpression 判别联合、校验与函数式 Filter DSL。
+- `packages/wow/src/query/aggregation.ts`：聚合判别联合、字段泛型、叶节点校验与函数式 Aggregation DSL。
+- `packages/wow/src/query/snapshot/snapshotQueryApi.ts`：公开 Snapshot 查询接口的聚合请求类型。
+- `packages/wow/src/query/snapshot/snapshotQueryClient.ts`：具体 Snapshot 客户端的聚合请求类型；运行时请求逻辑保持不变。
+- `packages/wow/test/query/filter.test.ts`：Filter JSON、边界校验和元素作用域类型测试。
+- `packages/wow/test/query/aggregation.test.ts`：Aggregation JSON、辅助函数、递归表达式与字段泛型测试。
+- `packages/wow/test/query/snapshot/snapshotQueryApi.test.ts`：Snapshot API 类型与请求 body 透传测试。
+- `packages/wow/README.md`、`packages/wow/README.zh-CN.md`：包级入门与常用示例。
+- `skills/fetcher-wow-cqrs/references/api.md`：完整公共 API 事实与签名。
+- `wiki/packages/wow.md`、`wiki/zh/packages/wow.md`：中英文站点文档。
+- 根、`packages/*` 与 `integration-test/package.json`：锁步 `3.18.0` 版本。
+
+### Task 1: 对齐并重塑 Filter DSL
+
+**Files:**
+
+- Modify: `packages/wow/test/query/filter.test.ts:14-622`
+- Modify: `packages/wow/src/query/filter.ts:21-898`
+
+**Interfaces:**
+
+- Consumes: 现有 `DeletionState`、`LogicalField`、`ElementFilterExpression` 与所有既有 `filter.*` 构造函数。
+- Produces: `SearchMode`、`TimeUnit`、`SearchFilterOptions<FIELDS>`，五个新日期操作符，以及新的 `filter.search(query, options?)`。
+
+- [ ] **Step 1: 写 Filter DSL 失败测试**
+
+在 `filter.test.ts` 的导入中加入 `SearchMode` 与 `TimeUnit`，并加入以下测试。旧
+`search(query, ...fields)` 的 `@ts-expect-error` 在实现前会因签名仍有效而导致类型测试
+失败；新导出与新函数也会使 Vitest 编译失败。
+
+```ts
+it('builds search filters with explicit defaults and phrase mode', () => {
+  expect(filter.search('wow')).toEqual({
+    op: FilterOperator.SEARCH,
+    query: 'wow',
+    mode: SearchMode.TERMS,
+    fields: [],
+  });
+  expect(
+    filter.search('event sourcing', {
+      mode: SearchMode.PHRASE,
+      fields: ['state.title', 'state.description'],
+    }),
+  ).toEqual({
+    op: FilterOperator.SEARCH,
+    query: 'event sourcing',
+    mode: SearchMode.PHRASE,
+    fields: ['state.title', 'state.description'],
+  });
+});
+
+const assertOldSearchSignatureRemoved = () => {
+  // @ts-expect-error The new Filter DSL does not retain rest-field compatibility.
+  filter.search('wow', 'state.name');
+};
+expectTypeOf(assertOldSearchSignatureRemoved).toBeFunction();
+
+it.each([
+  ['yesterday', filter.yesterday, FilterOperator.YESTERDAY],
+  ['next month', filter.nextMonth, FilterOperator.NEXT_MONTH],
+  ['last year', filter.lastYear, FilterOperator.LAST_YEAR],
+  ['this year', filter.thisYear, FilterOperator.THIS_YEAR],
+  ['next year', filter.nextYear, FilterOperator.NEXT_YEAR],
+] as const)('builds %s filters', (_name, create, op) => {
+  expect(create('createdAt')).toEqual({
+    op,
+    field: 'createdAt',
+    timeUnit: TimeUnit.MILLISECONDS,
+  });
+});
+
+it('emits every Wow relative-time unit', () => {
+  expect(
+    Object.values(TimeUnit).map(timeUnit =>
+      filter.today('createdAt', { timeUnit }),
+    ),
+  ).toEqual(
+    Object.values(TimeUnit).map(timeUnit => ({
+      op: FilterOperator.TODAY,
+      field: 'createdAt',
+      timeUnit,
+    })),
+  );
+});
+```
+
+在现有非法参数表中加入：
+
+```ts
+[
+  'invalid search mode',
+  () => Reflect.apply(filter.search, null, ['wow', { mode: 'INVALID' }]),
+],
+[
+  'invalid time unit',
+  () => filter.today('createdAt', { timeUnit: 'INVALID' as TimeUnit }),
+],
+```
+
+- [ ] **Step 2: 运行测试并确认 RED**
+
+Run:
+
+```bash
+pnpm --filter @ahoo-wang/fetcher-wow exec vitest run test/query/filter.test.ts
+pnpm --filter @ahoo-wang/fetcher-wow test:type
+```
+
+Expected: FAIL，报告 `SearchMode`、`TimeUnit`、`yesterday` 等导出不存在，并报告旧
+`search` 调用上的 `@ts-expect-error` 未使用。
+
+- [ ] **Step 3: 实现最新 Filter 线类型与 options 校验**
+
+在 `FilterOperator` 中加入：
+
+```ts
+YESTERDAY = 'YESTERDAY',
+NEXT_MONTH = 'NEXT_MONTH',
+LAST_YEAR = 'LAST_YEAR',
+THIS_YEAR = 'THIS_YEAR',
+NEXT_YEAR = 'NEXT_YEAR',
+```
+
+在 `StringComparison` 后加入：
+
+```ts
+export enum SearchMode {
+  TERMS = 'TERMS',
+  PHRASE = 'PHRASE',
+}
+
+export enum TimeUnit {
+  NANOSECONDS = 'NANOSECONDS',
+  MICROSECONDS = 'MICROSECONDS',
+  MILLISECONDS = 'MILLISECONDS',
+  SECONDS = 'SECONDS',
+  MINUTES = 'MINUTES',
+  HOURS = 'HOURS',
+  DAYS = 'DAYS',
+}
+```
+
+将搜索与相对时间 options 改为：
+
+```ts
+export type SearchFilter<FIELDS extends string = string> = {
+  op: FilterOperator.SEARCH;
+  query: string;
+  fields?: LogicalField<FIELDS>[];
+  mode?: SearchMode;
+};
+
+export interface SearchFilterOptions<FIELDS extends string = string> {
+  fields?: readonly LogicalField<FIELDS>[];
+  mode?: SearchMode;
+}
+
+export interface RelativeTimeFilterOptions {
+  zoneId?: string;
+  datePattern?: string;
+  timeUnit?: TimeUnit;
+}
+```
+
+让 `validateRelativeTimeOptions` 始终返回合法 `timeUnit`：
+
+```ts
+function validateRelativeTimeOptions({
+  zoneId,
+  datePattern,
+  timeUnit = TimeUnit.MILLISECONDS,
+}: RelativeTimeFilterOptions): RelativeTimeFilterOptions & {
+  timeUnit: TimeUnit;
+} {
+  if (zoneId !== undefined) {
+    if (typeof zoneId !== 'string' || !zoneId.trim()) {
+      throw new TypeError('zoneId cannot be blank.');
+    }
+    if (
+      OFFSET_ZONE_CANDIDATE_PATTERN.test(zoneId) &&
+      !isValidOffsetZone(zoneId)
+    ) {
+      throw new TypeError(`zoneId is invalid: [${zoneId}].`);
+    }
+  }
+  if (datePattern !== undefined) validateDatePattern(datePattern);
+  if (!Object.values(TimeUnit).includes(timeUnit)) {
+    throw new TypeError(`timeUnit is invalid: [${String(timeUnit)}].`);
+  }
+  return {
+    ...(zoneId === undefined ? {} : { zoneId }),
+    ...(datePattern === undefined ? {} : { datePattern }),
+    timeUnit,
+  };
+}
+```
+
+- [ ] **Step 4: 替换 search 并补齐五个日期构造函数**
+
+用以下函数替换旧的 rest-fields `search`：
+
+```ts
+search<FIELDS extends string>(
+  query: string,
+  {
+    fields = [],
+    mode = SearchMode.TERMS,
+  }: SearchFilterOptions<FIELDS> = {},
+): SearchFilter<FIELDS> {
+  if (typeof query !== 'string' || !query.trim()) {
+    throw new TypeError('SEARCH query cannot be blank.');
+  }
+  if (!Object.values(SearchMode).includes(mode)) {
+    throw new TypeError(`SEARCH mode is invalid: [${String(mode)}].`);
+  }
+  return {
+    op: FilterOperator.SEARCH,
+    query,
+    mode,
+    fields: fields.map(logicalField),
+  };
+},
+```
+
+把五个新 operator 加入 `CalendarFilter` 联合，并在 `filter` 对象中加入：
+
+```ts
+yesterday<FIELDS extends string>(
+  field: FIELDS,
+  options: RelativeTimeFilterOptions = {},
+): CalendarFilter<FIELDS> {
+  return {
+    ...validateRelativeTimeOptions(options),
+    op: FilterOperator.YESTERDAY,
+    field: logicalField(field),
+  };
+},
+nextMonth<FIELDS extends string>(
+  field: FIELDS,
+  options: RelativeTimeFilterOptions = {},
+): CalendarFilter<FIELDS> {
+  return {
+    ...validateRelativeTimeOptions(options),
+    op: FilterOperator.NEXT_MONTH,
+    field: logicalField(field),
+  };
+},
+lastYear<FIELDS extends string>(
+  field: FIELDS,
+  options: RelativeTimeFilterOptions = {},
+): CalendarFilter<FIELDS> {
+  return {
+    ...validateRelativeTimeOptions(options),
+    op: FilterOperator.LAST_YEAR,
+    field: logicalField(field),
+  };
+},
+thisYear<FIELDS extends string>(
+  field: FIELDS,
+  options: RelativeTimeFilterOptions = {},
+): CalendarFilter<FIELDS> {
+  return {
+    ...validateRelativeTimeOptions(options),
+    op: FilterOperator.THIS_YEAR,
+    field: logicalField(field),
+  };
+},
+nextYear<FIELDS extends string>(
+  field: FIELDS,
+  options: RelativeTimeFilterOptions = {},
+): CalendarFilter<FIELDS> {
+  return {
+    ...validateRelativeTimeOptions(options),
+    op: FilterOperator.NEXT_YEAR,
+    field: logicalField(field),
+  };
+},
+```
+
+现有 `today`、`beforeToday`、`tomorrow`、week/month、recent/earlier days 都继续展开
+`validateRelativeTimeOptions`，所以其测试期望值必须加入
+`timeUnit: TimeUnit.MILLISECONDS`；显式 `timeUnit` 时使用调用值。
+
+- [ ] **Step 5: 运行 Filter 测试、类型检查与格式检查**
+
+Run:
+
+```bash
+pnpm --filter @ahoo-wang/fetcher-wow exec vitest run test/query/filter.test.ts
+pnpm --filter @ahoo-wang/fetcher-wow test:type
+pnpm --package=prettier dlx prettier --check packages/wow/src/query/filter.ts packages/wow/test/query/filter.test.ts
+```
+
+Expected: PASS；旧 rest-fields 搜索只出现在带 `@ts-expect-error` 的破坏性边界测试中。
+
+- [ ] **Step 6: 提交 Filter DSL**
+
+```bash
+git add packages/wow/src/query/filter.ts packages/wow/test/query/filter.test.ts
+git commit -m "feat(wow): align filter DSL with Wow query API"
+```
+
+### Task 2: 实现类型安全的 Aggregation DSL
+
+**Files:**
+
+- Modify: `packages/wow/test/query/aggregation.test.ts:14-179`
+- Modify: `packages/wow/src/query/aggregation.ts:14-115`
+
+**Interfaces:**
+
+- Consumes: Task 1 的 `filter`、`ElementFilterExpression<FIELDS>`、`FilterExpression<FIELDS>` 与 `LogicalField<FIELDS>`。
+- Produces: `AggregationExpressionOperator`、递归 `AggregationExpression<FIELDS>`、字段泛型 Group/Metric、`AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS>` 与扁平 `aggregation` 函数对象。
+
+- [ ] **Step 1: 写 Aggregation DSL 失败测试**
+
+替换 `aggregation.test.ts` 的枚举和完整请求测试，使其导入 `aggregation` 与
+`AggregationExpressionOperator`，并验证以下对象：
+
+```ts
+type RootFields = 'state.status' | 'state.orders';
+type ItemFields = 'status' | 'quantity' | 'productId' | 'amount' | 'createdAt';
+
+it('builds arithmetic aggregation JSON through the functional DSL', () => {
+  const revenue = aggregation.multiply(
+    aggregation.field<ItemFields>('amount'),
+    aggregation.constant(1.2),
+  );
+  const query: AggregationQuery<RootFields, ItemFields> = {
+    filter: filter.eq('state.status', 'COMPLETED'),
+    elements: [
+      aggregation.element('state.orders', filter.eq('status', 'PAID')),
+    ],
+    groupBy: [
+      aggregation.terms('productId', 'product'),
+      aggregation.histogram('amount', {
+        interval: 10,
+        alias: 'amountBand',
+      }),
+      aggregation.dateHistogram('createdAt', {
+        unit: AggregationDateUnit.MONTH,
+        alias: 'month',
+      }),
+    ],
+    metrics: [aggregation.count('count'), aggregation.sum(revenue, 'revenue')],
+    sort: [{ field: 'revenue', direction: SortDirection.DESC }],
+    limit: 20,
+  };
+
+  expect(query).toStrictEqual({
+    filter: { op: 'EQ', field: 'state.status', value: 'COMPLETED' },
+    elements: [
+      {
+        path: 'state.orders',
+        filter: { op: 'EQ', field: 'status', value: 'PAID' },
+      },
+    ],
+    groupBy: [
+      { type: 'TERMS', field: 'productId', alias: 'product' },
+      { type: 'HISTOGRAM', field: 'amount', interval: 10, alias: 'amountBand' },
+      {
+        type: 'DATE_HISTOGRAM',
+        field: 'createdAt',
+        unit: 'MONTH',
+        alias: 'month',
+        timeZone: 'UTC',
+      },
+    ],
+    metrics: [
+      { type: 'COUNT', alias: 'count' },
+      {
+        type: 'NUMERIC',
+        function: 'SUM',
+        expression: {
+          type: 'BINARY',
+          operator: 'MULTIPLY',
+          left: { type: 'FIELD', field: 'amount' },
+          right: { type: 'CONSTANT', value: 1.2 },
+        },
+        alias: 'revenue',
+      },
+    ],
+    sort: [{ field: 'revenue', direction: 'DESC' }],
+    limit: 20,
+  });
+});
+```
+
+把枚举断言改为：
+
+```ts
+expect(Object.values(AggregationExpressionType)).toEqual([
+  'FIELD',
+  'CONSTANT',
+  'BINARY',
+]);
+expect(Object.values(AggregationExpressionOperator)).toEqual([
+  'ADD',
+  'SUBTRACT',
+  'MULTIPLY',
+  'DIVIDE',
+]);
+```
+
+加入其余算术与数值指标 helper 的精确 JSON 测试：
+
+```ts
+it('builds every arithmetic and numeric metric helper', () => {
+  const field = aggregation.field<'amount'>('amount');
+  const constant = aggregation.constant(2);
+
+  expect([
+    aggregation.add(field, constant),
+    aggregation.subtract(field, constant),
+    aggregation.divide(field, constant),
+  ]).toEqual([
+    {
+      type: 'BINARY',
+      operator: 'ADD',
+      left: { type: 'FIELD', field: 'amount' },
+      right: { type: 'CONSTANT', value: 2 },
+    },
+    {
+      type: 'BINARY',
+      operator: 'SUBTRACT',
+      left: { type: 'FIELD', field: 'amount' },
+      right: { type: 'CONSTANT', value: 2 },
+    },
+    {
+      type: 'BINARY',
+      operator: 'DIVIDE',
+      left: { type: 'FIELD', field: 'amount' },
+      right: { type: 'CONSTANT', value: 2 },
+    },
+  ]);
+  expect([
+    aggregation.avg(field, 'average'),
+    aggregation.min(field, 'minimum'),
+    aggregation.max(field, 'maximum'),
+  ]).toEqual([
+    { type: 'NUMERIC', function: 'AVG', expression: field, alias: 'average' },
+    { type: 'NUMERIC', function: 'MIN', expression: field, alias: 'minimum' },
+    { type: 'NUMERIC', function: 'MAX', expression: field, alias: 'maximum' },
+  ]);
+});
+```
+
+把旧“允许省略 FIELD.type”测试替换为破坏性类型边界：
+
+```ts
+const assertFieldTypeIsRequired = () => {
+  // @ts-expect-error FIELD expressions require their discriminator in 3.18.
+  const expression: AggregationExpression = { field: 'amount' };
+  void expression;
+};
+expectTypeOf(assertFieldTypeIsRequired).toBeFunction();
+```
+
+加入非法叶节点测试：
+
+```ts
+it.each([
+  ['invalid field', () => aggregation.field('bad field')],
+  ['non-finite constant', () => aggregation.constant(Number.NaN)],
+  [
+    'zero histogram interval',
+    () => aggregation.histogram('amount', { interval: 0, alias: 'band' }),
+  ],
+  ['multi-segment alias', () => aggregation.terms('status', 'group.status')],
+  ['reserved alias', () => aggregation.count('__wow_count')],
+  [
+    'blank time zone',
+    () =>
+      aggregation.dateHistogram('createdAt', {
+        unit: AggregationDateUnit.DAY,
+        alias: 'day',
+        timeZone: ' ',
+      }),
+  ],
+  [
+    'root filter inside element',
+    () => aggregation.element('state.items', filter.id('snapshot-1') as never),
+  ],
+])('rejects %s', (_name, create) => {
+  expect(create).toThrow(TypeError);
+});
+```
+
+- [ ] **Step 2: 运行 Aggregation 测试并确认 RED**
+
+Run:
+
+```bash
+pnpm --filter @ahoo-wang/fetcher-wow exec vitest run test/query/aggregation.test.ts
+pnpm --filter @ahoo-wang/fetcher-wow test:type
+```
+
+Expected: FAIL，报告 `aggregation`、`AggregationExpressionOperator` 与递归表达式类型
+不存在，并报告旧 FIELD.type 可省略测试不再符合目标。
+
+- [ ] **Step 3: 扩展聚合判别联合与字段泛型**
+
+先把 `aggregation.ts` 的 Filter 导入改为运行时 `filter` 加类型导入：
+
+```ts
+import {
+  filter,
+  type ElementFilterExpression,
+  type FilterExpression,
+  type LogicalField,
+} from './filter';
+```
+
+然后把现有类型改为：
+
+```ts
+export enum AggregationExpressionType {
+  FIELD = 'FIELD',
+  CONSTANT = 'CONSTANT',
+  BINARY = 'BINARY',
+}
+
+export enum AggregationExpressionOperator {
+  ADD = 'ADD',
+  SUBTRACT = 'SUBTRACT',
+  MULTIPLY = 'MULTIPLY',
+  DIVIDE = 'DIVIDE',
+}
+
+interface AggregationGroupBase<FIELDS extends string = string> {
+  field: LogicalField<FIELDS>;
+  alias: string;
+}
+
+export interface FieldAggregationExpression<FIELDS extends string = string> {
+  type: AggregationExpressionType.FIELD;
+  field: LogicalField<FIELDS>;
+}
+
+export interface ConstantAggregationExpression {
+  type: AggregationExpressionType.CONSTANT;
+  value: number;
+}
+
+export interface BinaryAggregationExpression<FIELDS extends string = string> {
+  type: AggregationExpressionType.BINARY;
+  operator: AggregationExpressionOperator;
+  left: AggregationExpression<FIELDS>;
+  right: AggregationExpression<FIELDS>;
+}
+
+export type AggregationExpression<FIELDS extends string = string> =
+  | FieldAggregationExpression<FIELDS>
+  | ConstantAggregationExpression
+  | BinaryAggregationExpression<FIELDS>;
+```
+
+给 `TermsAggregationGroup`、`HistogramAggregationGroup`、
+`DateHistogramAggregationGroup`、`AggregationGroup`、`NumericAggregationMetric` 与
+`AggregationMetric` 加同一个 `FIELDS extends string = string` 泛型。将顶层查询改为：
+
+```ts
+export interface AggregationQuery<
+  ROOT_FIELDS extends string = string,
+  AGGREGATION_FIELDS extends string = ROOT_FIELDS,
+> {
+  filter?: FilterExpression<ROOT_FIELDS>;
+  elements?: AggregationElement[];
+  groupBy?: AggregationGroup<AGGREGATION_FIELDS>[];
+  metrics: [
+    AggregationMetric<AGGREGATION_FIELDS>,
+    ...AggregationMetric<AGGREGATION_FIELDS>[],
+  ];
+  sort?: FieldSort[];
+  limit?: number;
+}
+```
+
+- [ ] **Step 4: 实现扁平 aggregation 函数对象**
+
+加入 options 与内部校验：
+
+```ts
+export interface HistogramAggregationOptions {
+  interval: number;
+  alias: string;
+}
+
+export interface DateHistogramAggregationOptions {
+  unit: AggregationDateUnit;
+  alias: string;
+  timeZone?: string;
+}
+
+const LOGICAL_FIELD_PATTERN =
+  /^@?[A-Za-z_][A-Za-z0-9_-]*(\.(?:@?[A-Za-z_][A-Za-z0-9_-]*|[0-9]+))*$/;
+
+function aggregationField<FIELDS extends string>(field: FIELDS): FIELDS {
+  if (typeof field !== 'string' || !LOGICAL_FIELD_PATTERN.test(field)) {
+    throw new TypeError(`Logical field is invalid: [${String(field)}].`);
+  }
+  return field;
+}
+
+function aggregationAlias(alias: string): string {
+  aggregationField(alias);
+  if (alias.includes('.')) {
+    throw new TypeError('aggregation alias must contain one segment.');
+  }
+  if (alias.startsWith('__wow')) {
+    throw new TypeError(
+      'aggregation alias must not use the reserved __wow prefix.',
+    );
+  }
+  return alias;
+}
+```
+
+实现表达式和指标内部函数：
+
+```ts
+function binary<FIELDS extends string>(
+  operator: AggregationExpressionOperator,
+  left: AggregationExpression<FIELDS>,
+  right: AggregationExpression<FIELDS>,
+): BinaryAggregationExpression<FIELDS> {
+  return { type: AggregationExpressionType.BINARY, operator, left, right };
+}
+
+function numeric<FIELDS extends string>(
+  fn: AggregationFunction,
+  expression: AggregationExpression<FIELDS>,
+  alias: string,
+): NumericAggregationMetric<FIELDS> {
+  return {
+    type: AggregationMetricType.NUMERIC,
+    function: fn,
+    expression,
+    alias: aggregationAlias(alias),
+  };
+}
+```
+
+公开的扁平对象必须包含完整函数，不新增 class 或嵌套 namespace：
+
+```ts
+export const aggregation = {
+  element(
+    path: string,
+    predicate?: ElementFilterExpression,
+  ): AggregationElement {
+    const validPath = aggregationField(path);
+    if (predicate === undefined) return { path: validPath };
+    filter.elementMatch(path, predicate);
+    return { path: validPath, filter: predicate };
+  },
+  field<FIELDS extends string>(
+    field: FIELDS,
+  ): FieldAggregationExpression<FIELDS> {
+    return {
+      type: AggregationExpressionType.FIELD,
+      field: aggregationField(field),
+    };
+  },
+  constant(value: number): ConstantAggregationExpression {
+    if (!Number.isFinite(value)) {
+      throw new TypeError('aggregation constant must be finite.');
+    }
+    return { type: AggregationExpressionType.CONSTANT, value };
+  },
+  add: <FIELDS extends string>(
+    left: AggregationExpression<FIELDS>,
+    right: AggregationExpression<FIELDS>,
+  ) => binary(AggregationExpressionOperator.ADD, left, right),
+  subtract: <FIELDS extends string>(
+    left: AggregationExpression<FIELDS>,
+    right: AggregationExpression<FIELDS>,
+  ) => binary(AggregationExpressionOperator.SUBTRACT, left, right),
+  multiply: <FIELDS extends string>(
+    left: AggregationExpression<FIELDS>,
+    right: AggregationExpression<FIELDS>,
+  ) => binary(AggregationExpressionOperator.MULTIPLY, left, right),
+  divide: <FIELDS extends string>(
+    left: AggregationExpression<FIELDS>,
+    right: AggregationExpression<FIELDS>,
+  ) => binary(AggregationExpressionOperator.DIVIDE, left, right),
+  terms<FIELDS extends string>(
+    field: FIELDS,
+    alias: string,
+  ): TermsAggregationGroup<FIELDS> {
+    return {
+      type: AggregationGroupType.TERMS,
+      field: aggregationField(field),
+      alias: aggregationAlias(alias),
+    };
+  },
+  histogram<FIELDS extends string>(
+    field: FIELDS,
+    { interval, alias }: HistogramAggregationOptions,
+  ): HistogramAggregationGroup<FIELDS> {
+    if (!Number.isFinite(interval) || interval <= 0) {
+      throw new TypeError(
+        'histogram interval must be finite and greater than 0.',
+      );
+    }
+    return {
+      type: AggregationGroupType.HISTOGRAM,
+      field: aggregationField(field),
+      interval,
+      alias: aggregationAlias(alias),
+    };
+  },
+  dateHistogram<FIELDS extends string>(
+    field: FIELDS,
+    { unit, alias, timeZone = 'UTC' }: DateHistogramAggregationOptions,
+  ): DateHistogramAggregationGroup<FIELDS> {
+    if (typeof timeZone !== 'string' || !timeZone.trim()) {
+      throw new TypeError('date histogram timeZone cannot be blank.');
+    }
+    return {
+      type: AggregationGroupType.DATE_HISTOGRAM,
+      field: aggregationField(field),
+      unit,
+      alias: aggregationAlias(alias),
+      timeZone,
+    };
+  },
+  count(alias: string): CountAggregationMetric {
+    return {
+      type: AggregationMetricType.COUNT,
+      alias: aggregationAlias(alias),
+    };
+  },
+  sum: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+  ) => numeric(AggregationFunction.SUM, expression, alias),
+  avg: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+  ) => numeric(AggregationFunction.AVG, expression, alias),
+  min: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+  ) => numeric(AggregationFunction.MIN, expression, alias),
+  max: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+  ) => numeric(AggregationFunction.MAX, expression, alias),
+};
+```
+
+- [ ] **Step 5: 锁定字段泛型边界**
+
+在静态边界测试中加入：
+
+```ts
+const assertAggregationFields = () => {
+  const valid: AggregationQuery<RootFields, ItemFields> = {
+    filter: filter.eq('state.status', 'PAID'),
+    groupBy: [aggregation.terms('productId', 'product')],
+    metrics: [aggregation.sum(aggregation.field('amount'), 'total')],
+  };
+  const invalidAggregationField: AggregationQuery<RootFields, ItemFields> = {
+    filter: filter.eq('state.status', 'PAID'),
+    groupBy: [
+      // @ts-expect-error unknown is not an ItemFields member.
+      aggregation.terms('unknown', 'unknown'),
+    ],
+    metrics: [aggregation.count('count')],
+  };
+  void valid;
+  void invalidAggregationField;
+};
+expectTypeOf(assertAggregationFields).toBeFunction();
+```
+
+- [ ] **Step 6: 运行 Aggregation 测试、类型检查与格式检查**
+
+Run:
+
+```bash
+pnpm --filter @ahoo-wang/fetcher-wow exec vitest run test/query/aggregation.test.ts
+pnpm --filter @ahoo-wang/fetcher-wow test:type
+pnpm --package=prettier dlx prettier --check packages/wow/src/query/aggregation.ts packages/wow/test/query/aggregation.test.ts
+```
+
+Expected: PASS；表达式枚举为三个值，所有 helper 生成完整 discriminator，非法叶节点
+抛 `TypeError`。
+
+- [ ] **Step 7: 提交 Aggregation DSL**
+
+```bash
+git add packages/wow/src/query/aggregation.ts packages/wow/test/query/aggregation.test.ts
+git commit -m "feat(wow): add functional aggregation DSL"
+```
+
+### Task 3: 让 Snapshot 客户端接受双字段域并证明 body 透传
+
+**Files:**
+
+- Modify: `packages/wow/test/query/snapshot/snapshotQueryApi.test.ts:14-77`
+- Modify: `packages/wow/src/query/snapshot/snapshotQueryApi.ts:32-48`
+- Modify: `packages/wow/src/query/snapshot/snapshotQueryClient.ts:129-150`
+
+**Interfaces:**
+
+- Consumes: Task 2 的 `AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS>` 与 `aggregation`。
+- Produces: 保持结果行泛型优先的 `aggregate<Row, AGGREGATION_FIELDS>` 与 `aggregateStream<Row, AGGREGATION_FIELDS>`。
+
+- [ ] **Step 1: 写客户端类型与 body 透传失败测试**
+
+在 `snapshotQueryApi.test.ts` 中加入 `NamedFetcher`、`vi`、`aggregation`、`filter` 与
+`SnapshotQueryClient` 运行时导入，然后把查询改为双字段域：
+
+```ts
+import { NamedFetcher } from '@ahoo-wang/fetcher';
+import type { SnapshotQueryApi } from '../../../src';
+import {
+  aggregation,
+  filter,
+  SnapshotQueryClient,
+  type AggregationQuery,
+  type DynamicDocument,
+} from '../../../src';
+```
+
+```ts
+type RootFields = 'state.status';
+type ItemFields = 'productId' | 'amount';
+const query: AggregationQuery<RootFields, ItemFields> = {
+  filter: filter.eq('state.status', 'PAID'),
+  groupBy: [aggregation.terms('productId', 'product')],
+  metrics: [aggregation.sum(aggregation.field('amount'), 'total')],
+};
+```
+
+把以上 types 与 `query` 放在 `describe` 作用域，使类型测试和 body 透传测试使用同一个
+请求对象。现有结果类型断言改为：
+
+```ts
+const assertClientTypes = (
+  client: SnapshotQueryClient<unknown, RootFields>,
+) => {
+  expectTypeOf(client.aggregate<AggregationRow>(query)).toEqualTypeOf<
+    Promise<AggregationRow[]>
+  >();
+  expectTypeOf(client.aggregateStream<AggregationRow>(query)).toEqualTypeOf<
+    Promise<ReadableStream<JsonServerSentEvent<AggregationRow>>>
+  >();
+};
+```
+
+加入真实 decorator/fetcher 管线的 unit test：
+
+```ts
+it('forwards aggregation DSL output as the request body', async () => {
+  const fetcher = new NamedFetcher('aggregation-body-test');
+  const exchange = vi
+    .spyOn(fetcher.interceptors, 'exchange')
+    .mockImplementation(async current => {
+      const body =
+        typeof current.request.body === 'string'
+          ? JSON.parse(current.request.body)
+          : current.request.body;
+      expect(body).toEqual(query);
+      current.extractResult = vi.fn().mockResolvedValue([]);
+      return current;
+    });
+  const client = new SnapshotQueryClient<unknown, RootFields>({
+    basePath: '/order',
+    fetcher,
+  });
+
+  await client.aggregate(query);
+
+  expect(exchange).toHaveBeenCalledOnce();
+});
+```
+
+- [ ] **Step 2: 运行 Snapshot 测试并确认 RED**
+
+Run:
+
+```bash
+pnpm --filter @ahoo-wang/fetcher-wow exec vitest run test/query/snapshot/snapshotQueryApi.test.ts
+pnpm --filter @ahoo-wang/fetcher-wow test:type
+```
+
+Expected: FAIL，当前客户端把第二字段域默认成根字段域，拒绝
+`AggregationQuery<RootFields, ItemFields>`。
+
+- [ ] **Step 3: 扩展接口与具体客户端的类型参数**
+
+在 `SnapshotQueryApi` 和 `SnapshotQueryClient` 的两个聚合方法上使用同一签名；保留
+`Row` 为第一个泛型，使现有结果行写法仍直观，但第二泛型默认 `string`，不承担旧
+`filter.ts` / `aggregation.ts` 的兼容义务：
+
+```ts
+aggregate?<
+  Row extends DynamicDocument = DynamicDocument,
+  AGGREGATION_FIELDS extends string = string,
+>(
+  query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>,
+  attributes?: Record<string, any>,
+  abortController?: AbortController,
+): Promise<Row[]>;
+
+aggregateStream?<
+  Row extends DynamicDocument = DynamicDocument,
+  AGGREGATION_FIELDS extends string = string,
+>(
+  query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>,
+  attributes?: Record<string, any>,
+  abortController?: AbortController,
+): Promise<ReadableStream<JsonServerSentEvent<Row>>>;
+```
+
+具体类的方法移除 `?`，保留原有 decorator、endpoint、headers、resultExtractor 与函数
+体，只替换泛型和 query 参数类型。
+
+- [ ] **Step 4: 运行 Snapshot、Aggregation 与类型测试**
+
+Run:
+
+```bash
+pnpm --filter @ahoo-wang/fetcher-wow exec vitest run test/query/aggregation.test.ts test/query/snapshot/snapshotQueryApi.test.ts
+pnpm --filter @ahoo-wang/fetcher-wow test:type
+```
+
+Expected: PASS；mock exchange 收到与 `query` 深度相等的 body，JSON 与 SSE 返回类型保持
+不变。
+
+- [ ] **Step 5: 提交客户端类型接线**
+
+```bash
+git add packages/wow/src/query/snapshot/snapshotQueryApi.ts packages/wow/src/query/snapshot/snapshotQueryClient.ts packages/wow/test/query/snapshot/snapshotQueryApi.test.ts
+git commit -m "feat(wow): type aggregation field scopes in snapshot client"
+```
+
+### Task 4: 同步 README、Skill 与双语 Wiki
+
+**Files:**
+
+- Modify: `packages/wow/README.md:155-185,311-479`
+- Modify: `packages/wow/README.zh-CN.md:155-176,302-466`
+- Modify: `skills/fetcher-wow-cqrs/references/api.md:74-164,311-430,544-676`
+- Modify: `wiki/packages/wow.md:250-355,469-472`
+- Modify: `wiki/zh/packages/wow.md:249-351,464-467`
+
+**Interfaces:**
+
+- Consumes: Tasks 1-3 的最终导出、函数签名、默认值和双字段域泛型。
+- Produces: 五份只引用真实 `3.18.0` API 的同步文档；`Condition` 章节内容保持现状。
+
+- [ ] **Step 1: 记录旧 API 文档命中作为 RED**
+
+Run:
+
+```bash
+rg -n "filter\.search\('wow', 'state\.name'\)|expression: \{ field:|type: AggregationGroupType\.TERMS" packages/wow/README.md packages/wow/README.zh-CN.md skills/fetcher-wow-cqrs/references/api.md wiki/packages/wow.md wiki/zh/packages/wow.md
+```
+
+Expected: 至少命中五个目标文档，证明它们仍展示旧搜索签名或手写旧聚合表达式。
+
+- [ ] **Step 2: 更新中英文 README 的主示例**
+
+两份 README 使用同一 TypeScript 事实，文字分别为英文和中文。Filter 示例必须使用：
+
+```ts
+filter.search('event sourcing', {
+  mode: SearchMode.PHRASE,
+  fields: ['state.title', 'state.description'],
+});
+
+filter.yesterday('state.createdAt', {
+  zoneId: 'Asia/Shanghai',
+  timeUnit: TimeUnit.MILLISECONDS,
+});
+```
+
+聚合示例必须使用：
+
+```ts
+const revenue = aggregation.multiply(
+  aggregation.field<ItemFields>('price'),
+  aggregation.field<ItemFields>('quantity'),
+);
+
+const aggregationQuery: AggregationQuery<CartFields, ItemFields> = {
+  filter: filter.eq('state.status', 'COMPLETED'),
+  elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
+  groupBy: [aggregation.terms('productId', 'product')],
+  metrics: [
+    aggregation.count('itemCount'),
+    aggregation.sum(revenue, 'revenue'),
+  ],
+};
+```
+
+README 导入列表加入示例实际使用的 `aggregation`、`SearchMode` 与 `TimeUnit`；删除
+“FIELD type 可省略”等过时说明。`AggregationExpressionOperator` 的完整导入与枚举值
+放在 Skill API reference。不要删除或改写 `Condition Builder` 章节。
+
+- [ ] **Step 3: 更新 Skill API reference**
+
+在统一导入与目录中加入：
+
+```ts
+aggregation,
+AggregationExpressionOperator,
+SearchMode,
+TimeUnit,
+type SearchFilterOptions,
+type HistogramAggregationOptions,
+type DateHistogramAggregationOptions,
+```
+
+Filter 章节完整记录：
+
+```ts
+filter.search(query, options?: SearchFilterOptions)
+filter.yesterday(field, options?)
+filter.nextMonth(field, options?)
+filter.lastYear(field, options?)
+filter.thisYear(field, options?)
+filter.nextYear(field, options?)
+```
+
+Aggregation 章节记录 `AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS =
+ROOT_FIELDS>`、三个表达式 discriminator、四个算术 operator、全部 `aggregation.*`
+函数及默认 `UTC`。明确整体 alias/sort/depth 约束由 Wow 服务端校验。
+
+- [ ] **Step 4: 同步更新英文与中文 Wiki**
+
+将 Wiki 的旧 Filter 搜索与手写 Aggregation JSON 替换成 README 的相同调用形状；导出
+表加入 `aggregation`、`SearchMode`、`TimeUnit`、
+`AggregationExpressionOperator`。英文和中文页面必须拥有相同的代码示例、默认值与
+非目标说明。不要修改 frontmatter、导航、Mermaid 图或生成产物。
+
+- [ ] **Step 5: 验证文档无旧签名且 Wiki 可构建**
+
+Run:
+
+```bash
+if rg -n "filter\.search\('wow', 'state\.name'\)|expression: \{ field:" packages/wow/README.md packages/wow/README.zh-CN.md skills/fetcher-wow-cqrs/references/api.md wiki/packages/wow.md wiki/zh/packages/wow.md; then exit 1; fi
+pnpm --package=prettier dlx prettier --check packages/wow/README.md packages/wow/README.zh-CN.md skills/fetcher-wow-cqrs/references/api.md wiki/packages/wow.md wiki/zh/packages/wow.md
+pnpm --dir wiki build
+git diff --check
+```
+
+Expected: 旧签名扫描无输出，Prettier、VitePress 与 diff 检查全部 PASS；不生成受版本
+控制的 `llms-full.txt`、`llms.txt` 或 `.vitepress/dist` 变更。
+
+- [ ] **Step 6: 提交文档同步**
+
+```bash
+git add packages/wow/README.md packages/wow/README.zh-CN.md skills/fetcher-wow-cqrs/references/api.md wiki/packages/wow.md wiki/zh/packages/wow.md
+git commit -m "docs(wow): document query DSL 3.18"
+```
+
+### Task 5: 锁步更新 3.18.0 并通过全部门禁
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `integration-test/package.json`
+- Modify: `packages/cosec/package.json`
+- Modify: `packages/decorator/package.json`
+- Modify: `packages/eventbus/package.json`
+- Modify: `packages/eventstream/package.json`
+- Modify: `packages/fetcher/package.json`
+- Modify: `packages/generator/package.json`
+- Modify: `packages/openai/package.json`
+- Modify: `packages/openapi/package.json`
+- Modify: `packages/react/package.json`
+- Modify: `packages/storage/package.json`
+- Modify: `packages/viewer/package.json`
+- Modify: `packages/wow/package.json`
+
+**Interfaces:**
+
+- Consumes: Tasks 1-4 的实现、测试与文档。
+- Produces: 所有发布包和 integration-test 均声明 `3.18.0`，全仓门禁通过的候选提交。
+
+- [ ] **Step 1: 运行仓库版本脚本**
+
+```bash
+pnpm update-version 3.18.0
+```
+
+Expected: 输出根、12 个 `packages/*` 和 `integration-test` 均更新到 `3.18.0`；
+`pnpm-lock.yaml` 不发生变化。
+
+- [ ] **Step 2: 精确验证所有版本文件**
+
+Run:
+
+```bash
+node <<'NODE'
+const fs = require('node:fs');
+const files = [
+  'package.json',
+  'integration-test/package.json',
+  ...fs
+    .readdirSync('packages', { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => `packages/${entry.name}/package.json`)
+    .filter(file => fs.existsSync(file)),
+];
+for (const file of files) {
+  const { version } = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (version !== '3.18.0') throw new Error(`${file}: ${version}`);
+}
+console.log(`verified ${files.length} package versions`);
+NODE
+```
+
+Expected: `verified 14 package versions`。
+
+- [ ] **Step 3: 运行格式、lint 与定向门禁**
+
+Run:
+
+```bash
+pnpm --package=prettier dlx prettier --write packages/wow/src/query/filter.ts packages/wow/src/query/aggregation.ts packages/wow/src/query/snapshot/snapshotQueryApi.ts packages/wow/src/query/snapshot/snapshotQueryClient.ts packages/wow/test/query/filter.test.ts packages/wow/test/query/aggregation.test.ts packages/wow/test/query/snapshot/snapshotQueryApi.test.ts packages/wow/README.md packages/wow/README.zh-CN.md skills/fetcher-wow-cqrs/references/api.md wiki/packages/wow.md wiki/zh/packages/wow.md
+pnpm lint
+pnpm --filter @ahoo-wang/fetcher-wow exec vitest run test/query/filter.test.ts test/query/aggregation.test.ts test/query/snapshot/snapshotQueryApi.test.ts
+pnpm --filter @ahoo-wang/fetcher-wow test:type
+```
+
+Expected: 全部 PASS；lint 不产生任务范围外的源文件变更。
+
+- [ ] **Step 4: 运行完整构建、单元测试与 Wiki 构建**
+
+Run:
+
+```bash
+pnpm build
+pnpm test:unit
+pnpm --dir wiki build
+```
+
+Expected: 三条命令退出码均为 0。`pnpm test:unit` 包含 Wow Vitest 与
+`test/tsconfig.types.json` 类型检查。
+
+- [ ] **Step 5: 检查范围、生成产物与 diff**
+
+Run:
+
+```bash
+git diff --check
+git diff --name-only origin/main...HEAD -- packages/generator/src packages/viewer/src packages/react/src
+git status --short
+```
+
+Expected:
+
+- `git diff --check` 无输出。
+- generator/viewer/react runtime 路径扫描无输出。
+- `git status --short` 只包含 Task 5 的 14 个 `package.json`；build、coverage、Wiki dist
+  与 llms 产物均不在状态列表中。
+
+- [ ] **Step 6: 提交版本更新**
+
+```bash
+git add package.json integration-test/package.json packages/*/package.json
+git commit -m "chore(release): bump version to 3.18.0"
+```
+
+- [ ] **Step 7: 记录最终候选证据**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -5
+git diff --check origin/main...HEAD
+```
+
+Expected: 工作树干净；最近提交依次覆盖 Filter、Aggregation、Snapshot 类型接线、文档
+和版本；range diff 检查通过。不要在本任务中 push、创建 PR、发布 npm 或部署。

--- a/packages/wow/docs/superpowers/specs/2026-08-27-wow-query-dsl-design.md
+++ b/packages/wow/docs/superpowers/specs/2026-08-27-wow-query-dsl-design.md
@@ -1,0 +1,248 @@
+# Fetcher Wow 查询 DSL 3.18 设计
+
+## 状态
+
+已确认，待实施计划。
+
+## 背景
+
+Wow `main` 的查询请求契约已经新增搜索模式、相对日期过滤、可配置时间单位和聚合
+算术表达式。`@ahoo-wang/fetcher-wow` 目前只覆盖较早的 `FilterExpression` 与字段型
+聚合指标，且聚合请求主要依赖调用方手写判别联合对象。
+
+本次以 Wow 当前线协议为事实来源，为 TypeScript 使用者提供无状态、可组合、类型
+推导稳定的函数式查询 DSL。旧 `Condition` 体系继续服务现有调用方，但不参与新 DSL
+的兼容设计。
+
+## 目标
+
+- 对齐 Wow 最新的过滤请求类型：搜索模式、五个相对日期操作符和时间单位。
+- 对齐聚合常量、二元算术表达式及四则运算符。
+- 通过纯函数 DSL 减少调用方手写 `op`、`type` 和递归 JSON 的负担。
+- 分别约束聚合请求的根字段与展开后的聚合字段。
+- 在能够准确判断的构造边界尽早报告无效参数。
+- 以 `3.18.0` 更新 monorepo 的锁步版本。
+
+## 非目标
+
+- 不新增或调用 `snapshot/schema`、`snapshot/schema/refresh`。
+- 不根据运行时 Schema 生成字段值类型，也不构建字段类型图。
+- 不修改、删除或迁移 `Condition`、legacy `Operator`、operator locale。
+- 不新增链式 Builder、可变查询对象、查询解析器或完整客户端验证器。
+- 不修改 generator、viewer、react；若实现时出现直接编译依赖，必须回到设计阶段
+  重新确认范围。
+- 不为 `filter.ts` 或 `aggregation.ts` 保留旧签名、兼容重载或别名。
+
+## 方案选择
+
+采用单一命名对象上的无状态函数式 DSL：`filter.*` 与 `aggregation.*`。每个函数直接
+返回 Wow 可序列化的普通对象，不保存状态，也不引入类。
+
+未采用的方案：
+
+- 链式 Builder：需要维护泛型状态和调用顺序，隐藏的可变状态也会增加测试面。
+- 仅导出判别联合：实现最少，但复杂聚合表达式需要大量重复 JSON，不符合易用目标。
+
+## Filter DSL
+
+### 公开类型
+
+`FilterOperator` 增加：
+
+- `YESTERDAY`
+- `NEXT_MONTH`
+- `LAST_YEAR`
+- `THIS_YEAR`
+- `NEXT_YEAR`
+
+新增：
+
+```ts
+enum SearchMode {
+  TERMS = 'TERMS',
+  PHRASE = 'PHRASE',
+}
+
+enum TimeUnit {
+  NANOSECONDS = 'NANOSECONDS',
+  MICROSECONDS = 'MICROSECONDS',
+  MILLISECONDS = 'MILLISECONDS',
+  SECONDS = 'SECONDS',
+  MINUTES = 'MINUTES',
+  HOURS = 'HOURS',
+  DAYS = 'DAYS',
+}
+```
+
+`SearchFilter` 增加可选 `mode`。`RelativeTimeFilterOptions` 增加可选 `timeUnit`。
+`CalendarFilter` 联合类型覆盖全部 Wow 相对日期操作符。底层请求类型保留 Wow 的可选
+默认字段，DSL 返回值则显式填入确定的默认值。
+
+### 构造函数
+
+`search` 只保留 options 形式：
+
+```ts
+filter.search('event sourcing', {
+  mode: SearchMode.PHRASE,
+  fields: ['state.title', 'state.description'],
+});
+```
+
+options 省略时，DSL 生成 `mode: TERMS` 与空 `fields`。不保留
+`search(query, ...fields)`。
+
+新增 `yesterday`、`nextMonth`、`lastYear`、`thisYear`、`nextYear`。所有相对时间函数
+继续使用同一个 options 对象：
+
+```ts
+filter.yesterday('state.createdAt', {
+  zoneId: 'Asia/Shanghai',
+  timeUnit: TimeUnit.MILLISECONDS,
+});
+```
+
+options 未提供时，DSL 显式生成 `timeUnit: MILLISECONDS`；`zoneId` 与 `datePattern`
+仍按需输出。`ElementFilterExpression` 在类型层继续排除 metadata、deletion、search
+等只允许出现在根级的过滤器。
+
+## Aggregation DSL
+
+### 公开类型
+
+`AggregationExpressionType` 包含 `FIELD`、`CONSTANT`、`BINARY`。新增：
+
+```ts
+enum AggregationExpressionOperator {
+  ADD = 'ADD',
+  SUBTRACT = 'SUBTRACT',
+  MULTIPLY = 'MULTIPLY',
+  DIVIDE = 'DIVIDE',
+}
+```
+
+`AggregationExpression<FIELDS>` 是字段、常量和递归二元表达式的判别联合。
+`AggregationGroup<FIELDS>` 与 `AggregationMetric<FIELDS>` 同样携带字段泛型。
+`FieldAggregationExpression.type` 必须显式为 `FIELD`，不保留旧的可省略形式。
+
+顶层查询使用：
+
+```ts
+AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS = ROOT_FIELDS>
+```
+
+`filter` 使用 `ROOT_FIELDS`；`groupBy` 与数值表达式使用
+`AGGREGATION_FIELDS`。Element 链可能在每一层改变相对字段作用域，没有运行时 Schema
+类型图时无法可靠静态表达，因此 `elements` 不伪造逐层字段安全。
+
+### 构造函数
+
+单一扁平 `aggregation` 对象提供：
+
+- Element：`element(path, filter?)`
+- 表达式：`field`、`constant`、`add`、`subtract`、`multiply`、`divide`
+- 分组：`terms`、`histogram`、`dateHistogram`
+- 指标：`count`、`sum`、`avg`、`min`、`max`
+
+常用签名保持短小；参数较多的分组使用 options 对象：
+
+```ts
+aggregation.terms('category', 'category');
+aggregation.histogram('price', { interval: 10, alias: 'priceBand' });
+aggregation.dateHistogram('createdAt', {
+  unit: AggregationDateUnit.DAY,
+  alias: 'day',
+  timeZone: 'Asia/Shanghai',
+});
+```
+
+`dateHistogram` 未提供 `timeZone` 时，DSL 显式生成 `UTC`；相对时间过滤器未提供
+`zoneId` 时仍省略该字段，交由 Wow 的查询时间上下文解释。
+
+完整示例：
+
+```ts
+const revenue = aggregation.multiply(
+  aggregation.field<ItemFields>('price'),
+  aggregation.field<ItemFields>('quantity'),
+);
+
+const query: AggregationQuery<OrderFields, ItemFields> = {
+  filter: filter.eq('state.status', 'PAID'),
+  elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
+  groupBy: [aggregation.terms('category', 'category')],
+  metrics: [aggregation.count('orders'), aggregation.sum(revenue, 'revenue')],
+};
+```
+
+DSL 与底层判别联合类型同时导出。高级调用方可以直接构造请求对象，但不会获得额外的
+运行时校验。
+
+## 数据流与校验
+
+DSL 返回的对象由现有 QueryClient 原样序列化并发送；不修改 URL、请求方法、header、
+SSE 或响应处理。
+
+Filter 构造函数沿用并扩展现有边界校验：
+
+- 逻辑字段格式、JSON 标量和非空集合
+- 搜索文本、`SearchMode`、`TimeUnit`
+- 日期、时区、日期格式与正整数天数
+- Element 内不允许的根级过滤器
+
+Aggregation 构造函数校验：
+
+- 字段与单段 alias 格式，以及保留的 `__wow` 前缀
+- 常量必须是有限数值
+- histogram interval 必须有限且大于零
+- date histogram 时区必须是非空字符串
+
+DSL 参数错误统一抛 `TypeError`。跨节点约束由 Wow 服务端负责，包括指标/分组/排序
+数量、alias 全局唯一、排序引用、表达式深度和节点总数。客户端不新增
+`aggregation.query()` 来复制这套整体验证。
+
+## 修改范围
+
+运行时与测试：
+
+- `packages/wow/src/query/filter.ts`
+- `packages/wow/src/query/aggregation.ts`
+- `packages/wow/test/query/filter.test.ts`
+- `packages/wow/test/query/aggregation.test.ts`
+- 必要时更新现有 query/client/index 测试中的新签名调用，但不修改其运行时逻辑
+
+文档：
+
+- `packages/wow/README.md`
+- `packages/wow/README.zh-CN.md`
+- `skills/fetcher-wow-cqrs/references/api.md`
+- `wiki/packages/wow.md`
+- `wiki/zh/packages/wow.md`
+
+版本由 `pnpm update-version 3.18.0` 锁步更新根、全部 workspace 包和 lockfile。
+
+## 测试策略
+
+先为新行为添加失败测试，再修改实现：
+
+- Filter：新操作符、搜索模式、七个时间单位、确定性默认输出和非法参数。
+- Aggregation：每个叶节点、递归四则表达式、分组/指标函数及非法参数。
+- 类型：根字段与聚合字段分别约束；Element 根级禁用过滤器继续被拒绝。
+- 传输：现有 SnapshotQueryClient 测试证明新聚合对象未经转换直接成为 request body。
+
+验证命令：
+
+- Wow 包定向 Vitest
+- `pnpm build`
+- `pnpm test:unit`
+- `pnpm lint`
+- `pnpm --dir wiki build`
+- Prettier 检查与 `git diff --check`
+
+## 完成标准
+
+- Filter 和 Aggregation 请求形状与 Wow 当前公开线协议一致。
+- 文档示例只使用实际导出的 `3.18.0` API，中英文事实一致。
+- `Condition` 及其现有调用方没有变化。
+- 没有兼容重载、别名、链式 Builder、Schema 客户端或生成器改动。
+- 全部构建、单元测试、lint、文档和 diff 检查通过。

--- a/packages/wow/docs/superpowers/specs/2026-08-27-wow-query-dsl-design.md
+++ b/packages/wow/docs/superpowers/specs/2026-08-27-wow-query-dsl-design.md
@@ -219,7 +219,8 @@ DSL 参数错误统一抛 `TypeError`。跨节点约束由 Wow 服务端负责�
 - `wiki/packages/wow.md`
 - `wiki/zh/packages/wow.md`
 
-版本由 `pnpm update-version 3.18.0` 锁步更新根、全部 workspace 包和 lockfile。
+版本由 `pnpm update-version 3.18.0` 锁步更新根、全部 workspace 包和
+`integration-test` 的 `package.json`；现有脚本不修改 lockfile。
 
 ## 测试策略
 

--- a/packages/wow/package.json
+++ b/packages/wow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-wow",
-  "version": "3.17.1",
+  "version": "3.18.0",
   "description": "Support for Wow(https://github.com/Ahoo-Wang/Wow) in Fetcher",
   "keywords": [
     "fetch",

--- a/packages/wow/src/query/aggregation.ts
+++ b/packages/wow/src/query/aggregation.ts
@@ -268,6 +268,9 @@ export const aggregation = {
     field: FIELDS,
     { unit, alias, timeZone = 'UTC' }: DateHistogramAggregationOptions,
   ): DateHistogramAggregationGroup<FIELDS> {
+    if (!Object.values(AggregationDateUnit).includes(unit)) {
+      throw new TypeError('date histogram unit is invalid.');
+    }
     if (typeof timeZone !== 'string' || !timeZone.trim()) {
       throw new TypeError('date histogram timeZone cannot be blank.');
     }

--- a/packages/wow/src/query/aggregation.ts
+++ b/packages/wow/src/query/aggregation.ts
@@ -11,10 +11,11 @@
  * limitations under the License.
  */
 
-import type {
-  ElementFilterExpression,
-  FilterExpression,
-  LogicalField,
+import {
+  filter,
+  type ElementFilterExpression,
+  type FilterExpression,
+  type LogicalField,
 } from './filter';
 import type { FieldSort } from './sort';
 
@@ -31,6 +32,15 @@ export enum AggregationMetricType {
 
 export enum AggregationExpressionType {
   FIELD = 'FIELD',
+  CONSTANT = 'CONSTANT',
+  BINARY = 'BINARY',
+}
+
+export enum AggregationExpressionOperator {
+  ADD = 'ADD',
+  SUBTRACT = 'SUBTRACT',
+  MULTIPLY = 'MULTIPLY',
+  DIVIDE = 'DIVIDE',
 }
 
 export enum AggregationDateUnit {
@@ -56,60 +66,239 @@ export interface AggregationElement {
   filter?: ElementFilterExpression;
 }
 
-interface AggregationGroupBase {
-  field: LogicalField;
+interface AggregationGroupBase<FIELDS extends string = string> {
+  field: LogicalField<FIELDS>;
   alias: string;
 }
 
-export interface TermsAggregationGroup extends AggregationGroupBase {
+export interface TermsAggregationGroup<
+  FIELDS extends string = string,
+> extends AggregationGroupBase<FIELDS> {
   type: AggregationGroupType.TERMS;
 }
 
-export interface HistogramAggregationGroup extends AggregationGroupBase {
+export interface HistogramAggregationGroup<
+  FIELDS extends string = string,
+> extends AggregationGroupBase<FIELDS> {
   type: AggregationGroupType.HISTOGRAM;
   interval: number;
 }
 
-export interface DateHistogramAggregationGroup
-  extends AggregationGroupBase {
+export interface DateHistogramAggregationGroup<
+  FIELDS extends string = string,
+> extends AggregationGroupBase<FIELDS> {
   type: AggregationGroupType.DATE_HISTOGRAM;
   unit: AggregationDateUnit;
   timeZone?: string;
 }
 
-export type AggregationGroup =
-  | TermsAggregationGroup
-  | HistogramAggregationGroup
-  | DateHistogramAggregationGroup;
+export type AggregationGroup<FIELDS extends string = string> =
+  | TermsAggregationGroup<FIELDS>
+  | HistogramAggregationGroup<FIELDS>
+  | DateHistogramAggregationGroup<FIELDS>;
 
-export interface FieldAggregationExpression {
-  type?: AggregationExpressionType.FIELD;
-  field: LogicalField;
+export interface FieldAggregationExpression<FIELDS extends string = string> {
+  type: AggregationExpressionType.FIELD;
+  field: LogicalField<FIELDS>;
 }
 
-export type AggregationExpression = FieldAggregationExpression;
+export interface ConstantAggregationExpression {
+  type: AggregationExpressionType.CONSTANT;
+  value: number;
+}
+
+export interface BinaryAggregationExpression<FIELDS extends string = string> {
+  type: AggregationExpressionType.BINARY;
+  operator: AggregationExpressionOperator;
+  left: AggregationExpression<FIELDS>;
+  right: AggregationExpression<FIELDS>;
+}
+
+export type AggregationExpression<FIELDS extends string = string> =
+  | FieldAggregationExpression<FIELDS>
+  | ConstantAggregationExpression
+  | BinaryAggregationExpression<FIELDS>;
 
 export interface CountAggregationMetric {
   type: AggregationMetricType.COUNT;
   alias: string;
 }
 
-export interface NumericAggregationMetric {
+export interface NumericAggregationMetric<FIELDS extends string = string> {
   type: AggregationMetricType.NUMERIC;
   function: AggregationFunction;
-  expression: AggregationExpression;
+  expression: AggregationExpression<FIELDS>;
   alias: string;
 }
 
-export type AggregationMetric =
-  | CountAggregationMetric
-  | NumericAggregationMetric;
+export type AggregationMetric<FIELDS extends string = string> =
+  CountAggregationMetric | NumericAggregationMetric<FIELDS>;
 
-export interface AggregationQuery<FIELDS extends string = string> {
-  filter?: FilterExpression<FIELDS>;
+export interface AggregationQuery<
+  ROOT_FIELDS extends string = string,
+  AGGREGATION_FIELDS extends string = ROOT_FIELDS,
+> {
+  filter?: FilterExpression<ROOT_FIELDS>;
   elements?: AggregationElement[];
-  groupBy?: AggregationGroup[];
-  metrics: [AggregationMetric, ...AggregationMetric[]];
+  groupBy?: AggregationGroup<AGGREGATION_FIELDS>[];
+  metrics: [
+    AggregationMetric<AGGREGATION_FIELDS>,
+    ...AggregationMetric<AGGREGATION_FIELDS>[],
+  ];
   sort?: FieldSort[];
   limit?: number;
 }
+
+export interface HistogramAggregationOptions {
+  interval: number;
+  alias: string;
+}
+
+export interface DateHistogramAggregationOptions {
+  unit: AggregationDateUnit;
+  alias: string;
+  timeZone?: string;
+}
+
+function aggregationField<FIELDS extends string>(field: FIELDS): FIELDS {
+  return filter.exists(field).field;
+}
+
+function aggregationAlias(alias: string): string {
+  aggregationField(alias);
+  if (alias.includes('.')) {
+    throw new TypeError('aggregation alias must contain one segment.');
+  }
+  if (alias.startsWith('__wow')) {
+    throw new TypeError(
+      'aggregation alias must not use the reserved __wow prefix.',
+    );
+  }
+  return alias;
+}
+
+function binary<FIELDS extends string>(
+  operator: AggregationExpressionOperator,
+  left: AggregationExpression<FIELDS>,
+  right: AggregationExpression<FIELDS>,
+): BinaryAggregationExpression<FIELDS> {
+  return { type: AggregationExpressionType.BINARY, operator, left, right };
+}
+
+function numeric<FIELDS extends string>(
+  fn: AggregationFunction,
+  expression: AggregationExpression<FIELDS>,
+  alias: string,
+): NumericAggregationMetric<FIELDS> {
+  return {
+    type: AggregationMetricType.NUMERIC,
+    function: fn,
+    expression,
+    alias: aggregationAlias(alias),
+  };
+}
+
+export const aggregation = {
+  element(
+    path: string,
+    predicate?: ElementFilterExpression,
+  ): AggregationElement {
+    const validPath = aggregationField(path);
+    if (predicate === undefined) return { path: validPath };
+    filter.elementMatch(path, predicate);
+    return { path: validPath, filter: predicate };
+  },
+  field<FIELDS extends string>(
+    field: FIELDS,
+  ): FieldAggregationExpression<FIELDS> {
+    return {
+      type: AggregationExpressionType.FIELD,
+      field: aggregationField(field),
+    };
+  },
+  constant(value: number): ConstantAggregationExpression {
+    if (!Number.isFinite(value)) {
+      throw new TypeError('aggregation constant must be finite.');
+    }
+    return { type: AggregationExpressionType.CONSTANT, value };
+  },
+  add: <FIELDS extends string>(
+    left: AggregationExpression<FIELDS>,
+    right: AggregationExpression<FIELDS>,
+  ) => binary(AggregationExpressionOperator.ADD, left, right),
+  subtract: <FIELDS extends string>(
+    left: AggregationExpression<FIELDS>,
+    right: AggregationExpression<FIELDS>,
+  ) => binary(AggregationExpressionOperator.SUBTRACT, left, right),
+  multiply: <FIELDS extends string>(
+    left: AggregationExpression<FIELDS>,
+    right: AggregationExpression<FIELDS>,
+  ) => binary(AggregationExpressionOperator.MULTIPLY, left, right),
+  divide: <FIELDS extends string>(
+    left: AggregationExpression<FIELDS>,
+    right: AggregationExpression<FIELDS>,
+  ) => binary(AggregationExpressionOperator.DIVIDE, left, right),
+  terms<FIELDS extends string>(
+    field: FIELDS,
+    alias: string,
+  ): TermsAggregationGroup<FIELDS> {
+    return {
+      type: AggregationGroupType.TERMS,
+      field: aggregationField(field),
+      alias: aggregationAlias(alias),
+    };
+  },
+  histogram<FIELDS extends string>(
+    field: FIELDS,
+    { interval, alias }: HistogramAggregationOptions,
+  ): HistogramAggregationGroup<FIELDS> {
+    if (!Number.isFinite(interval) || interval <= 0) {
+      throw new TypeError(
+        'histogram interval must be finite and greater than 0.',
+      );
+    }
+    return {
+      type: AggregationGroupType.HISTOGRAM,
+      field: aggregationField(field),
+      interval,
+      alias: aggregationAlias(alias),
+    };
+  },
+  dateHistogram<FIELDS extends string>(
+    field: FIELDS,
+    { unit, alias, timeZone = 'UTC' }: DateHistogramAggregationOptions,
+  ): DateHistogramAggregationGroup<FIELDS> {
+    if (typeof timeZone !== 'string' || !timeZone.trim()) {
+      throw new TypeError('date histogram timeZone cannot be blank.');
+    }
+    return {
+      type: AggregationGroupType.DATE_HISTOGRAM,
+      field: aggregationField(field),
+      unit,
+      alias: aggregationAlias(alias),
+      timeZone,
+    };
+  },
+  count(alias: string): CountAggregationMetric {
+    return {
+      type: AggregationMetricType.COUNT,
+      alias: aggregationAlias(alias),
+    };
+  },
+  sum: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+  ) => numeric(AggregationFunction.SUM, expression, alias),
+  avg: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+  ) => numeric(AggregationFunction.AVG, expression, alias),
+  min: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+  ) => numeric(AggregationFunction.MIN, expression, alias),
+  max: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+  ) => numeric(AggregationFunction.MAX, expression, alias),
+};

--- a/packages/wow/src/query/filter.ts
+++ b/packages/wow/src/query/filter.ts
@@ -60,6 +60,11 @@ export enum FilterOperator {
   LAST_WEEK = 'LAST_WEEK',
   THIS_MONTH = 'THIS_MONTH',
   LAST_MONTH = 'LAST_MONTH',
+  YESTERDAY = 'YESTERDAY',
+  NEXT_MONTH = 'NEXT_MONTH',
+  LAST_YEAR = 'LAST_YEAR',
+  THIS_YEAR = 'THIS_YEAR',
+  NEXT_YEAR = 'NEXT_YEAR',
   RECENT_DAYS = 'RECENT_DAYS',
   EARLIER_DAYS = 'EARLIER_DAYS',
 }
@@ -67,6 +72,21 @@ export enum FilterOperator {
 export enum StringComparison {
   CASE_SENSITIVE = 'CASE_SENSITIVE',
   CASE_INSENSITIVE = 'CASE_INSENSITIVE',
+}
+
+export enum SearchMode {
+  TERMS = 'TERMS',
+  PHRASE = 'PHRASE',
+}
+
+export enum TimeUnit {
+  NANOSECONDS = 'NANOSECONDS',
+  MICROSECONDS = 'MICROSECONDS',
+  MILLISECONDS = 'MILLISECONDS',
+  SECONDS = 'SECONDS',
+  MINUTES = 'MINUTES',
+  HOURS = 'HOURS',
+  DAYS = 'DAYS',
 }
 
 const LOCAL_TIME_PATTERN =
@@ -195,7 +215,10 @@ function isValidOffsetZone(zoneId: string): boolean {
 function validateRelativeTimeOptions({
   zoneId,
   datePattern,
-}: RelativeTimeFilterOptions): RelativeTimeFilterOptions {
+  timeUnit = TimeUnit.MILLISECONDS,
+}: RelativeTimeFilterOptions): RelativeTimeFilterOptions & {
+  timeUnit: TimeUnit;
+} {
   if (zoneId !== undefined) {
     if (typeof zoneId !== 'string' || !zoneId.trim()) {
       throw new TypeError('zoneId cannot be blank.');
@@ -210,9 +233,13 @@ function validateRelativeTimeOptions({
   if (datePattern !== undefined) {
     validateDatePattern(datePattern);
   }
+  if (!Object.values(TimeUnit).includes(timeUnit)) {
+    throw new TypeError(`timeUnit is invalid: [${String(timeUnit)}].`);
+  }
   return {
     ...(zoneId === undefined ? {} : { zoneId }),
     ...(datePattern === undefined ? {} : { datePattern }),
+    timeUnit,
   };
 }
 
@@ -406,11 +433,18 @@ export type SearchFilter<FIELDS extends string = string> = {
   op: FilterOperator.SEARCH;
   query: string;
   fields?: LogicalField<FIELDS>[];
+  mode?: SearchMode;
 };
+
+export interface SearchFilterOptions<FIELDS extends string = string> {
+  fields?: readonly LogicalField<FIELDS>[];
+  mode?: SearchMode;
+}
 
 export interface RelativeTimeFilterOptions {
   zoneId?: string;
   datePattern?: string;
+  timeUnit?: TimeUnit;
 }
 
 export type CalendarFilter<FIELDS extends string = string> =
@@ -422,7 +456,12 @@ export type CalendarFilter<FIELDS extends string = string> =
       | FilterOperator.NEXT_WEEK
       | FilterOperator.LAST_WEEK
       | FilterOperator.THIS_MONTH
-      | FilterOperator.LAST_MONTH;
+      | FilterOperator.LAST_MONTH
+      | FilterOperator.YESTERDAY
+      | FilterOperator.NEXT_MONTH
+      | FilterOperator.LAST_YEAR
+      | FilterOperator.THIS_YEAR
+      | FilterOperator.NEXT_YEAR;
     field: LogicalField<FIELDS>;
   };
 
@@ -773,14 +812,18 @@ export const filter = {
   },
   search<FIELDS extends string>(
     query: string,
-    ...fields: LogicalField<FIELDS>[]
+    { fields = [], mode = SearchMode.TERMS }: SearchFilterOptions<FIELDS> = {},
   ): SearchFilter<FIELDS> {
     if (typeof query !== 'string' || !query.trim()) {
       throw new TypeError('SEARCH query cannot be blank.');
     }
+    if (!Object.values(SearchMode).includes(mode)) {
+      throw new TypeError(`SEARCH mode is invalid: [${String(mode)}].`);
+    }
     return {
       op: FilterOperator.SEARCH,
       query,
+      mode,
       fields: fields.map(logicalField),
     };
   },
@@ -866,6 +909,56 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.LAST_MONTH,
+      field: logicalField(field),
+    };
+  },
+  yesterday<FIELDS extends string>(
+    field: FIELDS,
+    options: RelativeTimeFilterOptions = {},
+  ): CalendarFilter<FIELDS> {
+    return {
+      ...validateRelativeTimeOptions(options),
+      op: FilterOperator.YESTERDAY,
+      field: logicalField(field),
+    };
+  },
+  nextMonth<FIELDS extends string>(
+    field: FIELDS,
+    options: RelativeTimeFilterOptions = {},
+  ): CalendarFilter<FIELDS> {
+    return {
+      ...validateRelativeTimeOptions(options),
+      op: FilterOperator.NEXT_MONTH,
+      field: logicalField(field),
+    };
+  },
+  lastYear<FIELDS extends string>(
+    field: FIELDS,
+    options: RelativeTimeFilterOptions = {},
+  ): CalendarFilter<FIELDS> {
+    return {
+      ...validateRelativeTimeOptions(options),
+      op: FilterOperator.LAST_YEAR,
+      field: logicalField(field),
+    };
+  },
+  thisYear<FIELDS extends string>(
+    field: FIELDS,
+    options: RelativeTimeFilterOptions = {},
+  ): CalendarFilter<FIELDS> {
+    return {
+      ...validateRelativeTimeOptions(options),
+      op: FilterOperator.THIS_YEAR,
+      field: logicalField(field),
+    };
+  },
+  nextYear<FIELDS extends string>(
+    field: FIELDS,
+    options: RelativeTimeFilterOptions = {},
+  ): CalendarFilter<FIELDS> {
+    return {
+      ...validateRelativeTimeOptions(options),
+      op: FilterOperator.NEXT_YEAR,
       field: logicalField(field),
     };
   },

--- a/packages/wow/src/query/filter.ts
+++ b/packages/wow/src/query/filter.ts
@@ -812,11 +812,20 @@ export const filter = {
   },
   search<FIELDS extends string>(
     query: string,
-    { fields = [], mode = SearchMode.TERMS }: SearchFilterOptions<FIELDS> = {},
+    options?: SearchFilterOptions<FIELDS>,
   ): SearchFilter<FIELDS> {
     if (typeof query !== 'string' || !query.trim()) {
       throw new TypeError('SEARCH query cannot be blank.');
     }
+    if (
+      options !== undefined &&
+      (options === null ||
+        typeof options !== 'object' ||
+        Array.isArray(options))
+    ) {
+      throw new TypeError('SEARCH options must be a non-null object.');
+    }
+    const { fields = [], mode = SearchMode.TERMS } = options ?? {};
     if (!Object.values(SearchMode).includes(mode)) {
       throw new TypeError(`SEARCH mode is invalid: [${String(mode)}].`);
     }

--- a/packages/wow/src/query/snapshot/snapshotQueryApi.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryApi.ts
@@ -34,15 +34,21 @@ export interface SnapshotQueryApi<
   FIELDS extends string = string,
 > extends QueryApi<MaterializedSnapshot<S>, FIELDS> {
   /** Runs a snapshot aggregation and returns all result rows. */
-  aggregate?<Row extends DynamicDocument = DynamicDocument>(
-    query: AggregationQuery<FIELDS>,
+  aggregate?<
+    Row extends DynamicDocument = DynamicDocument,
+    AGGREGATION_FIELDS extends string = string,
+  >(
+    query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>,
     attributes?: Record<string, any>,
     abortController?: AbortController,
   ): Promise<Row[]>;
 
   /** Runs a snapshot aggregation and streams result rows as SSE. */
-  aggregateStream?<Row extends DynamicDocument = DynamicDocument>(
-    query: AggregationQuery<FIELDS>,
+  aggregateStream?<
+    Row extends DynamicDocument = DynamicDocument,
+    AGGREGATION_FIELDS extends string = string,
+  >(
+    query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>,
     attributes?: Record<string, any>,
     abortController?: AbortController,
   ): Promise<ReadableStream<JsonServerSentEvent<Row>>>;

--- a/packages/wow/src/query/snapshot/snapshotQueryClient.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryClient.ts
@@ -128,8 +128,11 @@ export class SnapshotQueryClient<S, FIELDS extends string = string>
 
   /** Runs a snapshot aggregation and returns all result rows. */
   @post(SnapshotQueryEndpointPaths.AGGREGATION)
-  aggregate<Row extends DynamicDocument = DynamicDocument>(
-    @body() query: AggregationQuery<FIELDS>,
+  aggregate<
+    Row extends DynamicDocument = DynamicDocument,
+    AGGREGATION_FIELDS extends string = string,
+  >(
+    @body() query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>,
     @attribute() attributes?: Record<string, any>,
     abortController?: AbortController,
   ): Promise<Row[]> {
@@ -141,8 +144,11 @@ export class SnapshotQueryClient<S, FIELDS extends string = string>
     headers: { Accept: ContentTypeValues.TEXT_EVENT_STREAM },
     resultExtractor: JsonEventStreamResultExtractor,
   })
-  aggregateStream<Row extends DynamicDocument = DynamicDocument>(
-    @body() query: AggregationQuery<FIELDS>,
+  aggregateStream<
+    Row extends DynamicDocument = DynamicDocument,
+    AGGREGATION_FIELDS extends string = string,
+  >(
+    @body() query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>,
     @attribute() attributes?: Record<string, any>,
     abortController?: AbortController,
   ): Promise<ReadableStream<JsonServerSentEvent<Row>>> {

--- a/packages/wow/test/query/aggregation.test.ts
+++ b/packages/wow/test/query/aggregation.test.ts
@@ -187,6 +187,22 @@ describe('AggregationQuery', () => {
         }),
     ],
     [
+      'missing date histogram unit',
+      () =>
+        Reflect.apply(aggregation.dateHistogram, null, [
+          'createdAt',
+          { alias: 'day' },
+        ]),
+    ],
+    [
+      'invalid date histogram unit',
+      () =>
+        Reflect.apply(aggregation.dateHistogram, null, [
+          'createdAt',
+          { unit: 'INVALID', alias: 'day' },
+        ]),
+    ],
+    [
       'root filter inside element',
       () =>
         aggregation.element('state.items', filter.id('snapshot-1') as never),
@@ -216,8 +232,38 @@ describe('AggregationQuery', () => {
       ],
       metrics: [aggregation.count('count')],
     };
+    const invalidRootFilter: AggregationQuery<RootFields, ItemFields> = {
+      // @ts-expect-error status is not a RootFields member.
+      filter: filter.eq('status', 'PAID'),
+      metrics: [aggregation.count('count')],
+    };
+    const invalidElementFilter: AggregationQuery<RootFields, ItemFields> = {
+      elements: [
+        {
+          path: 'state.orders',
+          // @ts-expect-error root metadata filters are not element predicates.
+          filter: filter.id('snapshot-1'),
+        },
+      ],
+      metrics: [aggregation.count('count')],
+    };
+    const emptyMetrics: AggregationQuery<RootFields, ItemFields> = {
+      // @ts-expect-error aggregation queries require at least one metric.
+      metrics: [],
+    };
+    const invalidMetricExpression: AggregationQuery<RootFields, ItemFields> = {
+      groupBy: [aggregation.terms('productId', 'product')],
+      metrics: [
+        // @ts-expect-error unknown is not an ItemFields member.
+        aggregation.sum(aggregation.field('unknown'), 'total'),
+      ],
+    };
     void valid;
     void invalidAggregationField;
+    void invalidRootFilter;
+    void invalidElementFilter;
+    void emptyMetrics;
+    void invalidMetricExpression;
   };
   expectTypeOf(assertAggregationFields).toBeFunction();
 });

--- a/packages/wow/test/query/aggregation.test.ts
+++ b/packages/wow/test/query/aggregation.test.ts
@@ -104,6 +104,8 @@ describe('AggregationQuery', () => {
     );
     const query: AggregationQuery<RootFields, ItemFields> = {
       filter: filter.eq('state.status', 'COMPLETED'),
+      elements: [aggregation.element('state.orders')],
+      groupBy: [aggregation.terms('productId', 'product')],
       metrics: [
         aggregation.count('count'),
         aggregation.sum(revenue, 'revenue'),
@@ -114,6 +116,8 @@ describe('AggregationQuery', () => {
 
     expect(query).toStrictEqual({
       filter: { op: 'EQ', field: 'state.status', value: 'COMPLETED' },
+      elements: [{ path: 'state.orders' }],
+      groupBy: [{ type: 'TERMS', field: 'productId', alias: 'product' }],
       metrics: [
         { type: 'COUNT', alias: 'count' },
         {

--- a/packages/wow/test/query/aggregation.test.ts
+++ b/packages/wow/test/query/aggregation.test.ts
@@ -57,27 +57,53 @@ describe('AggregationQuery', () => {
     });
   });
 
-  it('builds arithmetic aggregation JSON through the functional DSL', () => {
+  it('builds aggregation elements', () => {
+    expect([
+      aggregation.element('state.orders', filter.eq('status', 'PAID')),
+    ]).toStrictEqual([
+      {
+        path: 'state.orders',
+        filter: { op: 'EQ', field: 'status', value: 'PAID' },
+      },
+    ]);
+  });
+
+  it('builds aggregation groups', () => {
+    expect([
+      aggregation.terms('productId', 'product'),
+      aggregation.histogram('amount', {
+        interval: 10,
+        alias: 'amountBand',
+      }),
+      aggregation.dateHistogram('createdAt', {
+        unit: AggregationDateUnit.MONTH,
+        alias: 'month',
+      }),
+    ]).toStrictEqual([
+      { type: 'TERMS', field: 'productId', alias: 'product' },
+      {
+        type: 'HISTOGRAM',
+        field: 'amount',
+        interval: 10,
+        alias: 'amountBand',
+      },
+      {
+        type: 'DATE_HISTOGRAM',
+        field: 'createdAt',
+        unit: 'MONTH',
+        alias: 'month',
+        timeZone: 'UTC',
+      },
+    ]);
+  });
+
+  it('builds an arithmetic aggregation query', () => {
     const revenue = aggregation.multiply(
       aggregation.field<ItemFields>('amount'),
       aggregation.constant(1.2),
     );
     const query: AggregationQuery<RootFields, ItemFields> = {
       filter: filter.eq('state.status', 'COMPLETED'),
-      elements: [
-        aggregation.element('state.orders', filter.eq('status', 'PAID')),
-      ],
-      groupBy: [
-        aggregation.terms('productId', 'product'),
-        aggregation.histogram('amount', {
-          interval: 10,
-          alias: 'amountBand',
-        }),
-        aggregation.dateHistogram('createdAt', {
-          unit: AggregationDateUnit.MONTH,
-          alias: 'month',
-        }),
-      ],
       metrics: [
         aggregation.count('count'),
         aggregation.sum(revenue, 'revenue'),
@@ -88,28 +114,6 @@ describe('AggregationQuery', () => {
 
     expect(query).toStrictEqual({
       filter: { op: 'EQ', field: 'state.status', value: 'COMPLETED' },
-      elements: [
-        {
-          path: 'state.orders',
-          filter: { op: 'EQ', field: 'status', value: 'PAID' },
-        },
-      ],
-      groupBy: [
-        { type: 'TERMS', field: 'productId', alias: 'product' },
-        {
-          type: 'HISTOGRAM',
-          field: 'amount',
-          interval: 10,
-          alias: 'amountBand',
-        },
-        {
-          type: 'DATE_HISTOGRAM',
-          field: 'createdAt',
-          unit: 'MONTH',
-          alias: 'month',
-          timeZone: 'UTC',
-        },
-      ],
       metrics: [
         { type: 'COUNT', alias: 'count' },
         {
@@ -129,43 +133,37 @@ describe('AggregationQuery', () => {
     });
   });
 
-  it('builds every arithmetic and numeric metric helper', () => {
+  it.each([
+    ['ADD', aggregation.add],
+    ['SUBTRACT', aggregation.subtract],
+    ['MULTIPLY', aggregation.multiply],
+    ['DIVIDE', aggregation.divide],
+  ] as const)('builds %s arithmetic expressions', (operator, create) => {
     const field = aggregation.field<'amount'>('amount');
     const constant = aggregation.constant(2);
 
-    expect([
-      aggregation.add(field, constant),
-      aggregation.subtract(field, constant),
-      aggregation.divide(field, constant),
-    ]).toEqual([
-      {
-        type: 'BINARY',
-        operator: 'ADD',
-        left: { type: 'FIELD', field: 'amount' },
-        right: { type: 'CONSTANT', value: 2 },
-      },
-      {
-        type: 'BINARY',
-        operator: 'SUBTRACT',
-        left: { type: 'FIELD', field: 'amount' },
-        right: { type: 'CONSTANT', value: 2 },
-      },
-      {
-        type: 'BINARY',
-        operator: 'DIVIDE',
-        left: { type: 'FIELD', field: 'amount' },
-        right: { type: 'CONSTANT', value: 2 },
-      },
-    ]);
-    expect([
-      aggregation.avg(field, 'average'),
-      aggregation.min(field, 'minimum'),
-      aggregation.max(field, 'maximum'),
-    ]).toEqual([
-      { type: 'NUMERIC', function: 'AVG', expression: field, alias: 'average' },
-      { type: 'NUMERIC', function: 'MIN', expression: field, alias: 'minimum' },
-      { type: 'NUMERIC', function: 'MAX', expression: field, alias: 'maximum' },
-    ]);
+    expect(create(field, constant)).toEqual({
+      type: 'BINARY',
+      operator,
+      left: { type: 'FIELD', field: 'amount' },
+      right: { type: 'CONSTANT', value: 2 },
+    });
+  });
+
+  it.each([
+    ['SUM', 'sum', aggregation.sum],
+    ['AVG', 'average', aggregation.avg],
+    ['MIN', 'minimum', aggregation.min],
+    ['MAX', 'maximum', aggregation.max],
+  ] as const)('builds %s numeric metrics', (fn, alias, create) => {
+    const field = aggregation.field<'amount'>('amount');
+
+    expect(create(field, alias)).toEqual({
+      type: 'NUMERIC',
+      function: fn,
+      expression: field,
+      alias,
+    });
   });
 
   it.each([

--- a/packages/wow/test/query/aggregation.test.ts
+++ b/packages/wow/test/query/aggregation.test.ts
@@ -14,18 +14,20 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
   AggregationDateUnit,
+  AggregationExpressionOperator,
   AggregationExpressionType,
   AggregationFunction,
   AggregationGroupType,
   AggregationMetricType,
   filter,
   SortDirection,
-  type AggregationElement,
+  aggregation,
   type AggregationExpression,
   type AggregationQuery,
 } from '../../src';
 
 type RootFields = 'state.status' | 'state.orders';
+type ItemFields = 'status' | 'quantity' | 'productId' | 'amount' | 'createdAt';
 
 describe('AggregationQuery', () => {
   it('uses the Wow wire enum values', () => {
@@ -33,12 +35,14 @@ describe('AggregationQuery', () => {
       group: Object.values(AggregationGroupType),
       metric: Object.values(AggregationMetricType),
       expression: Object.values(AggregationExpressionType),
+      operator: Object.values(AggregationExpressionOperator),
       dateUnit: Object.values(AggregationDateUnit),
       function: Object.values(AggregationFunction),
     }).toEqual({
       group: ['TERMS', 'HISTOGRAM', 'DATE_HISTOGRAM'],
       metric: ['COUNT', 'NUMERIC'],
-      expression: ['FIELD'],
+      expression: ['FIELD', 'CONSTANT', 'BINARY'],
+      operator: ['ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE'],
       dateUnit: [
         'YEAR',
         'QUARTER',
@@ -53,49 +57,32 @@ describe('AggregationQuery', () => {
     });
   });
 
-  it('represents the complete Wow request shape', () => {
-    const query: AggregationQuery<RootFields> = {
+  it('builds arithmetic aggregation JSON through the functional DSL', () => {
+    const revenue = aggregation.multiply(
+      aggregation.field<ItemFields>('amount'),
+      aggregation.constant(1.2),
+    );
+    const query: AggregationQuery<RootFields, ItemFields> = {
       filter: filter.eq('state.status', 'COMPLETED'),
       elements: [
-        {
-          path: 'state.orders',
-          filter: filter.eq('status', 'PAID'),
-        },
-        {
-          path: 'lines',
-          filter: filter.gt('quantity', 0),
-        },
+        aggregation.element('state.orders', filter.eq('status', 'PAID')),
       ],
       groupBy: [
-        {
-          type: AggregationGroupType.TERMS,
-          field: 'productId',
-          alias: 'product',
-        },
-        {
-          type: AggregationGroupType.HISTOGRAM,
-          field: 'amount',
-          alias: 'amountBand',
+        aggregation.terms('productId', 'product'),
+        aggregation.histogram('amount', {
           interval: 10,
-        },
-        {
-          type: AggregationGroupType.DATE_HISTOGRAM,
-          field: 'createdAt',
-          alias: 'month',
+          alias: 'amountBand',
+        }),
+        aggregation.dateHistogram('createdAt', {
           unit: AggregationDateUnit.MONTH,
-          timeZone: 'UTC',
-        },
+          alias: 'month',
+        }),
       ],
       metrics: [
-        { type: AggregationMetricType.COUNT, alias: 'count' },
-        {
-          type: AggregationMetricType.NUMERIC,
-          function: AggregationFunction.SUM,
-          expression: { field: 'amount' },
-          alias: 'total',
-        },
+        aggregation.count('count'),
+        aggregation.sum(revenue, 'revenue'),
       ],
-      sort: [{ field: 'total', direction: SortDirection.DESC }],
+      sort: [{ field: 'revenue', direction: SortDirection.DESC }],
       limit: 20,
     };
 
@@ -106,24 +93,20 @@ describe('AggregationQuery', () => {
           path: 'state.orders',
           filter: { op: 'EQ', field: 'status', value: 'PAID' },
         },
-        {
-          path: 'lines',
-          filter: { op: 'GT', field: 'quantity', value: 0 },
-        },
       ],
       groupBy: [
         { type: 'TERMS', field: 'productId', alias: 'product' },
         {
           type: 'HISTOGRAM',
           field: 'amount',
-          alias: 'amountBand',
           interval: 10,
+          alias: 'amountBand',
         },
         {
           type: 'DATE_HISTOGRAM',
           field: 'createdAt',
-          alias: 'month',
           unit: 'MONTH',
+          alias: 'month',
           timeZone: 'UTC',
         },
       ],
@@ -132,48 +115,109 @@ describe('AggregationQuery', () => {
         {
           type: 'NUMERIC',
           function: 'SUM',
-          expression: { field: 'amount' },
-          alias: 'total',
+          expression: {
+            type: 'BINARY',
+            operator: 'MULTIPLY',
+            left: { type: 'FIELD', field: 'amount' },
+            right: { type: 'CONSTANT', value: 1.2 },
+          },
+          alias: 'revenue',
         },
       ],
-      sort: [{ field: 'total', direction: 'DESC' }],
+      sort: [{ field: 'revenue', direction: 'DESC' }],
       limit: 20,
     });
   });
 
-  it('accepts defaulted and explicit field expression types', () => {
-    const expressions: AggregationExpression[] = [
-      { field: 'amount' },
-      { type: AggregationExpressionType.FIELD, field: 'amount' },
-    ];
+  it('builds every arithmetic and numeric metric helper', () => {
+    const field = aggregation.field<'amount'>('amount');
+    const constant = aggregation.constant(2);
 
-    expect(expressions).toEqual([
-      { field: 'amount' },
-      { type: 'FIELD', field: 'amount' },
+    expect([
+      aggregation.add(field, constant),
+      aggregation.subtract(field, constant),
+      aggregation.divide(field, constant),
+    ]).toEqual([
+      {
+        type: 'BINARY',
+        operator: 'ADD',
+        left: { type: 'FIELD', field: 'amount' },
+        right: { type: 'CONSTANT', value: 2 },
+      },
+      {
+        type: 'BINARY',
+        operator: 'SUBTRACT',
+        left: { type: 'FIELD', field: 'amount' },
+        right: { type: 'CONSTANT', value: 2 },
+      },
+      {
+        type: 'BINARY',
+        operator: 'DIVIDE',
+        left: { type: 'FIELD', field: 'amount' },
+        right: { type: 'CONSTANT', value: 2 },
+      },
+    ]);
+    expect([
+      aggregation.avg(field, 'average'),
+      aggregation.min(field, 'minimum'),
+      aggregation.max(field, 'maximum'),
+    ]).toEqual([
+      { type: 'NUMERIC', function: 'AVG', expression: field, alias: 'average' },
+      { type: 'NUMERIC', function: 'MIN', expression: field, alias: 'minimum' },
+      { type: 'NUMERIC', function: 'MAX', expression: field, alias: 'maximum' },
     ]);
   });
 
-  it('enforces the static request boundaries', () => {
-    const assertInvalidQueries = () => {
-      const invalidRootFilter: AggregationQuery<RootFields> = {
-        // @ts-expect-error Root filter fields must belong to RootFields.
-        filter: filter.eq('state.unknown', 'value'),
-        metrics: [{ type: AggregationMetricType.COUNT, alias: 'count' }],
-      };
-      const invalidElementFilter: AggregationElement = {
-        path: 'lines',
-        // @ts-expect-error Root metadata filters cannot scope an Element.
-        filter: filter.id('snapshot-1'),
-      };
-      const invalidEmptyMetrics: AggregationQuery = {
-        // @ts-expect-error Aggregation metrics must be non-empty.
-        metrics: [],
-      };
-      void invalidRootFilter;
-      void invalidElementFilter;
-      void invalidEmptyMetrics;
-    };
-
-    expectTypeOf(assertInvalidQueries).toBeFunction();
+  it.each([
+    ['invalid field', () => aggregation.field('bad field')],
+    ['non-finite constant', () => aggregation.constant(Number.NaN)],
+    [
+      'zero histogram interval',
+      () => aggregation.histogram('amount', { interval: 0, alias: 'band' }),
+    ],
+    ['multi-segment alias', () => aggregation.terms('status', 'group.status')],
+    ['reserved alias', () => aggregation.count('__wow_count')],
+    [
+      'blank time zone',
+      () =>
+        aggregation.dateHistogram('createdAt', {
+          unit: AggregationDateUnit.DAY,
+          alias: 'day',
+          timeZone: ' ',
+        }),
+    ],
+    [
+      'root filter inside element',
+      () =>
+        aggregation.element('state.items', filter.id('snapshot-1') as never),
+    ],
+  ])('rejects %s', (_name, create) => {
+    expect(create).toThrow(TypeError);
   });
+
+  const assertFieldTypeIsRequired = () => {
+    // @ts-expect-error FIELD expressions require their discriminator in 3.18.
+    const expression: AggregationExpression = { field: 'amount' };
+    void expression;
+  };
+  expectTypeOf(assertFieldTypeIsRequired).toBeFunction();
+
+  const assertAggregationFields = () => {
+    const valid: AggregationQuery<RootFields, ItemFields> = {
+      filter: filter.eq('state.status', 'PAID'),
+      groupBy: [aggregation.terms('productId', 'product')],
+      metrics: [aggregation.sum(aggregation.field('amount'), 'total')],
+    };
+    const invalidAggregationField: AggregationQuery<RootFields, ItemFields> = {
+      filter: filter.eq('state.status', 'PAID'),
+      groupBy: [
+        // @ts-expect-error unknown is not an ItemFields member.
+        aggregation.terms('unknown', 'unknown'),
+      ],
+      metrics: [aggregation.count('count')],
+    };
+    void valid;
+    void invalidAggregationField;
+  };
+  expectTypeOf(assertAggregationFields).toBeFunction();
 });

--- a/packages/wow/test/query/filter.test.ts
+++ b/packages/wow/test/query/filter.test.ts
@@ -96,6 +96,12 @@ describe('filter', () => {
   };
   expectTypeOf(assertOldSearchSignatureRemoved).toBeFunction();
 
+  it('rejects the removed runtime search signature', () => {
+    expect(() =>
+      Reflect.apply(filter.search, null, ['wow', 'state.name']),
+    ).toThrow(TypeError);
+  });
+
   it.each([
     ['yesterday', filter.yesterday, FilterOperator.YESTERDAY],
     ['next month', filter.nextMonth, FilterOperator.NEXT_MONTH],

--- a/packages/wow/test/query/filter.test.ts
+++ b/packages/wow/test/query/filter.test.ts
@@ -15,7 +15,9 @@ import {
   DeletionState,
   filter,
   FilterOperator,
+  SearchMode,
   StringComparison,
+  TimeUnit,
   type ElementFilterExpression,
   type MetadataFilter,
 } from '../../src';
@@ -28,7 +30,7 @@ describe('filter', () => {
         filter.deletion(DeletionState.ACTIVE),
         filter.eq('state.status', 'PAID'),
         filter.elementMatch('state.items', filter.gt('quantity', 0)),
-        filter.search('wow', 'state.name'),
+        filter.search('wow', { fields: ['state.name'] }),
         filter.today('state.createdAt', { zoneId: 'UTC' }),
       ),
     ).toEqual({
@@ -41,10 +43,16 @@ describe('filter', () => {
           field: 'state.items',
           predicate: { op: FilterOperator.GT, field: 'quantity', value: 0 },
         },
-        { op: FilterOperator.SEARCH, query: 'wow', fields: ['state.name'] },
+        {
+          op: FilterOperator.SEARCH,
+          query: 'wow',
+          mode: SearchMode.TERMS,
+          fields: ['state.name'],
+        },
         {
           op: FilterOperator.TODAY,
           field: 'state.createdAt',
+          timeUnit: TimeUnit.MILLISECONDS,
           zoneId: 'UTC',
         },
       ],
@@ -60,6 +68,60 @@ describe('filter', () => {
       value: 'wow',
       stringComparison: StringComparison.CASE_INSENSITIVE,
     });
+  });
+
+  it('builds search filters with explicit defaults and phrase mode', () => {
+    expect(filter.search('wow')).toEqual({
+      op: FilterOperator.SEARCH,
+      query: 'wow',
+      mode: SearchMode.TERMS,
+      fields: [],
+    });
+    expect(
+      filter.search('event sourcing', {
+        mode: SearchMode.PHRASE,
+        fields: ['state.title', 'state.description'],
+      }),
+    ).toEqual({
+      op: FilterOperator.SEARCH,
+      query: 'event sourcing',
+      mode: SearchMode.PHRASE,
+      fields: ['state.title', 'state.description'],
+    });
+  });
+
+  const assertOldSearchSignatureRemoved = () => {
+    // @ts-expect-error The new Filter DSL does not retain rest-field compatibility.
+    filter.search('wow', 'state.name');
+  };
+  expectTypeOf(assertOldSearchSignatureRemoved).toBeFunction();
+
+  it.each([
+    ['yesterday', filter.yesterday, FilterOperator.YESTERDAY],
+    ['next month', filter.nextMonth, FilterOperator.NEXT_MONTH],
+    ['last year', filter.lastYear, FilterOperator.LAST_YEAR],
+    ['this year', filter.thisYear, FilterOperator.THIS_YEAR],
+    ['next year', filter.nextYear, FilterOperator.NEXT_YEAR],
+  ] as const)('builds %s filters', (_name, create, op) => {
+    expect(create('createdAt')).toEqual({
+      op,
+      field: 'createdAt',
+      timeUnit: TimeUnit.MILLISECONDS,
+    });
+  });
+
+  it('emits every Wow relative-time unit', () => {
+    expect(
+      Object.values(TimeUnit).map(timeUnit =>
+        filter.today('createdAt', { timeUnit }),
+      ),
+    ).toEqual(
+      Object.values(TimeUnit).map(timeUnit => ({
+        op: FilterOperator.TODAY,
+        field: 'createdAt',
+        timeUnit,
+      })),
+    );
   });
 
   it('builds metadata filters', () => {
@@ -237,7 +299,12 @@ describe('filter', () => {
     {
       name: 'search without fields',
       create: () => filter.search('wow'),
-      expected: { op: FilterOperator.SEARCH, query: 'wow', fields: [] },
+      expected: {
+        op: FilterOperator.SEARCH,
+        query: 'wow',
+        mode: SearchMode.TERMS,
+        fields: [],
+      },
     },
     {
       name: 'nested element match',
@@ -263,7 +330,11 @@ describe('filter', () => {
     {
       name: 'today',
       create: () => filter.today('createdAt'),
-      expected: { op: FilterOperator.TODAY, field: 'createdAt' },
+      expected: {
+        op: FilterOperator.TODAY,
+        field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
+      },
     },
     {
       name: 'today with JVM boundary options',
@@ -275,6 +346,7 @@ describe('filter', () => {
       expected: {
         op: FilterOperator.TODAY,
         field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
         zoneId: '+18:00',
         datePattern: 'ppHH[',
       },
@@ -288,6 +360,7 @@ describe('filter', () => {
       expected: {
         op: FilterOperator.TODAY,
         field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
         datePattern: 'pS:mm',
       },
     },
@@ -297,6 +370,7 @@ describe('filter', () => {
       expected: {
         op: FilterOperator.TODAY,
         field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
         datePattern: 'py',
       },
     },
@@ -309,6 +383,7 @@ describe('filter', () => {
       expected: {
         op: FilterOperator.TODAY,
         field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
         datePattern: 'YYYYYYYYYYYYYYYYYYYY',
       },
     },
@@ -322,6 +397,7 @@ describe('filter', () => {
       expected: {
         op: FilterOperator.BEFORE_TODAY,
         field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
         time: '09:30',
         zoneId: 'UTC+05:30',
         datePattern: "yyyy-MM-dd 'o''clock'['T'HH:mm:ss]",
@@ -330,32 +406,56 @@ describe('filter', () => {
     {
       name: 'tomorrow',
       create: () => filter.tomorrow('createdAt'),
-      expected: { op: FilterOperator.TOMORROW, field: 'createdAt' },
+      expected: {
+        op: FilterOperator.TOMORROW,
+        field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
+      },
     },
     {
       name: 'this week',
       create: () => filter.thisWeek('createdAt'),
-      expected: { op: FilterOperator.THIS_WEEK, field: 'createdAt' },
+      expected: {
+        op: FilterOperator.THIS_WEEK,
+        field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
+      },
     },
     {
       name: 'next week',
       create: () => filter.nextWeek('createdAt'),
-      expected: { op: FilterOperator.NEXT_WEEK, field: 'createdAt' },
+      expected: {
+        op: FilterOperator.NEXT_WEEK,
+        field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
+      },
     },
     {
       name: 'last week',
       create: () => filter.lastWeek('createdAt'),
-      expected: { op: FilterOperator.LAST_WEEK, field: 'createdAt' },
+      expected: {
+        op: FilterOperator.LAST_WEEK,
+        field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
+      },
     },
     {
       name: 'this month',
       create: () => filter.thisMonth('createdAt'),
-      expected: { op: FilterOperator.THIS_MONTH, field: 'createdAt' },
+      expected: {
+        op: FilterOperator.THIS_MONTH,
+        field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
+      },
     },
     {
       name: 'last month',
       create: () => filter.lastMonth('createdAt'),
-      expected: { op: FilterOperator.LAST_MONTH, field: 'createdAt' },
+      expected: {
+        op: FilterOperator.LAST_MONTH,
+        field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
+      },
     },
     {
       name: 'recent days',
@@ -363,6 +463,7 @@ describe('filter', () => {
       expected: {
         op: FilterOperator.RECENT_DAYS,
         field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
         days: 7,
       },
     },
@@ -372,6 +473,7 @@ describe('filter', () => {
       expected: {
         op: FilterOperator.EARLIER_DAYS,
         field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
         days: 30,
       },
     },
@@ -385,6 +487,7 @@ describe('filter', () => {
       expect(filter.today('createdAt', { zoneId })).toEqual({
         op: FilterOperator.TODAY,
         field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
         zoneId,
       });
     },
@@ -409,24 +512,32 @@ describe('filter', () => {
     ] as const;
 
     calendarFilters.forEach(([op, expression]) => {
-      expect(expression).toEqual({ zoneId: 'UTC', op, field: 'createdAt' });
+      expect(expression).toEqual({
+        zoneId: 'UTC',
+        op,
+        field: 'createdAt',
+        timeUnit: TimeUnit.MILLISECONDS,
+      });
     });
     expect(filter.beforeToday('createdAt', '09:30', options)).toEqual({
       zoneId: 'UTC',
       op: FilterOperator.BEFORE_TODAY,
       field: 'createdAt',
+      timeUnit: TimeUnit.MILLISECONDS,
       time: '09:30',
     });
     expect(filter.recentDays('createdAt', 7, options)).toEqual({
       zoneId: 'UTC',
       op: FilterOperator.RECENT_DAYS,
       field: 'createdAt',
+      timeUnit: TimeUnit.MILLISECONDS,
       days: 7,
     });
     expect(filter.earlierDays('createdAt', 30, options)).toEqual({
       zoneId: 'UTC',
       op: FilterOperator.EARLIER_DAYS,
       field: 'createdAt',
+      timeUnit: TimeUnit.MILLISECONDS,
       days: 30,
     });
   });
@@ -545,6 +656,10 @@ describe('filter', () => {
     ['blank search query', () => filter.search(' ')],
     ['non-string search query', () => Reflect.apply(filter.search, null, [1])],
     [
+      'invalid search mode',
+      () => Reflect.apply(filter.search, null, ['wow', { mode: 'INVALID' }]),
+    ],
+    [
       'non-string string operand',
       () => Reflect.apply(filter.contains, null, ['name', 1]),
     ],
@@ -567,6 +682,10 @@ describe('filter', () => {
       () => filter.recentDays('createdAt', 2_147_483_648),
     ],
     ['blank zone ID', () => filter.today('createdAt', { zoneId: ' ' })],
+    [
+      'invalid time unit',
+      () => filter.today('createdAt', { timeUnit: 'INVALID' as TimeUnit }),
+    ],
     [
       'zone offset outside the JVM range',
       () => filter.today('createdAt', { zoneId: '+23:59' }),

--- a/packages/wow/test/query/snapshot/snapshotQueryApi.test.ts
+++ b/packages/wow/test/query/snapshot/snapshotQueryApi.test.ts
@@ -11,17 +11,32 @@
  * limitations under the License.
  */
 
+import { NamedFetcher } from '@ahoo-wang/fetcher';
 import type { JsonServerSentEvent } from '@ahoo-wang/fetcher-eventstream';
-import { describe, expect, expectTypeOf, it } from 'vitest';
-import type { SnapshotQueryApi, SnapshotQueryClient } from '../../../src';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import type { SnapshotQueryApi } from '../../../src';
 import {
-  AggregationMetricType,
   SnapshotQueryEndpointPaths,
+  aggregation,
+  filter,
+  SnapshotQueryClient,
   type AggregationQuery,
   type DynamicDocument,
 } from '../../../src';
 
 describe('SnapshotQueryEndpointPaths', () => {
+  type RootFields = 'state.status';
+  type ItemFields = 'productId' | 'amount';
+  type AggregationRow = DynamicDocument & {
+    product: string;
+    total: number;
+  };
+  const query: AggregationQuery<RootFields, ItemFields> = {
+    filter: filter.eq('state.status', 'PAID'),
+    groupBy: [aggregation.terms('productId', 'product')],
+    metrics: [aggregation.sum(aggregation.field('amount'), 'total')],
+  };
+
   it('should have correct endpoint path values', () => {
     expect(SnapshotQueryEndpointPaths.SNAPSHOT_RESOURCE_NAME).toBe('snapshot');
     expect(SnapshotQueryEndpointPaths.AGGREGATION).toBe('snapshot/aggregation');
@@ -37,11 +52,6 @@ describe('SnapshotQueryEndpointPaths', () => {
   });
 
   it('exposes typed JSON and SSE aggregation results', () => {
-    type RootFields = 'state.status';
-    type AggregationRow = DynamicDocument & {
-      product: string;
-      total: number;
-    };
     type SnapshotApiHasAggregationKeys =
       'aggregate' extends keyof SnapshotQueryApi<unknown, RootFields>
         ? 'aggregateStream' extends keyof SnapshotQueryApi<unknown, RootFields>
@@ -56,9 +66,6 @@ describe('SnapshotQueryEndpointPaths', () => {
         ? true
         : false;
 
-    const query: AggregationQuery<RootFields> = {
-      metrics: [{ type: AggregationMetricType.COUNT, alias: 'total' }],
-    };
     const assertClientTypes = (
       client: SnapshotQueryClient<unknown, RootFields>,
     ) => {
@@ -73,5 +80,28 @@ describe('SnapshotQueryEndpointPaths', () => {
     expectTypeOf<SnapshotApiHasAggregationKeys>().toEqualTypeOf<true>();
     expectTypeOf<SnapshotApiRequiresAggregation>().toEqualTypeOf<false>();
     expectTypeOf(assertClientTypes).toBeFunction();
+  });
+
+  it('forwards aggregation DSL output as the request body', async () => {
+    const fetcher = new NamedFetcher('aggregation-body-test');
+    const exchange = vi
+      .spyOn(fetcher.interceptors, 'exchange')
+      .mockImplementation(async current => {
+        const body =
+          typeof current.request.body === 'string'
+            ? JSON.parse(current.request.body)
+            : current.request.body;
+        expect(body).toEqual(query);
+        current.extractResult = vi.fn().mockResolvedValue([]);
+        return current;
+      });
+    const client = new SnapshotQueryClient<unknown, RootFields>({
+      basePath: '/order',
+      fetcher,
+    });
+
+    await client.aggregate(query);
+
+    expect(exchange).toHaveBeenCalledOnce();
   });
 });

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -78,14 +78,18 @@ import {
   LoadOwnerStateAggregateClient,
   ResourceAttributionPathSpec,
   SortDirection,
+  aggregation,
   AggregationGroupType,
   AggregationMetricType,
   AggregationExpressionType,
+  AggregationExpressionOperator,
   AggregationDateUnit,
   AggregationFunction,
   DeletionState,
   FilterOperator,
+  SearchMode,
   StringComparison,
+  TimeUnit,
   filter,
   listQuery,
   cursorFilter,
@@ -151,6 +155,7 @@ import {
   type ElementFilterExpression,
   type MetadataFilter,
   type EqualityFilterValue,
+  type SearchFilterOptions,
   type RelativeTimeFilterOptions,
   type FilterListQuery,
   type FilterPagedQuery,
@@ -163,6 +168,8 @@ import {
   type AggregationElement,
   type AggregationGroup,
   type AggregationMetric,
+  type HistogramAggregationOptions,
+  type DateHistogramAggregationOptions,
   type DynamicDocument,
 } from '@ahoo-wang/fetcher-wow';
 ```
@@ -375,33 +382,28 @@ const state = await snapshotClient.singleState({
 ### Aggregation Methods
 
 ```typescript
+type CartFields = 'state.status' | 'state.items';
+type ItemFields = 'productId' | 'price' | 'quantity';
+
 type ProductSummary = {
   product: string;
   itemCount: number;
-  totalQuantity: number;
+  revenue: number;
 };
 
-const aggregationQuery: AggregationQuery = {
+const revenue = aggregation.multiply(
+  aggregation.field<ItemFields>('price'),
+  aggregation.field<ItemFields>('quantity'),
+);
+
+const aggregationQuery: AggregationQuery<CartFields, ItemFields> = {
   filter: filter.eq('state.status', 'COMPLETED'),
-  elements: [{ path: 'state.items' }],
-  groupBy: [
-    {
-      type: AggregationGroupType.TERMS,
-      field: 'productId',
-      alias: 'product',
-    },
-  ],
+  elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
+  groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
-    {
-      type: AggregationMetricType.NUMERIC,
-      function: AggregationFunction.SUM,
-      expression: { field: 'quantity' },
-      alias: 'totalQuantity',
-    },
+    aggregation.count('itemCount'),
+    aggregation.sum(revenue, 'revenue'),
   ],
-  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
-  limit: 10,
 };
 
 const summaries =
@@ -411,14 +413,20 @@ const summaryStream =
 ```
 
 ```typescript
-aggregate<Row extends DynamicDocument = DynamicDocument>(
-  query: AggregationQuery<FIELDS>,
+aggregate<
+  Row extends DynamicDocument = DynamicDocument,
+  AGGREGATION_FIELDS extends string = string,
+>(
+  query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>,
   attributes?: Record<string, any>,
   abortController?: AbortController,
 ): Promise<Row[]>;
 
-aggregateStream<Row extends DynamicDocument = DynamicDocument>(
-  query: AggregationQuery<FIELDS>,
+aggregateStream<
+  Row extends DynamicDocument = DynamicDocument,
+  AGGREGATION_FIELDS extends string = string,
+>(
+  query: AggregationQuery<FIELDS, AGGREGATION_FIELDS>,
   attributes?: Record<string, any>,
   abortController?: AbortController,
 ): Promise<ReadableStream<JsonServerSentEvent<Row>>>;
@@ -550,7 +558,14 @@ const expression = filter.and(
   filter.deletion(DeletionState.ACTIVE),
   filter.eq('state.status', 'PAID'),
   filter.elementMatch('state.items', filter.gt('quantity', 0)),
-  filter.search('wow', 'state.name'),
+  filter.search('event sourcing', {
+    mode: SearchMode.PHRASE,
+    fields: ['state.title', 'state.description'],
+  }),
+  filter.yesterday('state.createdAt', {
+    zoneId: 'Asia/Shanghai',
+    timeUnit: TimeUnit.MILLISECONDS,
+  }),
 );
 
 await snapshotClient.count(expression);
@@ -570,8 +585,8 @@ Available builders:
 - String: `contains`, `startsWith`, `endsWith`; pass `StringComparison` as the third argument
 - Collection: `isIn`, `notIn`, `containsAll`
 - Presence: `isEmpty`, `isNull`, `isNotNull`, `exists`, `notExists`
-- Scope/search: `deletion`, `elementMatch`, `search`
-- Relative time: `today`, `beforeToday`, `tomorrow`, `thisWeek`, `nextWeek`, `lastWeek`, `thisMonth`, `lastMonth`, `recentDays`, `earlierDays`
+- Scope/search: `deletion`, `elementMatch`, `search(query, options?: SearchFilterOptions)`
+- Relative time: `today`, `beforeToday`, `tomorrow`, `thisWeek`, `nextWeek`, `lastWeek`, `thisMonth`, `lastMonth`, `yesterday`, `nextMonth`, `lastYear`, `thisYear`, `nextYear`, `recentDays`, `earlierDays`
 
 `eq` and `ne` accept a JSON scalar or an array of JSON scalars. Logical field
 segments may start with `@`.
@@ -582,8 +597,10 @@ Relative-time builders accept JVM `ZoneId` and `DateTimeFormatter` options:
 interface RelativeTimeFilterOptions {
   zoneId?: string;
   datePattern?: string;
+  timeUnit?: TimeUnit;
 }
 
+filter.search(query, options?: SearchFilterOptions);
 filter.today(field, options?);
 filter.beforeToday(field, time, options?);
 filter.tomorrow(field, options?);
@@ -592,12 +609,18 @@ filter.nextWeek(field, options?);
 filter.lastWeek(field, options?);
 filter.thisMonth(field, options?);
 filter.lastMonth(field, options?);
+filter.yesterday(field, options?);
+filter.nextMonth(field, options?);
+filter.lastYear(field, options?);
+filter.thisYear(field, options?);
+filter.nextYear(field, options?);
 filter.recentDays(field, days, options?);
 filter.earlierDays(field, days, options?);
 ```
 
-`days` must be a positive JVM `Int`. Only `zoneId` and `datePattern` from the
-options object are emitted on the wire.
+`SearchFilterOptions` has optional `fields` and `mode`; `mode` defaults to
+`SearchMode.TERMS`. Relative-time `timeUnit` defaults to `TimeUnit.MILLISECONDS`.
+`days` must be a positive JVM `Int`.
 
 `SingleQueryRequest`, `ListQueryRequest`, and `PagedQueryRequest` accept either
 the filter-based request types or the existing condition-based request types.
@@ -632,12 +655,13 @@ const predicate: FilterExpression<'id'> = cursorFilter({
 
 ## AggregationQuery
 
-`AggregationQuery<FIELDS>` accepts these fields:
+`AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS = ROOT_FIELDS>` accepts
+these fields:
 
-- `filter?: FilterExpression<FIELDS>`
+- `filter?: FilterExpression<ROOT_FIELDS>`
 - `elements?: AggregationElement[]`
-- `groupBy?: AggregationGroup[]`
-- `metrics: [AggregationMetric, ...AggregationMetric[]]` (non-empty)
+- `groupBy?: AggregationGroup<AGGREGATION_FIELDS>[]`
+- `metrics: [AggregationMetric<AGGREGATION_FIELDS>, ...AggregationMetric<AGGREGATION_FIELDS>[]]` (non-empty)
 - `sort?: FieldSort[]`
 - `limit?: number`
 
@@ -660,17 +684,37 @@ to the current innermost element.
 
 `AggregationFunction` values are `SUM`, `AVG`, `MIN`, and `MAX`.
 `AggregationDateUnit` values are `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`,
-`HOUR`, `MINUTE`, and `SECOND`. The only aggregation expression is `FIELD`:
+`HOUR`, `MINUTE`, and `SECOND`. Aggregation expressions use these
+discriminators:
+
+- `AggregationExpressionType.FIELD`: `field`
+- `AggregationExpressionType.CONSTANT`: `value`
+- `AggregationExpressionType.BINARY`: `operator`, `left`, `right`
+
+`AggregationExpressionOperator` values are `ADD`, `SUBTRACT`, `MULTIPLY`, and
+`DIVIDE`. Use the `aggregation` builders rather than hand-writing these shapes:
 
 ```typescript
-const expression = {
-  // type: AggregationExpressionType.FIELD, // optional
-  field: 'quantity', // relative to state.items in the example above
-};
+aggregation.element(path, predicate?);
+aggregation.field(field);
+aggregation.constant(value);
+aggregation.add(left, right);
+aggregation.subtract(left, right);
+aggregation.multiply(left, right);
+aggregation.divide(left, right);
+aggregation.terms(field, alias);
+aggregation.histogram(field, { interval, alias });
+aggregation.dateHistogram(field, { unit, alias, timeZone }); // timeZone defaults to UTC
+aggregation.count(alias);
+aggregation.sum(expression, alias);
+aggregation.avg(expression, alias);
+aggregation.min(expression, alias);
+aggregation.max(expression, alias);
 ```
 
-The `Row` generic describes aggregation result rows only; Fetcher does not
-perform runtime decoding.
+Wow validates the complete aggregation's aliases, sort fields, and expression
+depth on the server. The `Row` generic describes aggregation result rows only;
+Fetcher does not perform runtime decoding.
 
 ## Query DSL Conditions (Deprecated)
 

--- a/wiki/packages/wow.md
+++ b/wiki/packages/wow.md
@@ -1,6 +1,6 @@
 ---
-title: '@ahoo-wang/fetcher-wow'
-description: 'Wow framework integration for Fetcher providing DDD + Event Sourcing + CQRS support with typed command clients, snapshot query clients, event stream queries, and aggregate root interaction patterns.'
+title: "@ahoo-wang/fetcher-wow"
+description: "Wow framework integration for Fetcher providing DDD + Event Sourcing + CQRS support with typed command clients, snapshot query clients, event stream queries, and aggregate root interaction patterns."
 ---
 
 # @ahoo-wang/fetcher-wow
@@ -110,18 +110,18 @@ Commands are wrapped in a `CommandRequest` that supports:
 
 ### Command Headers
 
-| Header                      | Constant                           | Description                |
-| --------------------------- | ---------------------------------- | -------------------------- |
-| `Command-Tenant-Id`         | `CommandHeaders.TENANT_ID`         | Tenant identifier          |
-| `Command-Owner-Id`          | `CommandHeaders.OWNER_ID`          | Owner identifier           |
-| `Command-Space-Id`          | `CommandHeaders.SPACE_ID`          | Space identifier           |
-| `Command-Aggregate-Id`      | `CommandHeaders.AGGREGATE_ID`      | Aggregate instance ID      |
+| Header | Constant | Description |
+|--------|----------|-------------|
+| `Command-Tenant-Id` | `CommandHeaders.TENANT_ID` | Tenant identifier |
+| `Command-Owner-Id` | `CommandHeaders.OWNER_ID` | Owner identifier |
+| `Command-Space-Id` | `CommandHeaders.SPACE_ID` | Space identifier |
+| `Command-Aggregate-Id` | `CommandHeaders.AGGREGATE_ID` | Aggregate instance ID |
 | `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | Expected aggregate version |
-| `Command-Wait-Stage`        | `CommandHeaders.WAIT_STAGE`        | Wait processing stage      |
-| `Command-Wait-Timeout`      | `CommandHeaders.WAIT_TIME_OUT`     | Wait timeout duration      |
-| `Command-Wait-Context`      | `CommandHeaders.WAIT_CONTEXT`      | Wait processing context    |
-| `Command-Request-Id`        | `CommandHeaders.REQUEST_ID`        | Request correlation ID     |
-| `Command-Local-First`       | `CommandHeaders.LOCAL_FIRST`       | Execute locally first      |
+| `Command-Wait-Stage` | `CommandHeaders.WAIT_STAGE` | Wait processing stage |
+| `Command-Wait-Timeout` | `CommandHeaders.WAIT_TIME_OUT` | Wait timeout duration |
+| `Command-Wait-Context` | `CommandHeaders.WAIT_CONTEXT` | Wait processing context |
+| `Command-Request-Id` | `CommandHeaders.REQUEST_ID` | Request correlation ID |
+| `Command-Local-First` | `CommandHeaders.LOCAL_FIRST` | Execute locally first |
 
 Source: [packages/wow/src/command/commandHeaders.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/commandHeaders.ts)
 
@@ -164,14 +164,14 @@ Source: [packages/wow/src/command/commandResult.ts:74-110](https://github.com/Ah
 
 The `CommandStage` enum defines the processing stages at which a command's wait-strategy can signal completion. It is used as the value of the `Command-Wait-Stage` header and the `CommandResult.stage` field:
 
-| Stage           | Value             | Completion Signal                                 |
-| --------------- | ----------------- | ------------------------------------------------- |
-| `SENT`          | `'SENT'`          | Command published to the command bus/queue        |
-| `PROCESSED`     | `'PROCESSED'`     | Command processed by the aggregate root           |
-| `SNAPSHOT`      | `'SNAPSHOT'`      | Snapshot generated (aggregate state materialized) |
-| `PROJECTED`     | `'PROJECTED'`     | Events projected to read models                   |
-| `EVENT_HANDLED` | `'EVENT_HANDLED'` | Events processed by event handlers                |
-| `SAGA_HANDLED`  | `'SAGA_HANDLED'`  | Events processed by Saga processes                |
+| Stage | Value | Completion Signal |
+|-------|-------|-------------------|
+| `SENT` | `'SENT'` | Command published to the command bus/queue |
+| `PROCESSED` | `'PROCESSED'` | Command processed by the aggregate root |
+| `SNAPSHOT` | `'SNAPSHOT'` | Snapshot generated (aggregate state materialized) |
+| `PROJECTED` | `'PROJECTED'` | Events projected to read models |
+| `EVENT_HANDLED` | `'EVENT_HANDLED'` | Events processed by event handlers |
+| `SAGA_HANDLED` | `'SAGA_HANDLED'` | Events processed by Saga processes |
 
 Source: [packages/wow/src/command/types.ts:54-84](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/types.ts#L54-L84)
 
@@ -231,23 +231,23 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 #### SnapshotQueryClient Methods
 
-| Method                       | Endpoint                 | Returns                                                                 | Description                |
-| ---------------------------- | ------------------------ | ----------------------------------------------------------------------- | -------------------------- |
-| `count(filter)`              | `/snapshot/count`        | `Promise<number>`                                                       | Count matching aggregates  |
-| `list(listQuery)`            | `/snapshot/list`         | `Promise<MaterializedSnapshot<S>[]>`                                    | List snapshots             |
-| `listStream(listQuery)`      | `/snapshot/list`         | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream         |
-| `listState(listQuery)`       | `/snapshot/list/state`   | `Promise<S[]>`                                                          | List state only            |
-| `listStateStream(listQuery)` | `/snapshot/list/state`   | `Promise<ReadableStream<JsonServerSentEvent<S>>>`                       | State as SSE stream        |
-| `paged(pagedQuery)`          | `/snapshot/paged`        | `Promise<PagedList<MaterializedSnapshot<S>>>`                           | Paginated snapshots        |
-| `pagedState(pagedQuery)`     | `/snapshot/paged/state`  | `Promise<PagedList<S>>`                                                 | Paginated state            |
-| `single(singleQuery)`        | `/snapshot/single`       | `Promise<MaterializedSnapshot<S>>`                                      | Single snapshot            |
-| `singleState(singleQuery)`   | `/snapshot/single/state` | `Promise<S>`                                                            | Single state               |
-| `getById(id)`                | --                       | `Promise<MaterializedSnapshot<S>>`                                      | Get by aggregate ID        |
-| `getStateById(id)`           | --                       | `Promise<S>`                                                            | Get state by ID            |
-| `getByIds(ids)`              | --                       | `Promise<MaterializedSnapshot<S>[]>`                                    | Get multiple by IDs        |
-| `getStateByIds(ids)`         | --                       | `Promise<S[]>`                                                          | Get multiple states        |
-| `aggregate(query)`           | `/snapshot/aggregation`  | `Promise<Row[]>`                                                        | Aggregate snapshots        |
-| `aggregateStream(query)`     | `/snapshot/aggregation`  | `Promise<ReadableStream<JsonServerSentEvent<Row>>>`                     | Aggregate snapshots as SSE |
+| Method | Endpoint | Returns | Description |
+|--------|----------|---------|-------------|
+| `count(filter)` | `/snapshot/count` | `Promise<number>` | Count matching aggregates |
+| `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | List snapshots |
+| `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream |
+| `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | List state only |
+| `listStateStream(listQuery)` | `/snapshot/list/state` | `Promise<ReadableStream<JsonServerSentEvent<S>>>` | State as SSE stream |
+| `paged(pagedQuery)` | `/snapshot/paged` | `Promise<PagedList<MaterializedSnapshot<S>>>` | Paginated snapshots |
+| `pagedState(pagedQuery)` | `/snapshot/paged/state` | `Promise<PagedList<S>>` | Paginated state |
+| `single(singleQuery)` | `/snapshot/single` | `Promise<MaterializedSnapshot<S>>` | Single snapshot |
+| `singleState(singleQuery)` | `/snapshot/single/state` | `Promise<S>` | Single state |
+| `getById(id)` | -- | `Promise<MaterializedSnapshot<S>>` | Get by aggregate ID |
+| `getStateById(id)` | -- | `Promise<S>` | Get state by ID |
+| `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | Get multiple by IDs |
+| `getStateByIds(ids)` | -- | `Promise<S[]>` | Get multiple states |
+| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | Aggregate snapshots |
+| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | Aggregate snapshots as SSE |
 
 For compatibility with existing implementations, `SnapshotQueryApi` declares
 `aggregate?` and `aggregateStream?` as optional. `SnapshotQueryClient`
@@ -258,11 +258,7 @@ Source: [packages/wow/src/query/snapshot/snapshotQueryClient.ts:119-516](https:/
 #### Snapshot Aggregation
 
 ```typescript
-import {
-  aggregation,
-  filter,
-  type AggregationQuery,
-} from '@ahoo-wang/fetcher-wow';
+import { aggregation, filter, type AggregationQuery } from '@ahoo-wang/fetcher-wow';
 
 type CartFields = 'state.status' | 'state.items';
 type ItemFields = 'productId' | 'price' | 'quantity';
@@ -292,10 +288,7 @@ const summaryStream = await client.aggregateStream<ProductSummary>(query);
 A factory that creates all query clients for a given aggregate, pre-configured with the correct base path:
 
 ```typescript
-import {
-  QueryClientFactory,
-  ResourceAttributionPathSpec,
-} from '@ahoo-wang/fetcher-wow';
+import { QueryClientFactory, ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow';
 
 const factory = new QueryClientFactory<CartState, CartFields, CartDomainEvent>({
   contextAlias: 'example',
@@ -310,12 +303,12 @@ const ownerStateClient = factory.createOwnerLoadStateAggregateClient();
 const eventClient = factory.createEventStreamQueryClient();
 ```
 
-| Factory Method                          | Creates                            | Description                   |
-| --------------------------------------- | ---------------------------------- | ----------------------------- |
-| `createSnapshotQueryClient()`           | `SnapshotQueryClient<S, FIELDS>`   | Snapshot queries with filters |
-| `createLoadStateAggregateClient()`      | `LoadStateAggregateClient<S>`      | Load by ID, version, or time  |
-| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state  |
-| `createEventStreamQueryClient()`        | `EventStreamQueryClient`           | Domain event stream queries   |
+| Factory Method | Creates | Description |
+|----------------|---------|-------------|
+| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | Snapshot queries with filters |
+| `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | Load by ID, version, or time |
+| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state |
+| `createEventStreamQueryClient()` | `EventStreamQueryClient` | Domain event stream queries |
 
 Source: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/queryClients.ts#L62-L214)
 
@@ -337,11 +330,7 @@ import {
 const activeCarts = filter.and(
   filter.isIn('state.status', 'ACTIVE', 'PENDING'),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
-  filter.contains(
-    'state.ownerName',
-    'ahoowang',
-    StringComparison.CASE_INSENSITIVE,
-  ),
+  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
 );
 
 const request = { filter: activeCarts, limit: 100 };
@@ -357,16 +346,16 @@ const yesterday = filter.yesterday('state.createdAt', {
 });
 ```
 
-| Category       | `filter` builders                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Notes                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Logical        | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)`                                                                                                                                                                                                                                                                                                                                                                                                               | Logical builders require one or more operands.                                                                                                                                                                                   |
-| Metadata       | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)`                                                                                                                                                                                                                                                                                                                                        | Scope a root snapshot by Wow metadata.                                                                                                                                                                                           |
-| Comparison     | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)`                                                                                                                                                                                                                                                                                                           | Values are JSON scalar values; equality also accepts `null` and arrays.                                                                                                                                                          |
-| String         | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)`                                                                                                                                                                                                                                                                                                                                                                                              | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`.                                                                                                                                                                |
-| Collection     | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)`                                                                                                                                                                                                                                                                                                                                                                                         | Collection builders require at least one value.                                                                                                                                                                                  |
-| Presence       | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`                                                                                                                                                                                                                                                                                                                                                                                   | Field presence builders.                                                                                                                                                                                                         |
-| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)`                                                                                                                                                                                                                                                                                                                                                                                               | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; `SearchFilterOptions` accepts `fields` and `mode` (`SearchMode.TERMS` by default); element predicates cannot contain root metadata, deletion, or search filters. |
-| Relative time  | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId`, `datePattern`, and `timeUnit` (`TimeUnit.MILLISECONDS` by default); `days` must be a positive JVM `Int`.                                                                                         |
+| Category | `filter` builders | Notes |
+|----------|-------------------|-------|
+| Logical | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)` | Logical builders require one or more operands. |
+| Metadata | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | Scope a root snapshot by Wow metadata. |
+| Comparison | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | Values are JSON scalar values; equality also accepts `null` and arrays. |
+| String | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`. |
+| Collection | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | Collection builders require at least one value. |
+| Presence | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | Field presence builders. |
+| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)` | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; `SearchFilterOptions` accepts `fields` and `mode` (`SearchMode.TERMS` by default); element predicates cannot contain root metadata, deletion, or search filters. |
+| Relative time | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId`, `datePattern`, and `timeUnit` (`TimeUnit.MILLISECONDS` by default); `days` must be a positive JVM `Int`. |
 
 Source: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
@@ -401,21 +390,12 @@ const list = {
 For large datasets, cursor-based pagination is more efficient than offset-based pagination. It avoids the performance degradation of deep offset queries by using a cursor ID to track position:
 
 ```typescript
-import {
-  cursorQuery,
-  CURSOR_ID_START,
-  filter,
-  SortDirection,
-} from '@ahoo-wang/fetcher-wow';
+import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
 
 // First page — start from the beginning
 const firstPage = cursorQuery({
-  query: {
-    filter: filter.matchAll(),
-    limit: 50,
-    projection: { include: ['id', 'name'] },
-  },
-  cursorId: CURSOR_ID_START, // '~' — start from the beginning
+  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
+  cursorId: CURSOR_ID_START,  // '~' — start from the beginning
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -423,7 +403,7 @@ const firstPage = cursorQuery({
 // Subsequent pages — use the last item's cursor ID from the previous result
 const nextPage = cursorQuery({
   query: { filter: filter.matchAll(), limit: 50 },
-  cursorId: lastItemId, // cursor ID from the previous page
+  cursorId: lastItemId,  // cursor ID from the previous page
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -489,34 +469,34 @@ Source: [packages/wow/src/index.ts](https://github.com/Ahoo-Wang/fetcher/blob/ma
 
 ## Key Exports
 
-| Export                                                                                                                                                      | Module            | Description                                      |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------------------------------------------ |
-| `CommandClient`                                                                                                                                             | `command/`        | Decorator-based command sending client           |
-| `CommandRequest`                                                                                                                                            | `command/`        | Typed command request with headers               |
-| `CommandResult`                                                                                                                                             | `command/`        | Command execution result                         |
-| `CommandResultEventStream`                                                                                                                                  | `command/`        | SSE stream of command results                    |
-| `CommandBody<C>`                                                                                                                                            | `command/`        | Command body wrapper type                        |
-| `CommandHeaders`                                                                                                                                            | `command/`        | Header name constants                            |
-| `QueryClientFactory`                                                                                                                                        | `query/`          | Factory for creating all query clients           |
-| `QueryClientOptions`                                                                                                                                        | `query/`          | Configuration for query clients                  |
-| `SnapshotQueryClient`                                                                                                                                       | `query/snapshot/` | Snapshot query operations                        |
-| `EventStreamQueryClient`                                                                                                                                    | `query/event/`    | Domain event stream queries                      |
-| `LoadStateAggregateClient`                                                                                                                                  | `query/state/`    | Load aggregate state by ID/version/time          |
-| `LoadOwnerStateAggregateClient`                                                                                                                             | `query/state/`    | Load owner's aggregate state                     |
-| `FilterExpression`                                                                                                                                          | `query/`          | Typed query-filter union                         |
-| `filter`                                                                                                                                                    | `query/`          | `FilterExpression` builders for new queries      |
-| `SearchMode`, `TimeUnit`                                                                                                                                    | `query/`          | Search and relative-time option enums            |
-| `AggregationQuery`                                                                                                                                          | `query/`          | Typed snapshot aggregation request               |
-| `aggregation`                                                                                                                                               | `query/`          | Aggregation query builders                       |
-| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/`          | Aggregation schema enums                         |
-| `SnapshotQueryClient.aggregate()`                                                                                                                           | `query/snapshot/` | Run an aggregation and return result rows        |
-| `SnapshotQueryClient.aggregateStream()`                                                                                                                     | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
-| `Condition`, `all()`, `and(...)`, `Operator`                                                                                                                | `query/`          | Deprecated compatibility API                     |
-| `listQuery()`                                                                                                                                               | `query/`          | Create a list query                              |
-| `pagedQuery()`                                                                                                                                              | `query/`          | Create a paged query                             |
-| `singleQuery()`                                                                                                                                             | `query/`          | Create a single query                            |
-| `FieldSort`                                                                                                                                                 | `query/`          | Sort specification                               |
-| `ResourceAttributionPathSpec`                                                                                                                               | `types/`          | Path spec for tenant/owner scoping               |
+| Export | Module | Description |
+|--------|--------|-------------|
+| `CommandClient` | `command/` | Decorator-based command sending client |
+| `CommandRequest` | `command/` | Typed command request with headers |
+| `CommandResult` | `command/` | Command execution result |
+| `CommandResultEventStream` | `command/` | SSE stream of command results |
+| `CommandBody<C>` | `command/` | Command body wrapper type |
+| `CommandHeaders` | `command/` | Header name constants |
+| `QueryClientFactory` | `query/` | Factory for creating all query clients |
+| `QueryClientOptions` | `query/` | Configuration for query clients |
+| `SnapshotQueryClient` | `query/snapshot/` | Snapshot query operations |
+| `EventStreamQueryClient` | `query/event/` | Domain event stream queries |
+| `LoadStateAggregateClient` | `query/state/` | Load aggregate state by ID/version/time |
+| `LoadOwnerStateAggregateClient` | `query/state/` | Load owner's aggregate state |
+| `FilterExpression` | `query/` | Typed query-filter union |
+| `filter` | `query/` | `FilterExpression` builders for new queries |
+| `SearchMode`, `TimeUnit` | `query/` | Search and relative-time option enums |
+| `AggregationQuery` | `query/` | Typed snapshot aggregation request |
+| `aggregation` | `query/` | Aggregation query builders |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/` | Aggregation schema enums |
+| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | Run an aggregation and return result rows |
+| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
+| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | Deprecated compatibility API |
+| `listQuery()` | `query/` | Create a list query |
+| `pagedQuery()` | `query/` | Create a paged query |
+| `singleQuery()` | `query/` | Create a single query |
+| `FieldSort` | `query/` | Sort specification |
+| `ResourceAttributionPathSpec` | `types/` | Path spec for tenant/owner scoping |
 
 ## Generated Clients
 

--- a/wiki/packages/wow.md
+++ b/wiki/packages/wow.md
@@ -1,6 +1,6 @@
 ---
-title: "@ahoo-wang/fetcher-wow"
-description: "Wow framework integration for Fetcher providing DDD + Event Sourcing + CQRS support with typed command clients, snapshot query clients, event stream queries, and aggregate root interaction patterns."
+title: '@ahoo-wang/fetcher-wow'
+description: 'Wow framework integration for Fetcher providing DDD + Event Sourcing + CQRS support with typed command clients, snapshot query clients, event stream queries, and aggregate root interaction patterns.'
 ---
 
 # @ahoo-wang/fetcher-wow
@@ -110,18 +110,18 @@ Commands are wrapped in a `CommandRequest` that supports:
 
 ### Command Headers
 
-| Header | Constant | Description |
-|--------|----------|-------------|
-| `Command-Tenant-Id` | `CommandHeaders.TENANT_ID` | Tenant identifier |
-| `Command-Owner-Id` | `CommandHeaders.OWNER_ID` | Owner identifier |
-| `Command-Space-Id` | `CommandHeaders.SPACE_ID` | Space identifier |
-| `Command-Aggregate-Id` | `CommandHeaders.AGGREGATE_ID` | Aggregate instance ID |
+| Header                      | Constant                           | Description                |
+| --------------------------- | ---------------------------------- | -------------------------- |
+| `Command-Tenant-Id`         | `CommandHeaders.TENANT_ID`         | Tenant identifier          |
+| `Command-Owner-Id`          | `CommandHeaders.OWNER_ID`          | Owner identifier           |
+| `Command-Space-Id`          | `CommandHeaders.SPACE_ID`          | Space identifier           |
+| `Command-Aggregate-Id`      | `CommandHeaders.AGGREGATE_ID`      | Aggregate instance ID      |
 | `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | Expected aggregate version |
-| `Command-Wait-Stage` | `CommandHeaders.WAIT_STAGE` | Wait processing stage |
-| `Command-Wait-Timeout` | `CommandHeaders.WAIT_TIME_OUT` | Wait timeout duration |
-| `Command-Wait-Context` | `CommandHeaders.WAIT_CONTEXT` | Wait processing context |
-| `Command-Request-Id` | `CommandHeaders.REQUEST_ID` | Request correlation ID |
-| `Command-Local-First` | `CommandHeaders.LOCAL_FIRST` | Execute locally first |
+| `Command-Wait-Stage`        | `CommandHeaders.WAIT_STAGE`        | Wait processing stage      |
+| `Command-Wait-Timeout`      | `CommandHeaders.WAIT_TIME_OUT`     | Wait timeout duration      |
+| `Command-Wait-Context`      | `CommandHeaders.WAIT_CONTEXT`      | Wait processing context    |
+| `Command-Request-Id`        | `CommandHeaders.REQUEST_ID`        | Request correlation ID     |
+| `Command-Local-First`       | `CommandHeaders.LOCAL_FIRST`       | Execute locally first      |
 
 Source: [packages/wow/src/command/commandHeaders.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/commandHeaders.ts)
 
@@ -164,14 +164,14 @@ Source: [packages/wow/src/command/commandResult.ts:74-110](https://github.com/Ah
 
 The `CommandStage` enum defines the processing stages at which a command's wait-strategy can signal completion. It is used as the value of the `Command-Wait-Stage` header and the `CommandResult.stage` field:
 
-| Stage | Value | Completion Signal |
-|-------|-------|-------------------|
-| `SENT` | `'SENT'` | Command published to the command bus/queue |
-| `PROCESSED` | `'PROCESSED'` | Command processed by the aggregate root |
-| `SNAPSHOT` | `'SNAPSHOT'` | Snapshot generated (aggregate state materialized) |
-| `PROJECTED` | `'PROJECTED'` | Events projected to read models |
-| `EVENT_HANDLED` | `'EVENT_HANDLED'` | Events processed by event handlers |
-| `SAGA_HANDLED` | `'SAGA_HANDLED'` | Events processed by Saga processes |
+| Stage           | Value             | Completion Signal                                 |
+| --------------- | ----------------- | ------------------------------------------------- |
+| `SENT`          | `'SENT'`          | Command published to the command bus/queue        |
+| `PROCESSED`     | `'PROCESSED'`     | Command processed by the aggregate root           |
+| `SNAPSHOT`      | `'SNAPSHOT'`      | Snapshot generated (aggregate state materialized) |
+| `PROJECTED`     | `'PROJECTED'`     | Events projected to read models                   |
+| `EVENT_HANDLED` | `'EVENT_HANDLED'` | Events processed by event handlers                |
+| `SAGA_HANDLED`  | `'SAGA_HANDLED'`  | Events processed by Saga processes                |
 
 Source: [packages/wow/src/command/types.ts:54-84](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/types.ts#L54-L84)
 
@@ -231,23 +231,23 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 #### SnapshotQueryClient Methods
 
-| Method | Endpoint | Returns | Description |
-|--------|----------|---------|-------------|
-| `count(filter)` | `/snapshot/count` | `Promise<number>` | Count matching aggregates |
-| `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | List snapshots |
-| `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream |
-| `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | List state only |
-| `listStateStream(listQuery)` | `/snapshot/list/state` | `Promise<ReadableStream<JsonServerSentEvent<S>>>` | State as SSE stream |
-| `paged(pagedQuery)` | `/snapshot/paged` | `Promise<PagedList<MaterializedSnapshot<S>>>` | Paginated snapshots |
-| `pagedState(pagedQuery)` | `/snapshot/paged/state` | `Promise<PagedList<S>>` | Paginated state |
-| `single(singleQuery)` | `/snapshot/single` | `Promise<MaterializedSnapshot<S>>` | Single snapshot |
-| `singleState(singleQuery)` | `/snapshot/single/state` | `Promise<S>` | Single state |
-| `getById(id)` | -- | `Promise<MaterializedSnapshot<S>>` | Get by aggregate ID |
-| `getStateById(id)` | -- | `Promise<S>` | Get state by ID |
-| `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | Get multiple by IDs |
-| `getStateByIds(ids)` | -- | `Promise<S[]>` | Get multiple states |
-| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | Aggregate snapshots |
-| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | Aggregate snapshots as SSE |
+| Method                       | Endpoint                 | Returns                                                                 | Description                |
+| ---------------------------- | ------------------------ | ----------------------------------------------------------------------- | -------------------------- |
+| `count(filter)`              | `/snapshot/count`        | `Promise<number>`                                                       | Count matching aggregates  |
+| `list(listQuery)`            | `/snapshot/list`         | `Promise<MaterializedSnapshot<S>[]>`                                    | List snapshots             |
+| `listStream(listQuery)`      | `/snapshot/list`         | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream         |
+| `listState(listQuery)`       | `/snapshot/list/state`   | `Promise<S[]>`                                                          | List state only            |
+| `listStateStream(listQuery)` | `/snapshot/list/state`   | `Promise<ReadableStream<JsonServerSentEvent<S>>>`                       | State as SSE stream        |
+| `paged(pagedQuery)`          | `/snapshot/paged`        | `Promise<PagedList<MaterializedSnapshot<S>>>`                           | Paginated snapshots        |
+| `pagedState(pagedQuery)`     | `/snapshot/paged/state`  | `Promise<PagedList<S>>`                                                 | Paginated state            |
+| `single(singleQuery)`        | `/snapshot/single`       | `Promise<MaterializedSnapshot<S>>`                                      | Single snapshot            |
+| `singleState(singleQuery)`   | `/snapshot/single/state` | `Promise<S>`                                                            | Single state               |
+| `getById(id)`                | --                       | `Promise<MaterializedSnapshot<S>>`                                      | Get by aggregate ID        |
+| `getStateById(id)`           | --                       | `Promise<S>`                                                            | Get state by ID            |
+| `getByIds(ids)`              | --                       | `Promise<MaterializedSnapshot<S>[]>`                                    | Get multiple by IDs        |
+| `getStateByIds(ids)`         | --                       | `Promise<S[]>`                                                          | Get multiple states        |
+| `aggregate(query)`           | `/snapshot/aggregation`  | `Promise<Row[]>`                                                        | Aggregate snapshots        |
+| `aggregateStream(query)`     | `/snapshot/aggregation`  | `Promise<ReadableStream<JsonServerSentEvent<Row>>>`                     | Aggregate snapshots as SSE |
 
 For compatibility with existing implementations, `SnapshotQueryApi` declares
 `aggregate?` and `aggregateStream?` as optional. `SnapshotQueryClient`
@@ -259,22 +259,28 @@ Source: [packages/wow/src/query/snapshot/snapshotQueryClient.ts:119-516](https:/
 
 ```typescript
 import {
-  AggregationFunction, AggregationGroupType, AggregationMetricType,
-  type AggregationQuery, SortDirection, filter,
+  aggregation,
+  filter,
+  type AggregationQuery,
 } from '@ahoo-wang/fetcher-wow';
 
-type ProductSummary = { product: string; itemCount: number; totalQuantity: number };
+type CartFields = 'state.status' | 'state.items';
+type ItemFields = 'productId' | 'price' | 'quantity';
+type ProductSummary = { product: string; itemCount: number; revenue: number };
 
-const query: AggregationQuery = {
+const revenue = aggregation.multiply(
+  aggregation.field<ItemFields>('price'),
+  aggregation.field<ItemFields>('quantity'),
+);
+
+const query: AggregationQuery<CartFields, ItemFields> = {
   filter: filter.eq('state.status', 'COMPLETED'),
-  elements: [{ path: 'state.items' }],
-  groupBy: [{ type: AggregationGroupType.TERMS, field: 'productId', alias: 'product' }],
+  elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
+  groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
-    { type: AggregationMetricType.NUMERIC, function: AggregationFunction.SUM, expression: { field: 'quantity' }, alias: 'totalQuantity' },
+    aggregation.count('itemCount'),
+    aggregation.sum(revenue, 'revenue'),
   ],
-  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
-  limit: 10,
 };
 
 const summaries = await client.aggregate<ProductSummary>(query);
@@ -286,7 +292,10 @@ const summaryStream = await client.aggregateStream<ProductSummary>(query);
 A factory that creates all query clients for a given aggregate, pre-configured with the correct base path:
 
 ```typescript
-import { QueryClientFactory, ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow';
+import {
+  QueryClientFactory,
+  ResourceAttributionPathSpec,
+} from '@ahoo-wang/fetcher-wow';
 
 const factory = new QueryClientFactory<CartState, CartFields, CartDomainEvent>({
   contextAlias: 'example',
@@ -301,12 +310,12 @@ const ownerStateClient = factory.createOwnerLoadStateAggregateClient();
 const eventClient = factory.createEventStreamQueryClient();
 ```
 
-| Factory Method | Creates | Description |
-|----------------|---------|-------------|
-| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | Snapshot queries with filters |
-| `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | Load by ID, version, or time |
-| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state |
-| `createEventStreamQueryClient()` | `EventStreamQueryClient` | Domain event stream queries |
+| Factory Method                          | Creates                            | Description                   |
+| --------------------------------------- | ---------------------------------- | ----------------------------- |
+| `createSnapshotQueryClient()`           | `SnapshotQueryClient<S, FIELDS>`   | Snapshot queries with filters |
+| `createLoadStateAggregateClient()`      | `LoadStateAggregateClient<S>`      | Load by ID, version, or time  |
+| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state  |
+| `createEventStreamQueryClient()`        | `EventStreamQueryClient`           | Domain event stream queries   |
 
 Source: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/queryClients.ts#L62-L214)
 
@@ -318,27 +327,46 @@ Use the `filter` builder for new queries. It creates typed
 `FilterExpression` values that are placed in a request's `filter` property.
 
 ```typescript
-import { filter, StringComparison } from '@ahoo-wang/fetcher-wow';
+import {
+  filter,
+  SearchMode,
+  StringComparison,
+  TimeUnit,
+} from '@ahoo-wang/fetcher-wow';
 
 const activeCarts = filter.and(
   filter.isIn('state.status', 'ACTIVE', 'PENDING'),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
-  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
+  filter.contains(
+    'state.ownerName',
+    'ahoowang',
+    StringComparison.CASE_INSENSITIVE,
+  ),
 );
 
 const request = { filter: activeCarts, limit: 100 };
+
+const fullText = filter.search('event sourcing', {
+  mode: SearchMode.PHRASE,
+  fields: ['state.title', 'state.description'],
+});
+
+const yesterday = filter.yesterday('state.createdAt', {
+  zoneId: 'Asia/Shanghai',
+  timeUnit: TimeUnit.MILLISECONDS,
+});
 ```
 
-| Category | `filter` builders | Notes |
-|----------|-------------------|-------|
-| Logical | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)` | Logical builders require one or more operands. |
-| Metadata | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | Scope a root snapshot by Wow metadata. |
-| Comparison | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | Values are JSON scalar values; equality also accepts `null` and arrays. |
-| String | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`. |
-| Collection | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | Collection builders require at least one value. |
-| Presence | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | Field presence builders. |
-| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, ...fields)` | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; element predicates cannot contain root metadata, deletion, or search filters. |
-| Relative time | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId` and `datePattern`; `days` must be a positive JVM `Int`. |
+| Category       | `filter` builders                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Notes                                                                                                                                                                                                                            |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Logical        | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)`                                                                                                                                                                                                                                                                                                                                                                                                               | Logical builders require one or more operands.                                                                                                                                                                                   |
+| Metadata       | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)`                                                                                                                                                                                                                                                                                                                                        | Scope a root snapshot by Wow metadata.                                                                                                                                                                                           |
+| Comparison     | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)`                                                                                                                                                                                                                                                                                                           | Values are JSON scalar values; equality also accepts `null` and arrays.                                                                                                                                                          |
+| String         | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)`                                                                                                                                                                                                                                                                                                                                                                                              | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`.                                                                                                                                                                |
+| Collection     | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)`                                                                                                                                                                                                                                                                                                                                                                                         | Collection builders require at least one value.                                                                                                                                                                                  |
+| Presence       | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`                                                                                                                                                                                                                                                                                                                                                                                   | Field presence builders.                                                                                                                                                                                                         |
+| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)`                                                                                                                                                                                                                                                                                                                                                                                               | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; `SearchFilterOptions` accepts `fields` and `mode` (`SearchMode.TERMS` by default); element predicates cannot contain root metadata, deletion, or search filters. |
+| Relative time  | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId`, `datePattern`, and `timeUnit` (`TimeUnit.MILLISECONDS` by default); `days` must be a positive JVM `Int`.                                                                                         |
 
 Source: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
@@ -373,12 +401,21 @@ const list = {
 For large datasets, cursor-based pagination is more efficient than offset-based pagination. It avoids the performance degradation of deep offset queries by using a cursor ID to track position:
 
 ```typescript
-import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
+import {
+  cursorQuery,
+  CURSOR_ID_START,
+  filter,
+  SortDirection,
+} from '@ahoo-wang/fetcher-wow';
 
 // First page — start from the beginning
 const firstPage = cursorQuery({
-  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
-  cursorId: CURSOR_ID_START,  // '~' — start from the beginning
+  query: {
+    filter: filter.matchAll(),
+    limit: 50,
+    projection: { include: ['id', 'name'] },
+  },
+  cursorId: CURSOR_ID_START, // '~' — start from the beginning
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -386,7 +423,7 @@ const firstPage = cursorQuery({
 // Subsequent pages — use the last item's cursor ID from the previous result
 const nextPage = cursorQuery({
   query: { filter: filter.matchAll(), limit: 50 },
-  cursorId: lastItemId,  // cursor ID from the previous page
+  cursorId: lastItemId, // cursor ID from the previous page
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -452,32 +489,34 @@ Source: [packages/wow/src/index.ts](https://github.com/Ahoo-Wang/fetcher/blob/ma
 
 ## Key Exports
 
-| Export | Module | Description |
-|--------|--------|-------------|
-| `CommandClient` | `command/` | Decorator-based command sending client |
-| `CommandRequest` | `command/` | Typed command request with headers |
-| `CommandResult` | `command/` | Command execution result |
-| `CommandResultEventStream` | `command/` | SSE stream of command results |
-| `CommandBody<C>` | `command/` | Command body wrapper type |
-| `CommandHeaders` | `command/` | Header name constants |
-| `QueryClientFactory` | `query/` | Factory for creating all query clients |
-| `QueryClientOptions` | `query/` | Configuration for query clients |
-| `SnapshotQueryClient` | `query/snapshot/` | Snapshot query operations |
-| `EventStreamQueryClient` | `query/event/` | Domain event stream queries |
-| `LoadStateAggregateClient` | `query/state/` | Load aggregate state by ID/version/time |
-| `LoadOwnerStateAggregateClient` | `query/state/` | Load owner's aggregate state |
-| `FilterExpression` | `query/` | Typed query-filter union |
-| `filter` | `query/` | `FilterExpression` builders for new queries |
-| `AggregationQuery` | `query/` | Typed snapshot aggregation request |
-| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationDateUnit`, `AggregationFunction` | `query/` | Aggregation schema enums |
-| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | Run an aggregation and return result rows |
-| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
-| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | Deprecated compatibility API |
-| `listQuery()` | `query/` | Create a list query |
-| `pagedQuery()` | `query/` | Create a paged query |
-| `singleQuery()` | `query/` | Create a single query |
-| `FieldSort` | `query/` | Sort specification |
-| `ResourceAttributionPathSpec` | `types/` | Path spec for tenant/owner scoping |
+| Export                                                                                                                                                      | Module            | Description                                      |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------------------------------------------ |
+| `CommandClient`                                                                                                                                             | `command/`        | Decorator-based command sending client           |
+| `CommandRequest`                                                                                                                                            | `command/`        | Typed command request with headers               |
+| `CommandResult`                                                                                                                                             | `command/`        | Command execution result                         |
+| `CommandResultEventStream`                                                                                                                                  | `command/`        | SSE stream of command results                    |
+| `CommandBody<C>`                                                                                                                                            | `command/`        | Command body wrapper type                        |
+| `CommandHeaders`                                                                                                                                            | `command/`        | Header name constants                            |
+| `QueryClientFactory`                                                                                                                                        | `query/`          | Factory for creating all query clients           |
+| `QueryClientOptions`                                                                                                                                        | `query/`          | Configuration for query clients                  |
+| `SnapshotQueryClient`                                                                                                                                       | `query/snapshot/` | Snapshot query operations                        |
+| `EventStreamQueryClient`                                                                                                                                    | `query/event/`    | Domain event stream queries                      |
+| `LoadStateAggregateClient`                                                                                                                                  | `query/state/`    | Load aggregate state by ID/version/time          |
+| `LoadOwnerStateAggregateClient`                                                                                                                             | `query/state/`    | Load owner's aggregate state                     |
+| `FilterExpression`                                                                                                                                          | `query/`          | Typed query-filter union                         |
+| `filter`                                                                                                                                                    | `query/`          | `FilterExpression` builders for new queries      |
+| `SearchMode`, `TimeUnit`                                                                                                                                    | `query/`          | Search and relative-time option enums            |
+| `AggregationQuery`                                                                                                                                          | `query/`          | Typed snapshot aggregation request               |
+| `aggregation`                                                                                                                                               | `query/`          | Aggregation query builders                       |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/`          | Aggregation schema enums                         |
+| `SnapshotQueryClient.aggregate()`                                                                                                                           | `query/snapshot/` | Run an aggregation and return result rows        |
+| `SnapshotQueryClient.aggregateStream()`                                                                                                                     | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
+| `Condition`, `all()`, `and(...)`, `Operator`                                                                                                                | `query/`          | Deprecated compatibility API                     |
+| `listQuery()`                                                                                                                                               | `query/`          | Create a list query                              |
+| `pagedQuery()`                                                                                                                                              | `query/`          | Create a paged query                             |
+| `singleQuery()`                                                                                                                                             | `query/`          | Create a single query                            |
+| `FieldSort`                                                                                                                                                 | `query/`          | Sort specification                               |
+| `ResourceAttributionPathSpec`                                                                                                                               | `types/`          | Path spec for tenant/owner scoping               |
 
 ## Generated Clients
 

--- a/wiki/zh/packages/wow.md
+++ b/wiki/zh/packages/wow.md
@@ -1,6 +1,6 @@
 ---
-title: "@ahoo-wang/fetcher-wow"
-description: "Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS 支持，包括类型化命令客户端、快照查询客户端、事件流查询和聚合根交互模式。"
+title: '@ahoo-wang/fetcher-wow'
+description: 'Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS 支持，包括类型化命令客户端、快照查询客户端、事件流查询和聚合根交互模式。'
 ---
 
 # @ahoo-wang/fetcher-wow
@@ -110,18 +110,18 @@ console.log('Command ID:', result.commandId);
 
 ### 命令头
 
-| 请求头 | 常量 | 描述 |
-|--------|----------|-------------|
-| `Command-Tenant-Id` | `CommandHeaders.TENANT_ID` | 租户标识符 |
-| `Command-Owner-Id` | `CommandHeaders.OWNER_ID` | 所有者标识符 |
-| `Command-Space-Id` | `CommandHeaders.SPACE_ID` | 空间标识符 |
-| `Command-Aggregate-Id` | `CommandHeaders.AGGREGATE_ID` | 聚合实例 ID |
-| `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | 预期聚合版本 |
-| `Command-Wait-Stage` | `CommandHeaders.WAIT_STAGE` | 等待处理阶段 |
-| `Command-Wait-Timeout` | `CommandHeaders.WAIT_TIME_OUT` | 等待超时时长 |
-| `Command-Wait-Context` | `CommandHeaders.WAIT_CONTEXT` | 等待处理上下文 |
-| `Command-Request-Id` | `CommandHeaders.REQUEST_ID` | 请求关联 ID |
-| `Command-Local-First` | `CommandHeaders.LOCAL_FIRST` | 优先本地执行 |
+| 请求头                      | 常量                               | 描述           |
+| --------------------------- | ---------------------------------- | -------------- |
+| `Command-Tenant-Id`         | `CommandHeaders.TENANT_ID`         | 租户标识符     |
+| `Command-Owner-Id`          | `CommandHeaders.OWNER_ID`          | 所有者标识符   |
+| `Command-Space-Id`          | `CommandHeaders.SPACE_ID`          | 空间标识符     |
+| `Command-Aggregate-Id`      | `CommandHeaders.AGGREGATE_ID`      | 聚合实例 ID    |
+| `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | 预期聚合版本   |
+| `Command-Wait-Stage`        | `CommandHeaders.WAIT_STAGE`        | 等待处理阶段   |
+| `Command-Wait-Timeout`      | `CommandHeaders.WAIT_TIME_OUT`     | 等待超时时长   |
+| `Command-Wait-Context`      | `CommandHeaders.WAIT_CONTEXT`      | 等待处理上下文 |
+| `Command-Request-Id`        | `CommandHeaders.REQUEST_ID`        | 请求关联 ID    |
+| `Command-Local-First`       | `CommandHeaders.LOCAL_FIRST`       | 优先本地执行   |
 
 来源: [packages/wow/src/command/commandHeaders.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/commandHeaders.ts)
 
@@ -164,14 +164,14 @@ classDiagram
 
 `CommandStage` 枚举定义了命令等待策略可以发出完成信号的处理阶段。它用作 `Command-Wait-Stage` 头的值和 `CommandResult.stage` 字段：
 
-| 阶段 | 值 | 完成信号 |
-|------|-----|---------|
-| `SENT` | `'SENT'` | 命令已发布到命令总线/队列 |
-| `PROCESSED` | `'PROCESSED'` | 命令已被聚合根处理 |
-| `SNAPSHOT` | `'SNAPSHOT'` | 已生成快照（聚合状态已物化） |
-| `PROJECTED` | `'PROJECTED'` | 事件已投射到读模型 |
-| `EVENT_HANDLED` | `'EVENT_HANDLED'` | 事件已被事件处理器处理 |
-| `SAGA_HANDLED` | `'SAGA_HANDLED'` | 事件已被 Saga 处理 |
+| 阶段            | 值                | 完成信号                     |
+| --------------- | ----------------- | ---------------------------- |
+| `SENT`          | `'SENT'`          | 命令已发布到命令总线/队列    |
+| `PROCESSED`     | `'PROCESSED'`     | 命令已被聚合根处理           |
+| `SNAPSHOT`      | `'SNAPSHOT'`      | 已生成快照（聚合状态已物化） |
+| `PROJECTED`     | `'PROJECTED'`     | 事件已投射到读模型           |
+| `EVENT_HANDLED` | `'EVENT_HANDLED'` | 事件已被事件处理器处理       |
+| `SAGA_HANDLED`  | `'SAGA_HANDLED'`  | 事件已被 Saga 处理           |
 
 源码: [packages/wow/src/command/types.ts:54-84](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/types.ts#L54-L84)
 
@@ -231,23 +231,23 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 #### SnapshotQueryClient 方法
 
-| 方法 | 端点 | 返回类型 | 描述 |
-|------|------|----------|------|
-| `count(filter)` | `/snapshot/count` | `Promise<number>` | 统计匹配的聚合数量 |
-| `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | 列表查询快照 |
-| `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
-| `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | 仅列出状态 |
-| `listStateStream(listQuery)` | `/snapshot/list/state` | `Promise<ReadableStream<JsonServerSentEvent<S>>>` | 以 SSE 流形式列出状态 |
-| `paged(pagedQuery)` | `/snapshot/paged` | `Promise<PagedList<MaterializedSnapshot<S>>>` | 分页查询快照 |
-| `pagedState(pagedQuery)` | `/snapshot/paged/state` | `Promise<PagedList<S>>` | 分页查询状态 |
-| `single(singleQuery)` | `/snapshot/single` | `Promise<MaterializedSnapshot<S>>` | 单个快照查询 |
-| `singleState(singleQuery)` | `/snapshot/single/state` | `Promise<S>` | 单个状态查询 |
-| `getById(id)` | -- | `Promise<MaterializedSnapshot<S>>` | 通过聚合 ID 获取 |
-| `getStateById(id)` | -- | `Promise<S>` | 通过 ID 获取状态 |
-| `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | 通过多个 ID 获取 |
-| `getStateByIds(ids)` | -- | `Promise<S[]>` | 通过多个 ID 获取状态 |
-| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | 聚合快照 |
-| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | 以 SSE 聚合快照 |
+| 方法                         | 端点                     | 返回类型                                                                | 描述                  |
+| ---------------------------- | ------------------------ | ----------------------------------------------------------------------- | --------------------- |
+| `count(filter)`              | `/snapshot/count`        | `Promise<number>`                                                       | 统计匹配的聚合数量    |
+| `list(listQuery)`            | `/snapshot/list`         | `Promise<MaterializedSnapshot<S>[]>`                                    | 列表查询快照          |
+| `listStream(listQuery)`      | `/snapshot/list`         | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
+| `listState(listQuery)`       | `/snapshot/list/state`   | `Promise<S[]>`                                                          | 仅列出状态            |
+| `listStateStream(listQuery)` | `/snapshot/list/state`   | `Promise<ReadableStream<JsonServerSentEvent<S>>>`                       | 以 SSE 流形式列出状态 |
+| `paged(pagedQuery)`          | `/snapshot/paged`        | `Promise<PagedList<MaterializedSnapshot<S>>>`                           | 分页查询快照          |
+| `pagedState(pagedQuery)`     | `/snapshot/paged/state`  | `Promise<PagedList<S>>`                                                 | 分页查询状态          |
+| `single(singleQuery)`        | `/snapshot/single`       | `Promise<MaterializedSnapshot<S>>`                                      | 单个快照查询          |
+| `singleState(singleQuery)`   | `/snapshot/single/state` | `Promise<S>`                                                            | 单个状态查询          |
+| `getById(id)`                | --                       | `Promise<MaterializedSnapshot<S>>`                                      | 通过聚合 ID 获取      |
+| `getStateById(id)`           | --                       | `Promise<S>`                                                            | 通过 ID 获取状态      |
+| `getByIds(ids)`              | --                       | `Promise<MaterializedSnapshot<S>[]>`                                    | 通过多个 ID 获取      |
+| `getStateByIds(ids)`         | --                       | `Promise<S[]>`                                                          | 通过多个 ID 获取状态  |
+| `aggregate(query)`           | `/snapshot/aggregation`  | `Promise<Row[]>`                                                        | 聚合快照              |
+| `aggregateStream(query)`     | `/snapshot/aggregation`  | `Promise<ReadableStream<JsonServerSentEvent<Row>>>`                     | 以 SSE 聚合快照       |
 
 为兼容既有实现，`SnapshotQueryApi` 将 `aggregate?` 和 `aggregateStream?`
 声明为可选方法；`SnapshotQueryClient` 将两者实现为必需方法。
@@ -258,22 +258,28 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 ```typescript
 import {
-  AggregationFunction, AggregationGroupType, AggregationMetricType,
-  type AggregationQuery, SortDirection, filter,
+  aggregation,
+  filter,
+  type AggregationQuery,
 } from '@ahoo-wang/fetcher-wow';
 
-type ProductSummary = { product: string; itemCount: number; totalQuantity: number };
+type CartFields = 'state.status' | 'state.items';
+type ItemFields = 'productId' | 'price' | 'quantity';
+type ProductSummary = { product: string; itemCount: number; revenue: number };
 
-const query: AggregationQuery = {
+const revenue = aggregation.multiply(
+  aggregation.field<ItemFields>('price'),
+  aggregation.field<ItemFields>('quantity'),
+);
+
+const query: AggregationQuery<CartFields, ItemFields> = {
   filter: filter.eq('state.status', 'COMPLETED'),
-  elements: [{ path: 'state.items' }],
-  groupBy: [{ type: AggregationGroupType.TERMS, field: 'productId', alias: 'product' }],
+  elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
+  groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
-    { type: AggregationMetricType.COUNT, alias: 'itemCount' },
-    { type: AggregationMetricType.NUMERIC, function: AggregationFunction.SUM, expression: { field: 'quantity' }, alias: 'totalQuantity' },
+    aggregation.count('itemCount'),
+    aggregation.sum(revenue, 'revenue'),
   ],
-  sort: [{ field: 'totalQuantity', direction: SortDirection.DESC }],
-  limit: 10,
 };
 
 const summaries = await client.aggregate<ProductSummary>(query);
@@ -285,7 +291,10 @@ const summaryStream = await client.aggregateStream<ProductSummary>(query);
 为给定聚合创建所有查询客户端的工厂，预配置了正确的基本路径：
 
 ```typescript
-import { QueryClientFactory, ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow';
+import {
+  QueryClientFactory,
+  ResourceAttributionPathSpec,
+} from '@ahoo-wang/fetcher-wow';
 
 const factory = new QueryClientFactory<CartState, CartFields, CartDomainEvent>({
   contextAlias: 'example',
@@ -300,12 +309,12 @@ const ownerStateClient = factory.createOwnerLoadStateAggregateClient();
 const eventClient = factory.createEventStreamQueryClient();
 ```
 
-| 工厂方法 | 创建的客户端 | 描述 |
-|----------|-------------|------|
-| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | 带筛选器的快照查询 |
-| `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | 通过 ID、版本或时间加载 |
-| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态 |
-| `createEventStreamQueryClient()` | `EventStreamQueryClient` | 领域事件流查询 |
+| 工厂方法                                | 创建的客户端                       | 描述                    |
+| --------------------------------------- | ---------------------------------- | ----------------------- |
+| `createSnapshotQueryClient()`           | `SnapshotQueryClient<S, FIELDS>`   | 带筛选器的快照查询      |
+| `createLoadStateAggregateClient()`      | `LoadStateAggregateClient<S>`      | 通过 ID、版本或时间加载 |
+| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态    |
+| `createEventStreamQueryClient()`        | `EventStreamQueryClient`           | 领域事件流查询          |
 
 来源: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/queryClients.ts#L62-L214)
 
@@ -316,27 +325,46 @@ const eventClient = factory.createEventStreamQueryClient();
 新查询应使用 `filter` 构建器。它创建类型化的 `FilterExpression` 值，并放入请求的 `filter` 属性。
 
 ```typescript
-import { filter, StringComparison } from '@ahoo-wang/fetcher-wow';
+import {
+  filter,
+  SearchMode,
+  StringComparison,
+  TimeUnit,
+} from '@ahoo-wang/fetcher-wow';
 
 const activeCarts = filter.and(
   filter.isIn('state.status', 'ACTIVE', 'PENDING'),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
-  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
+  filter.contains(
+    'state.ownerName',
+    'ahoowang',
+    StringComparison.CASE_INSENSITIVE,
+  ),
 );
 
 const request = { filter: activeCarts, limit: 100 };
+
+const fullText = filter.search('event sourcing', {
+  mode: SearchMode.PHRASE,
+  fields: ['state.title', 'state.description'],
+});
+
+const yesterday = filter.yesterday('state.createdAt', {
+  zoneId: 'Asia/Shanghai',
+  timeUnit: TimeUnit.MILLISECONDS,
+});
 ```
 
-| 分类 | `filter` 构建器 | 说明 |
-|------|-----------------|------|
-| 逻辑 | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)` | 逻辑构建器至少需要一个操作数。 |
-| 元数据 | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | 按 Wow 元数据约束根快照范围。 |
-| 比较 | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | 值为 JSON 标量；相等比较也接受 `null` 和数组。 |
-| 字符串 | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。 |
-| 集合 | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | 集合构建器至少需要一个值。 |
-| 存在性 | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | 字段存在性构建器。 |
-| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, ...fields)` | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；元素谓词不能包含根元数据、删除或搜索筛选器。 |
-| 相对时间 | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId` 和 `datePattern`；`days` 必须为正的 JVM `Int`。 |
+| 分类          | `filter` 构建器                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 说明                                                                                                                                                                               |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 逻辑          | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)`                                                                                                                                                                                                                                                                                                                                                                                                               | 逻辑构建器至少需要一个操作数。                                                                                                                                                     |
+| 元数据        | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)`                                                                                                                                                                                                                                                                                                                                        | 按 Wow 元数据约束根快照范围。                                                                                                                                                      |
+| 比较          | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)`                                                                                                                                                                                                                                                                                                           | 值为 JSON 标量；相等比较也接受 `null` 和数组。                                                                                                                                     |
+| 字符串        | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)`                                                                                                                                                                                                                                                                                                                                                                                              | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。                                                                                                                      |
+| 集合          | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)`                                                                                                                                                                                                                                                                                                                                                                                         | 集合构建器至少需要一个值。                                                                                                                                                         |
+| 存在性        | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`                                                                                                                                                                                                                                                                                                                                                                                   | 字段存在性构建器。                                                                                                                                                                 |
+| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)`                                                                                                                                                                                                                                                                                                                                                                                               | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；`SearchFilterOptions` 接受 `fields` 和 `mode`（默认 `SearchMode.TERMS`）；元素谓词不能包含根元数据、删除或搜索筛选器。 |
+| 相对时间      | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId`、`datePattern` 和 `timeUnit`（默认 `TimeUnit.MILLISECONDS`）；`days` 必须为正的 JVM `Int`。                                                              |
 
 来源: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
@@ -368,12 +396,21 @@ const list = {
 对于大型数据集，基于游标的分页比基于偏移量的分页更高效。它通过使用游标 ID 跟踪位置，避免了深偏移查询的性能退化：
 
 ```typescript
-import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
+import {
+  cursorQuery,
+  CURSOR_ID_START,
+  filter,
+  SortDirection,
+} from '@ahoo-wang/fetcher-wow';
 
 // 第一页——从头开始
 const firstPage = cursorQuery({
-  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
-  cursorId: CURSOR_ID_START,  // '~'——从头开始
+  query: {
+    filter: filter.matchAll(),
+    limit: 50,
+    projection: { include: ['id', 'name'] },
+  },
+  cursorId: CURSOR_ID_START, // '~'——从头开始
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -381,7 +418,7 @@ const firstPage = cursorQuery({
 // 后续页——使用前一个结果的最后一条记录的游标 ID
 const nextPage = cursorQuery({
   query: { filter: filter.matchAll(), limit: 50 },
-  cursorId: lastItemId,  // 上一页的游标 ID
+  cursorId: lastItemId, // 上一页的游标 ID
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -447,32 +484,34 @@ graph TB
 
 ## 主要导出
 
-| 导出 | 模块 | 描述 |
-|------|------|------|
-| `CommandClient` | `command/` | 基于装饰器的命令发送客户端 |
-| `CommandRequest` | `command/` | 带请求头的类型化命令请求 |
-| `CommandResult` | `command/` | 命令执行结果 |
-| `CommandResultEventStream` | `command/` | 命令结果的 SSE 流 |
-| `CommandBody<C>` | `command/` | 命令体包装类型 |
-| `CommandHeaders` | `command/` | 请求头名称常量 |
-| `QueryClientFactory` | `query/` | 创建所有查询客户端的工厂 |
-| `QueryClientOptions` | `query/` | 查询客户端配置 |
-| `SnapshotQueryClient` | `query/snapshot/` | 快照查询操作 |
-| `EventStreamQueryClient` | `query/event/` | 领域事件流查询 |
-| `LoadStateAggregateClient` | `query/state/` | 通过 ID/版本/时间加载聚合状态 |
-| `LoadOwnerStateAggregateClient` | `query/state/` | 加载所有者的聚合状态 |
-| `FilterExpression` | `query/` | 类型化查询筛选器联合类型 |
-| `filter` | `query/` | 用于新查询的 `FilterExpression` 构建器 |
-| `AggregationQuery` | `query/` | 类型化快照聚合请求 |
-| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationDateUnit`, `AggregationFunction` | `query/` | 聚合结构枚举 |
-| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | 执行聚合并返回结果行 |
-| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行 |
-| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | 已弃用的兼容 API |
-| `listQuery()` | `query/` | 创建列表查询 |
-| `pagedQuery()` | `query/` | 创建分页查询 |
-| `singleQuery()` | `query/` | 创建单条查询 |
-| `FieldSort` | `query/` | 排序规范 |
-| `ResourceAttributionPathSpec` | `types/` | 租户/所有者范围的路径规范 |
+| 导出                                                                                                                                                        | 模块              | 描述                                   |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | -------------------------------------- |
+| `CommandClient`                                                                                                                                             | `command/`        | 基于装饰器的命令发送客户端             |
+| `CommandRequest`                                                                                                                                            | `command/`        | 带请求头的类型化命令请求               |
+| `CommandResult`                                                                                                                                             | `command/`        | 命令执行结果                           |
+| `CommandResultEventStream`                                                                                                                                  | `command/`        | 命令结果的 SSE 流                      |
+| `CommandBody<C>`                                                                                                                                            | `command/`        | 命令体包装类型                         |
+| `CommandHeaders`                                                                                                                                            | `command/`        | 请求头名称常量                         |
+| `QueryClientFactory`                                                                                                                                        | `query/`          | 创建所有查询客户端的工厂               |
+| `QueryClientOptions`                                                                                                                                        | `query/`          | 查询客户端配置                         |
+| `SnapshotQueryClient`                                                                                                                                       | `query/snapshot/` | 快照查询操作                           |
+| `EventStreamQueryClient`                                                                                                                                    | `query/event/`    | 领域事件流查询                         |
+| `LoadStateAggregateClient`                                                                                                                                  | `query/state/`    | 通过 ID/版本/时间加载聚合状态          |
+| `LoadOwnerStateAggregateClient`                                                                                                                             | `query/state/`    | 加载所有者的聚合状态                   |
+| `FilterExpression`                                                                                                                                          | `query/`          | 类型化查询筛选器联合类型               |
+| `filter`                                                                                                                                                    | `query/`          | 用于新查询的 `FilterExpression` 构建器 |
+| `SearchMode`, `TimeUnit`                                                                                                                                    | `query/`          | 搜索与相对时间选项枚举                 |
+| `AggregationQuery`                                                                                                                                          | `query/`          | 类型化快照聚合请求                     |
+| `aggregation`                                                                                                                                               | `query/`          | 聚合查询构建器                         |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/`          | 聚合结构枚举                           |
+| `SnapshotQueryClient.aggregate()`                                                                                                                           | `query/snapshot/` | 执行聚合并返回结果行                   |
+| `SnapshotQueryClient.aggregateStream()`                                                                                                                     | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行          |
+| `Condition`, `all()`, `and(...)`, `Operator`                                                                                                                | `query/`          | 已弃用的兼容 API                       |
+| `listQuery()`                                                                                                                                               | `query/`          | 创建列表查询                           |
+| `pagedQuery()`                                                                                                                                              | `query/`          | 创建分页查询                           |
+| `singleQuery()`                                                                                                                                             | `query/`          | 创建单条查询                           |
+| `FieldSort`                                                                                                                                                 | `query/`          | 排序规范                               |
+| `ResourceAttributionPathSpec`                                                                                                                               | `types/`          | 租户/所有者范围的路径规范              |
 
 ## 生成的客户端
 

--- a/wiki/zh/packages/wow.md
+++ b/wiki/zh/packages/wow.md
@@ -1,6 +1,6 @@
 ---
-title: '@ahoo-wang/fetcher-wow'
-description: 'Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS 支持，包括类型化命令客户端、快照查询客户端、事件流查询和聚合根交互模式。'
+title: "@ahoo-wang/fetcher-wow"
+description: "Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS 支持，包括类型化命令客户端、快照查询客户端、事件流查询和聚合根交互模式。"
 ---
 
 # @ahoo-wang/fetcher-wow
@@ -110,18 +110,18 @@ console.log('Command ID:', result.commandId);
 
 ### 命令头
 
-| 请求头                      | 常量                               | 描述           |
-| --------------------------- | ---------------------------------- | -------------- |
-| `Command-Tenant-Id`         | `CommandHeaders.TENANT_ID`         | 租户标识符     |
-| `Command-Owner-Id`          | `CommandHeaders.OWNER_ID`          | 所有者标识符   |
-| `Command-Space-Id`          | `CommandHeaders.SPACE_ID`          | 空间标识符     |
-| `Command-Aggregate-Id`      | `CommandHeaders.AGGREGATE_ID`      | 聚合实例 ID    |
-| `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | 预期聚合版本   |
-| `Command-Wait-Stage`        | `CommandHeaders.WAIT_STAGE`        | 等待处理阶段   |
-| `Command-Wait-Timeout`      | `CommandHeaders.WAIT_TIME_OUT`     | 等待超时时长   |
-| `Command-Wait-Context`      | `CommandHeaders.WAIT_CONTEXT`      | 等待处理上下文 |
-| `Command-Request-Id`        | `CommandHeaders.REQUEST_ID`        | 请求关联 ID    |
-| `Command-Local-First`       | `CommandHeaders.LOCAL_FIRST`       | 优先本地执行   |
+| 请求头 | 常量 | 描述 |
+|--------|----------|-------------|
+| `Command-Tenant-Id` | `CommandHeaders.TENANT_ID` | 租户标识符 |
+| `Command-Owner-Id` | `CommandHeaders.OWNER_ID` | 所有者标识符 |
+| `Command-Space-Id` | `CommandHeaders.SPACE_ID` | 空间标识符 |
+| `Command-Aggregate-Id` | `CommandHeaders.AGGREGATE_ID` | 聚合实例 ID |
+| `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | 预期聚合版本 |
+| `Command-Wait-Stage` | `CommandHeaders.WAIT_STAGE` | 等待处理阶段 |
+| `Command-Wait-Timeout` | `CommandHeaders.WAIT_TIME_OUT` | 等待超时时长 |
+| `Command-Wait-Context` | `CommandHeaders.WAIT_CONTEXT` | 等待处理上下文 |
+| `Command-Request-Id` | `CommandHeaders.REQUEST_ID` | 请求关联 ID |
+| `Command-Local-First` | `CommandHeaders.LOCAL_FIRST` | 优先本地执行 |
 
 来源: [packages/wow/src/command/commandHeaders.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/commandHeaders.ts)
 
@@ -164,14 +164,14 @@ classDiagram
 
 `CommandStage` 枚举定义了命令等待策略可以发出完成信号的处理阶段。它用作 `Command-Wait-Stage` 头的值和 `CommandResult.stage` 字段：
 
-| 阶段            | 值                | 完成信号                     |
-| --------------- | ----------------- | ---------------------------- |
-| `SENT`          | `'SENT'`          | 命令已发布到命令总线/队列    |
-| `PROCESSED`     | `'PROCESSED'`     | 命令已被聚合根处理           |
-| `SNAPSHOT`      | `'SNAPSHOT'`      | 已生成快照（聚合状态已物化） |
-| `PROJECTED`     | `'PROJECTED'`     | 事件已投射到读模型           |
-| `EVENT_HANDLED` | `'EVENT_HANDLED'` | 事件已被事件处理器处理       |
-| `SAGA_HANDLED`  | `'SAGA_HANDLED'`  | 事件已被 Saga 处理           |
+| 阶段 | 值 | 完成信号 |
+|------|-----|---------|
+| `SENT` | `'SENT'` | 命令已发布到命令总线/队列 |
+| `PROCESSED` | `'PROCESSED'` | 命令已被聚合根处理 |
+| `SNAPSHOT` | `'SNAPSHOT'` | 已生成快照（聚合状态已物化） |
+| `PROJECTED` | `'PROJECTED'` | 事件已投射到读模型 |
+| `EVENT_HANDLED` | `'EVENT_HANDLED'` | 事件已被事件处理器处理 |
+| `SAGA_HANDLED` | `'SAGA_HANDLED'` | 事件已被 Saga 处理 |
 
 源码: [packages/wow/src/command/types.ts:54-84](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/types.ts#L54-L84)
 
@@ -231,23 +231,23 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 #### SnapshotQueryClient 方法
 
-| 方法                         | 端点                     | 返回类型                                                                | 描述                  |
-| ---------------------------- | ------------------------ | ----------------------------------------------------------------------- | --------------------- |
-| `count(filter)`              | `/snapshot/count`        | `Promise<number>`                                                       | 统计匹配的聚合数量    |
-| `list(listQuery)`            | `/snapshot/list`         | `Promise<MaterializedSnapshot<S>[]>`                                    | 列表查询快照          |
-| `listStream(listQuery)`      | `/snapshot/list`         | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
-| `listState(listQuery)`       | `/snapshot/list/state`   | `Promise<S[]>`                                                          | 仅列出状态            |
-| `listStateStream(listQuery)` | `/snapshot/list/state`   | `Promise<ReadableStream<JsonServerSentEvent<S>>>`                       | 以 SSE 流形式列出状态 |
-| `paged(pagedQuery)`          | `/snapshot/paged`        | `Promise<PagedList<MaterializedSnapshot<S>>>`                           | 分页查询快照          |
-| `pagedState(pagedQuery)`     | `/snapshot/paged/state`  | `Promise<PagedList<S>>`                                                 | 分页查询状态          |
-| `single(singleQuery)`        | `/snapshot/single`       | `Promise<MaterializedSnapshot<S>>`                                      | 单个快照查询          |
-| `singleState(singleQuery)`   | `/snapshot/single/state` | `Promise<S>`                                                            | 单个状态查询          |
-| `getById(id)`                | --                       | `Promise<MaterializedSnapshot<S>>`                                      | 通过聚合 ID 获取      |
-| `getStateById(id)`           | --                       | `Promise<S>`                                                            | 通过 ID 获取状态      |
-| `getByIds(ids)`              | --                       | `Promise<MaterializedSnapshot<S>[]>`                                    | 通过多个 ID 获取      |
-| `getStateByIds(ids)`         | --                       | `Promise<S[]>`                                                          | 通过多个 ID 获取状态  |
-| `aggregate(query)`           | `/snapshot/aggregation`  | `Promise<Row[]>`                                                        | 聚合快照              |
-| `aggregateStream(query)`     | `/snapshot/aggregation`  | `Promise<ReadableStream<JsonServerSentEvent<Row>>>`                     | 以 SSE 聚合快照       |
+| 方法 | 端点 | 返回类型 | 描述 |
+|------|------|----------|------|
+| `count(filter)` | `/snapshot/count` | `Promise<number>` | 统计匹配的聚合数量 |
+| `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | 列表查询快照 |
+| `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
+| `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | 仅列出状态 |
+| `listStateStream(listQuery)` | `/snapshot/list/state` | `Promise<ReadableStream<JsonServerSentEvent<S>>>` | 以 SSE 流形式列出状态 |
+| `paged(pagedQuery)` | `/snapshot/paged` | `Promise<PagedList<MaterializedSnapshot<S>>>` | 分页查询快照 |
+| `pagedState(pagedQuery)` | `/snapshot/paged/state` | `Promise<PagedList<S>>` | 分页查询状态 |
+| `single(singleQuery)` | `/snapshot/single` | `Promise<MaterializedSnapshot<S>>` | 单个快照查询 |
+| `singleState(singleQuery)` | `/snapshot/single/state` | `Promise<S>` | 单个状态查询 |
+| `getById(id)` | -- | `Promise<MaterializedSnapshot<S>>` | 通过聚合 ID 获取 |
+| `getStateById(id)` | -- | `Promise<S>` | 通过 ID 获取状态 |
+| `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | 通过多个 ID 获取 |
+| `getStateByIds(ids)` | -- | `Promise<S[]>` | 通过多个 ID 获取状态 |
+| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | 聚合快照 |
+| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | 以 SSE 聚合快照 |
 
 为兼容既有实现，`SnapshotQueryApi` 将 `aggregate?` 和 `aggregateStream?`
 声明为可选方法；`SnapshotQueryClient` 将两者实现为必需方法。
@@ -257,11 +257,7 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 #### 快照聚合
 
 ```typescript
-import {
-  aggregation,
-  filter,
-  type AggregationQuery,
-} from '@ahoo-wang/fetcher-wow';
+import { aggregation, filter, type AggregationQuery } from '@ahoo-wang/fetcher-wow';
 
 type CartFields = 'state.status' | 'state.items';
 type ItemFields = 'productId' | 'price' | 'quantity';
@@ -291,10 +287,7 @@ const summaryStream = await client.aggregateStream<ProductSummary>(query);
 为给定聚合创建所有查询客户端的工厂，预配置了正确的基本路径：
 
 ```typescript
-import {
-  QueryClientFactory,
-  ResourceAttributionPathSpec,
-} from '@ahoo-wang/fetcher-wow';
+import { QueryClientFactory, ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow';
 
 const factory = new QueryClientFactory<CartState, CartFields, CartDomainEvent>({
   contextAlias: 'example',
@@ -309,12 +302,12 @@ const ownerStateClient = factory.createOwnerLoadStateAggregateClient();
 const eventClient = factory.createEventStreamQueryClient();
 ```
 
-| 工厂方法                                | 创建的客户端                       | 描述                    |
-| --------------------------------------- | ---------------------------------- | ----------------------- |
-| `createSnapshotQueryClient()`           | `SnapshotQueryClient<S, FIELDS>`   | 带筛选器的快照查询      |
-| `createLoadStateAggregateClient()`      | `LoadStateAggregateClient<S>`      | 通过 ID、版本或时间加载 |
-| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态    |
-| `createEventStreamQueryClient()`        | `EventStreamQueryClient`           | 领域事件流查询          |
+| 工厂方法 | 创建的客户端 | 描述 |
+|----------|-------------|------|
+| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | 带筛选器的快照查询 |
+| `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | 通过 ID、版本或时间加载 |
+| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态 |
+| `createEventStreamQueryClient()` | `EventStreamQueryClient` | 领域事件流查询 |
 
 来源: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/queryClients.ts#L62-L214)
 
@@ -335,11 +328,7 @@ import {
 const activeCarts = filter.and(
   filter.isIn('state.status', 'ACTIVE', 'PENDING'),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
-  filter.contains(
-    'state.ownerName',
-    'ahoowang',
-    StringComparison.CASE_INSENSITIVE,
-  ),
+  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
 );
 
 const request = { filter: activeCarts, limit: 100 };
@@ -355,16 +344,16 @@ const yesterday = filter.yesterday('state.createdAt', {
 });
 ```
 
-| 分类          | `filter` 构建器                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 说明                                                                                                                                                                               |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 逻辑          | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)`                                                                                                                                                                                                                                                                                                                                                                                                               | 逻辑构建器至少需要一个操作数。                                                                                                                                                     |
-| 元数据        | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)`                                                                                                                                                                                                                                                                                                                                        | 按 Wow 元数据约束根快照范围。                                                                                                                                                      |
-| 比较          | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)`                                                                                                                                                                                                                                                                                                           | 值为 JSON 标量；相等比较也接受 `null` 和数组。                                                                                                                                     |
-| 字符串        | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)`                                                                                                                                                                                                                                                                                                                                                                                              | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。                                                                                                                      |
-| 集合          | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)`                                                                                                                                                                                                                                                                                                                                                                                         | 集合构建器至少需要一个值。                                                                                                                                                         |
-| 存在性        | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`                                                                                                                                                                                                                                                                                                                                                                                   | 字段存在性构建器。                                                                                                                                                                 |
-| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)`                                                                                                                                                                                                                                                                                                                                                                                               | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；`SearchFilterOptions` 接受 `fields` 和 `mode`（默认 `SearchMode.TERMS`）；元素谓词不能包含根元数据、删除或搜索筛选器。 |
-| 相对时间      | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId`、`datePattern` 和 `timeUnit`（默认 `TimeUnit.MILLISECONDS`）；`days` 必须为正的 JVM `Int`。                                                              |
+| 分类 | `filter` 构建器 | 说明 |
+|------|-----------------|------|
+| 逻辑 | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)` | 逻辑构建器至少需要一个操作数。 |
+| 元数据 | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | 按 Wow 元数据约束根快照范围。 |
+| 比较 | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | 值为 JSON 标量；相等比较也接受 `null` 和数组。 |
+| 字符串 | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。 |
+| 集合 | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | 集合构建器至少需要一个值。 |
+| 存在性 | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | 字段存在性构建器。 |
+| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)` | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；`SearchFilterOptions` 接受 `fields` 和 `mode`（默认 `SearchMode.TERMS`）；元素谓词不能包含根元数据、删除或搜索筛选器。 |
+| 相对时间 | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId`、`datePattern` 和 `timeUnit`（默认 `TimeUnit.MILLISECONDS`）；`days` 必须为正的 JVM `Int`。 |
 
 来源: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
@@ -396,21 +385,12 @@ const list = {
 对于大型数据集，基于游标的分页比基于偏移量的分页更高效。它通过使用游标 ID 跟踪位置，避免了深偏移查询的性能退化：
 
 ```typescript
-import {
-  cursorQuery,
-  CURSOR_ID_START,
-  filter,
-  SortDirection,
-} from '@ahoo-wang/fetcher-wow';
+import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
 
 // 第一页——从头开始
 const firstPage = cursorQuery({
-  query: {
-    filter: filter.matchAll(),
-    limit: 50,
-    projection: { include: ['id', 'name'] },
-  },
-  cursorId: CURSOR_ID_START, // '~'——从头开始
+  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
+  cursorId: CURSOR_ID_START,  // '~'——从头开始
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -418,7 +398,7 @@ const firstPage = cursorQuery({
 // 后续页——使用前一个结果的最后一条记录的游标 ID
 const nextPage = cursorQuery({
   query: { filter: filter.matchAll(), limit: 50 },
-  cursorId: lastItemId, // 上一页的游标 ID
+  cursorId: lastItemId,  // 上一页的游标 ID
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -484,34 +464,34 @@ graph TB
 
 ## 主要导出
 
-| 导出                                                                                                                                                        | 模块              | 描述                                   |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | -------------------------------------- |
-| `CommandClient`                                                                                                                                             | `command/`        | 基于装饰器的命令发送客户端             |
-| `CommandRequest`                                                                                                                                            | `command/`        | 带请求头的类型化命令请求               |
-| `CommandResult`                                                                                                                                             | `command/`        | 命令执行结果                           |
-| `CommandResultEventStream`                                                                                                                                  | `command/`        | 命令结果的 SSE 流                      |
-| `CommandBody<C>`                                                                                                                                            | `command/`        | 命令体包装类型                         |
-| `CommandHeaders`                                                                                                                                            | `command/`        | 请求头名称常量                         |
-| `QueryClientFactory`                                                                                                                                        | `query/`          | 创建所有查询客户端的工厂               |
-| `QueryClientOptions`                                                                                                                                        | `query/`          | 查询客户端配置                         |
-| `SnapshotQueryClient`                                                                                                                                       | `query/snapshot/` | 快照查询操作                           |
-| `EventStreamQueryClient`                                                                                                                                    | `query/event/`    | 领域事件流查询                         |
-| `LoadStateAggregateClient`                                                                                                                                  | `query/state/`    | 通过 ID/版本/时间加载聚合状态          |
-| `LoadOwnerStateAggregateClient`                                                                                                                             | `query/state/`    | 加载所有者的聚合状态                   |
-| `FilterExpression`                                                                                                                                          | `query/`          | 类型化查询筛选器联合类型               |
-| `filter`                                                                                                                                                    | `query/`          | 用于新查询的 `FilterExpression` 构建器 |
-| `SearchMode`, `TimeUnit`                                                                                                                                    | `query/`          | 搜索与相对时间选项枚举                 |
-| `AggregationQuery`                                                                                                                                          | `query/`          | 类型化快照聚合请求                     |
-| `aggregation`                                                                                                                                               | `query/`          | 聚合查询构建器                         |
-| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/`          | 聚合结构枚举                           |
-| `SnapshotQueryClient.aggregate()`                                                                                                                           | `query/snapshot/` | 执行聚合并返回结果行                   |
-| `SnapshotQueryClient.aggregateStream()`                                                                                                                     | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行          |
-| `Condition`, `all()`, `and(...)`, `Operator`                                                                                                                | `query/`          | 已弃用的兼容 API                       |
-| `listQuery()`                                                                                                                                               | `query/`          | 创建列表查询                           |
-| `pagedQuery()`                                                                                                                                              | `query/`          | 创建分页查询                           |
-| `singleQuery()`                                                                                                                                             | `query/`          | 创建单条查询                           |
-| `FieldSort`                                                                                                                                                 | `query/`          | 排序规范                               |
-| `ResourceAttributionPathSpec`                                                                                                                               | `types/`          | 租户/所有者范围的路径规范              |
+| 导出 | 模块 | 描述 |
+|------|------|------|
+| `CommandClient` | `command/` | 基于装饰器的命令发送客户端 |
+| `CommandRequest` | `command/` | 带请求头的类型化命令请求 |
+| `CommandResult` | `command/` | 命令执行结果 |
+| `CommandResultEventStream` | `command/` | 命令结果的 SSE 流 |
+| `CommandBody<C>` | `command/` | 命令体包装类型 |
+| `CommandHeaders` | `command/` | 请求头名称常量 |
+| `QueryClientFactory` | `query/` | 创建所有查询客户端的工厂 |
+| `QueryClientOptions` | `query/` | 查询客户端配置 |
+| `SnapshotQueryClient` | `query/snapshot/` | 快照查询操作 |
+| `EventStreamQueryClient` | `query/event/` | 领域事件流查询 |
+| `LoadStateAggregateClient` | `query/state/` | 通过 ID/版本/时间加载聚合状态 |
+| `LoadOwnerStateAggregateClient` | `query/state/` | 加载所有者的聚合状态 |
+| `FilterExpression` | `query/` | 类型化查询筛选器联合类型 |
+| `filter` | `query/` | 用于新查询的 `FilterExpression` 构建器 |
+| `SearchMode`, `TimeUnit` | `query/` | 搜索与相对时间选项枚举 |
+| `AggregationQuery` | `query/` | 类型化快照聚合请求 |
+| `aggregation` | `query/` | 聚合查询构建器 |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/` | 聚合结构枚举 |
+| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | 执行聚合并返回结果行 |
+| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行 |
+| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | 已弃用的兼容 API |
+| `listQuery()` | `query/` | 创建列表查询 |
+| `pagedQuery()` | `query/` | 创建分页查询 |
+| `singleQuery()` | `query/` | 创建单条查询 |
+| `FieldSort` | `query/` | 排序规范 |
+| `ResourceAttributionPathSpec` | `types/` | 租户/所有者范围的路径规范 |
 
 ## 生成的客户端
 


### PR DESCRIPTION
## Description

Align `@ahoo-wang/fetcher-wow` with the current Wow query wire API and provide a TypeScript-first functional query DSL.

- add SearchMode, TimeUnit, new relative-calendar filters, and runtime input guards
- add recursive aggregation arithmetic expressions and a flat `aggregation.*` builder API
- separate root and aggregation field domains in snapshot aggregation queries
- synchronize package README, Skill API reference, and bilingual Wiki documentation
- bump all workspace package manifests to 3.18.0

No new dependencies are required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Wow focused Vitest: 109 tests passed
- [x] Wow TypeScript typecheck
- [x] Workspace lint: 0 errors
- [x] Full workspace build
- [x] Full workspace unit suite
- [x] VitePress Wiki build

**Test Configuration**:

- Firmware version: N/A
- Hardware: macOS development host
- Toolchain: Node.js 24.12.0, pnpm 10.34.5, TypeScript 6.0.3
- SDK: N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)
- [x] I have checked my code and corrected any misspellings
