### PR TITLE
refactor(wow): make filter collections array-first

### DIFF
--- a/packages/wow/README.md
+++ b/packages/wow/README.md
@@ -172,7 +172,7 @@ import {
   TimeUnit,
 } from '@ahoo-wang/fetcher-wow';
 
-const expression = filter.and(
+const expression = filter.and([
   filter.deletion(DeletionState.ACTIVE),
   filter.eq('state.status', 'PAID'),
   filter.elementMatch('state.items', filter.gt('quantity', 0)),
@@ -184,12 +184,13 @@ const expression = filter.and(
     zoneId: 'Asia/Shanghai',
     timeUnit: TimeUnit.MILLISECONDS,
   }),
-);
+]);
 ```
 
 Builders are grouped under `filter`: `matchAll`, `matchNone`, `and`, `or`,
 `nor`, comparisons, string/collection predicates, presence checks,
 `elementMatch`, `search`, deletion scope, and relative-time filters.
+Builders with multiple operands or values accept one `readonly` array.
 
 #### Condition Builder (Deprecated)
 
@@ -803,10 +804,10 @@ class ReactiveQueryManager {
         filter: filter.eq('aggregateId', userId),
       }),
       this.snapshotClient.list({
-        filter: filter.and(
+        filter: filter.and([
           filter.eq('state.userId', userId),
           filter.eq('state.type', 'activity'),
-        ),
+        ]),
         limit: 10,
       }),
       this.snapshotClient.count(filter.eq('state.userId', userId)),
@@ -832,10 +833,10 @@ console.log('Dashboard:', dashboard);
 queryManager.subscribeToQuery(
   'user-activity',
   {
-    filter: filter.and(
+    filter: filter.and([
       filter.eq('state.userId', 'user-123'),
       filter.eq('state.type', 'activity'),
-    ),
+    ]),
   },
   update => {
     console.log('New activity:', update);

--- a/packages/wow/README.md
+++ b/packages/wow/README.md
@@ -190,7 +190,9 @@ const expression = filter.and([
 Builders are grouped under `filter`: `matchAll`, `matchNone`, `and`, `or`,
 `nor`, comparisons, string/collection predicates, presence checks,
 `elementMatch`, `search`, deletion scope, and relative-time filters.
-Builders with multiple operands or values accept one `readonly` array.
+`and`, `or`, `nor`, `ids`, `aggregateIds`, `isIn`, `notIn`, and
+`containsAll` accept one non-empty `readonly` array and throw `TypeError` for
+an empty array.
 
 #### Condition Builder (Deprecated)
 

--- a/packages/wow/README.zh-CN.md
+++ b/packages/wow/README.zh-CN.md
@@ -181,7 +181,8 @@ const expression = filter.and([
 
 所有构建器集中在 `filter`：`matchAll`、`matchNone`、`and`、`or`、`nor`、
 比较、字符串/集合谓词、存在性检查、`elementMatch`、`search`、删除范围和相对时间过滤器。
-包含多个操作数或值的构建器接收一个 `readonly` 数组。
+`and`、`or`、`nor`、`ids`、`aggregateIds`、`isIn`、`notIn` 和
+`containsAll` 接收一个非空 `readonly` 数组；传入空数组时抛出 `TypeError`。
 
 #### 条件构建器（已弃用）
 

--- a/packages/wow/README.zh-CN.md
+++ b/packages/wow/README.zh-CN.md
@@ -164,7 +164,7 @@ import {
   TimeUnit,
 } from '@ahoo-wang/fetcher-wow';
 
-const expression = filter.and(
+const expression = filter.and([
   filter.deletion(DeletionState.ACTIVE),
   filter.eq('state.status', 'PAID'),
   filter.elementMatch('state.items', filter.gt('quantity', 0)),
@@ -176,11 +176,12 @@ const expression = filter.and(
     zoneId: 'Asia/Shanghai',
     timeUnit: TimeUnit.MILLISECONDS,
   }),
-);
+]);
 ```
 
 所有构建器集中在 `filter`：`matchAll`、`matchNone`、`and`、`or`、`nor`、
 比较、字符串/集合谓词、存在性检查、`elementMatch`、`search`、删除范围和相对时间过滤器。
+包含多个操作数或值的构建器接收一个 `readonly` 数组。
 
 #### 条件构建器（已弃用）
 

--- a/packages/wow/src/query/cursorQuery.ts
+++ b/packages/wow/src/query/cursorQuery.ts
@@ -123,7 +123,7 @@ export function cursorQuery<FIELDS extends string = string>(
   if (queryFilter !== undefined) {
     return {
       ...query,
-      filter: filter.and(cursorFilter(options), queryFilter),
+      filter: filter.and([cursorFilter(options), queryFilter]),
       sort: [mergedSort],
     };
   }

--- a/packages/wow/src/query/filter.ts
+++ b/packages/wow/src/query/filter.ts
@@ -541,51 +541,42 @@ function validateElementPredicate(predicate: FilterExpression): void {
 }
 
 function andFilter<FIELDS extends string>(
-  ...operands: [
-    ElementFilterExpression<FIELDS>,
-    ...ElementFilterExpression<FIELDS>[],
-  ]
+  operands: readonly ElementFilterExpression<FIELDS>[],
 ): ElementLogicalFilter<FIELDS>;
 function andFilter<FIELDS extends string>(
-  ...operands: [FilterExpression<FIELDS>, ...FilterExpression<FIELDS>[]]
+  operands: readonly FilterExpression<FIELDS>[],
 ): LogicalFilter<FIELDS>;
 function andFilter<FIELDS extends string>(
-  ...operands: [FilterExpression<FIELDS>, ...FilterExpression<FIELDS>[]]
+  operands: readonly FilterExpression<FIELDS>[],
 ): LogicalFilter<FIELDS> {
   requireNonEmpty('AND operands', operands);
-  return { op: FilterOperator.AND, operands };
+  return { op: FilterOperator.AND, operands: [...operands] };
 }
 
 function orFilter<FIELDS extends string>(
-  ...operands: [
-    ElementFilterExpression<FIELDS>,
-    ...ElementFilterExpression<FIELDS>[],
-  ]
+  operands: readonly ElementFilterExpression<FIELDS>[],
 ): ElementLogicalFilter<FIELDS>;
 function orFilter<FIELDS extends string>(
-  ...operands: [FilterExpression<FIELDS>, ...FilterExpression<FIELDS>[]]
+  operands: readonly FilterExpression<FIELDS>[],
 ): LogicalFilter<FIELDS>;
 function orFilter<FIELDS extends string>(
-  ...operands: [FilterExpression<FIELDS>, ...FilterExpression<FIELDS>[]]
+  operands: readonly FilterExpression<FIELDS>[],
 ): LogicalFilter<FIELDS> {
   requireNonEmpty('OR operands', operands);
-  return { op: FilterOperator.OR, operands };
+  return { op: FilterOperator.OR, operands: [...operands] };
 }
 
 function norFilter<FIELDS extends string>(
-  ...operands: [
-    ElementFilterExpression<FIELDS>,
-    ...ElementFilterExpression<FIELDS>[],
-  ]
+  operands: readonly ElementFilterExpression<FIELDS>[],
 ): ElementLogicalFilter<FIELDS>;
 function norFilter<FIELDS extends string>(
-  ...operands: [FilterExpression<FIELDS>, ...FilterExpression<FIELDS>[]]
+  operands: readonly FilterExpression<FIELDS>[],
 ): LogicalFilter<FIELDS>;
 function norFilter<FIELDS extends string>(
-  ...operands: [FilterExpression<FIELDS>, ...FilterExpression<FIELDS>[]]
+  operands: readonly FilterExpression<FIELDS>[],
 ): LogicalFilter<FIELDS> {
   requireNonEmpty('NOR operands', operands);
-  return { op: FilterOperator.NOR, operands };
+  return { op: FilterOperator.NOR, operands: [...operands] };
 }
 
 export const filter = {
@@ -598,10 +589,10 @@ export const filter = {
   id(value: string): MetadataValueFilter {
     return { op: FilterOperator.ID, value: requiredString('ID value', value) };
   },
-  ids(...values: [string, ...string[]]): MetadataValuesFilter {
+  ids(values: readonly string[]): MetadataValuesFilter {
     requireNonEmpty('IDS values', values);
     values.forEach(value => requiredString('IDS value', value));
-    return { op: FilterOperator.IDS, values };
+    return { op: FilterOperator.IDS, values: [...values] };
   },
   aggregateId(value: string): MetadataValueFilter {
     return {
@@ -609,10 +600,10 @@ export const filter = {
       value: requiredString('AGGREGATE_ID value', value),
     };
   },
-  aggregateIds(...values: [string, ...string[]]): MetadataValuesFilter {
+  aggregateIds(values: readonly string[]): MetadataValuesFilter {
     requireNonEmpty('AGGREGATE_IDS values', values);
     values.forEach(value => requiredString('AGGREGATE_IDS value', value));
-    return { op: FilterOperator.AGGREGATE_IDS, values };
+    return { op: FilterOperator.AGGREGATE_IDS, values: [...values] };
   },
   tenantId(value: string): MetadataValueFilter {
     return {
@@ -736,30 +727,38 @@ export const filter = {
   },
   isIn<FIELDS extends string>(
     field: FIELDS,
-    ...values: [ComparableFilterLiteral, ...ComparableFilterLiteral[]]
+    values: readonly ComparableFilterLiteral[],
   ): CollectionFilter<FIELDS> {
     requireNonEmpty('IN values', values);
     values.forEach(value => filterLiteral(value, false));
-    return { op: FilterOperator.IN, field: logicalField(field), values };
+    return {
+      op: FilterOperator.IN,
+      field: logicalField(field),
+      values: [...values],
+    };
   },
   notIn<FIELDS extends string>(
     field: FIELDS,
-    ...values: [ComparableFilterLiteral, ...ComparableFilterLiteral[]]
+    values: readonly ComparableFilterLiteral[],
   ): CollectionFilter<FIELDS> {
     requireNonEmpty('NOT_IN values', values);
     values.forEach(value => filterLiteral(value, false));
-    return { op: FilterOperator.NOT_IN, field: logicalField(field), values };
+    return {
+      op: FilterOperator.NOT_IN,
+      field: logicalField(field),
+      values: [...values],
+    };
   },
   containsAll<FIELDS extends string>(
     field: FIELDS,
-    ...values: [ComparableFilterLiteral, ...ComparableFilterLiteral[]]
+    values: readonly ComparableFilterLiteral[],
   ): CollectionFilter<FIELDS> {
     requireNonEmpty('CONTAINS_ALL values', values);
     values.forEach(value => filterLiteral(value, false));
     return {
       op: FilterOperator.CONTAINS_ALL,
       field: logicalField(field),
-      values,
+      values: [...values],
     };
   },
   between<FIELDS extends string>(

--- a/packages/wow/src/query/snapshot/snapshotQueryClient.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryClient.ts
@@ -508,7 +508,7 @@ export class SnapshotQueryClient<S, FIELDS extends string = string>
   ): Promise<MaterializedSnapshot<S>[]> {
     if (ids.length === 0) return Promise.resolve([]);
     const query = listQuery<FIELDS>({
-      filter: filter.aggregateIds(ids[0], ...ids.slice(1)),
+      filter: filter.aggregateIds(ids),
       limit: ids.length,
     });
     return this.list(query, attributes, abortController);
@@ -539,7 +539,7 @@ export class SnapshotQueryClient<S, FIELDS extends string = string>
   ): Promise<S[]> {
     if (ids.length === 0) return Promise.resolve([]);
     const query = listQuery<FIELDS>({
-      filter: filter.aggregateIds(ids[0], ...ids.slice(1)),
+      filter: filter.aggregateIds(ids),
       limit: ids.length,
     });
     return this.listState(query, attributes, abortController);

--- a/packages/wow/src/query/snapshot/snapshotQueryClient.ts
+++ b/packages/wow/src/query/snapshot/snapshotQueryClient.ts
@@ -15,9 +15,9 @@ import {
   type SnapshotQueryApi,
   SnapshotQueryEndpointPaths,
 } from './snapshotQueryApi';
-import { aggregateId, aggregateIds, type Condition } from '../condition';
+import { aggregateId, type Condition } from '../condition';
 import type { AggregationQuery } from '../aggregation';
-import type { FilterExpression } from '../filter';
+import { filter, type FilterExpression } from '../filter';
 import {
   listQuery,
   type ListQueryRequest,
@@ -506,8 +506,9 @@ export class SnapshotQueryClient<S, FIELDS extends string = string>
     @attribute() attributes?: Record<string, any>,
     abortController?: AbortController,
   ): Promise<MaterializedSnapshot<S>[]> {
+    if (ids.length === 0) return Promise.resolve([]);
     const query = listQuery<FIELDS>({
-      condition: aggregateIds<FIELDS>(ids),
+      filter: filter.aggregateIds(ids[0], ...ids.slice(1)),
       limit: ids.length,
     });
     return this.list(query, attributes, abortController);
@@ -536,8 +537,9 @@ export class SnapshotQueryClient<S, FIELDS extends string = string>
     @attribute() attributes?: Record<string, any>,
     abortController?: AbortController,
   ): Promise<S[]> {
+    if (ids.length === 0) return Promise.resolve([]);
     const query = listQuery<FIELDS>({
-      condition: aggregateIds<FIELDS>(ids),
+      filter: filter.aggregateIds(ids[0], ...ids.slice(1)),
       limit: ids.length,
     });
     return this.listState(query, attributes, abortController);

--- a/packages/wow/test/query/cursorQuery.test.ts
+++ b/packages/wow/test/query/cursorQuery.test.ts
@@ -62,14 +62,14 @@ describe('cursorQuery', () => {
     });
 
     expect(result.filter).toEqual(
-      filter.and(
+      filter.and([
         cursorFilter({
           field: 'id',
           cursorId: 'cursor123',
           direction: SortDirection.ASC,
         }),
         query.filter,
-      ),
+      ]),
     );
   });
 

--- a/packages/wow/test/query/filter.test.ts
+++ b/packages/wow/test/query/filter.test.ts
@@ -26,13 +26,13 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 describe('filter', () => {
   it('builds the Wow FilterExpression wire shape', () => {
     expect(
-      filter.and(
+      filter.and([
         filter.deletion(DeletionState.ACTIVE),
         filter.eq('state.status', 'PAID'),
         filter.elementMatch('state.items', filter.gt('quantity', 0)),
         filter.search('wow', { fields: ['state.name'] }),
         filter.today('state.createdAt', { zoneId: 'UTC' }),
-      ),
+      ]),
     ).toEqual({
       op: FilterOperator.AND,
       operands: [
@@ -133,9 +133,9 @@ describe('filter', () => {
   it('builds metadata filters', () => {
     const expressions: MetadataFilter[] = [
       filter.id('snapshot-1'),
-      filter.ids('snapshot-1', 'snapshot-2'),
+      filter.ids(['snapshot-1', 'snapshot-2']),
       filter.aggregateId('order-1'),
-      filter.aggregateIds('order-1', 'order-2'),
+      filter.aggregateIds(['order-1', 'order-2']),
       filter.tenantId('tenant-1'),
       filter.ownerId('owner-1'),
       filter.spaceId('space-1'),
@@ -153,6 +153,71 @@ describe('filter', () => {
       { op: FilterOperator.OWNER_ID, value: 'owner-1' },
       { op: FilterOperator.SPACE_ID, value: 'space-1' },
     ]);
+  });
+
+  it('accepts readonly arrays for value-list builders', () => {
+    const ids = ['snapshot-1', 'snapshot-2'] as const;
+    const aggregateIds = ['order-1', 'order-2'] as const;
+    const statuses = ['PAID', 'SHIPPED'] as const;
+    const tags = ['wow', 'cqrs'] as const;
+
+    expect([
+      filter.ids(ids),
+      filter.aggregateIds(aggregateIds),
+      filter.isIn('status', statuses),
+      filter.notIn('status', statuses),
+      filter.containsAll('tags', tags),
+    ]).toEqual([
+      { op: 'IDS', values: ['snapshot-1', 'snapshot-2'] },
+      { op: 'AGGREGATE_IDS', values: ['order-1', 'order-2'] },
+      { op: 'IN', field: 'status', values: ['PAID', 'SHIPPED'] },
+      { op: 'NOT_IN', field: 'status', values: ['PAID', 'SHIPPED'] },
+      { op: 'CONTAINS_ALL', field: 'tags', values: ['wow', 'cqrs'] },
+    ]);
+    expect(filter.aggregateIds(aggregateIds).values).not.toBe(aggregateIds);
+  });
+
+  it('accepts readonly arrays for logical builders', () => {
+    const operands = [
+      filter.eq('status', 'PAID'),
+      filter.isNotNull('paidAt'),
+    ] as const;
+
+    expect([
+      filter.and(operands),
+      filter.or(operands),
+      filter.nor(operands),
+    ]).toEqual([
+      { op: 'AND', operands },
+      { op: 'OR', operands },
+      { op: 'NOR', operands },
+    ]);
+    expect(filter.and(operands).operands).not.toBe(operands);
+  });
+
+  it.each([
+    ['AND', () => filter.and([]), 'AND operands cannot be empty.'],
+    ['OR', () => filter.or([]), 'OR operands cannot be empty.'],
+    ['NOR', () => filter.nor([]), 'NOR operands cannot be empty.'],
+    ['IDS', () => filter.ids([]), 'IDS values cannot be empty.'],
+    [
+      'AGGREGATE_IDS',
+      () => filter.aggregateIds([]),
+      'AGGREGATE_IDS values cannot be empty.',
+    ],
+    ['IN', () => filter.isIn('status', []), 'IN values cannot be empty.'],
+    [
+      'NOT_IN',
+      () => filter.notIn('status', []),
+      'NOT_IN values cannot be empty.',
+    ],
+    [
+      'CONTAINS_ALL',
+      () => filter.containsAll('tags', []),
+      'CONTAINS_ALL values cannot be empty.',
+    ],
+  ])('rejects an empty %s array', (_name, create, message) => {
+    expect(create).toThrow(message);
   });
 
   it('supports Kotlin equality values and logical fields', () => {
@@ -190,7 +255,7 @@ describe('filter', () => {
     },
     {
       name: 'or',
-      create: () => filter.or(filter.eq('status', 'PAID')),
+      create: () => filter.or([filter.eq('status', 'PAID')]),
       expected: {
         op: FilterOperator.OR,
         operands: [{ op: FilterOperator.EQ, field: 'status', value: 'PAID' }],
@@ -198,7 +263,7 @@ describe('filter', () => {
     },
     {
       name: 'nor',
-      create: () => filter.nor(filter.ne('status', null)),
+      create: () => filter.nor([filter.ne('status', null)]),
       expected: {
         op: FilterOperator.NOR,
         operands: [{ op: FilterOperator.NE, field: 'status', value: null }],
@@ -242,7 +307,7 @@ describe('filter', () => {
     },
     {
       name: 'in',
-      create: () => filter.isIn('status', 'PAID', 'SHIPPED'),
+      create: () => filter.isIn('status', ['PAID', 'SHIPPED']),
       expected: {
         op: FilterOperator.IN,
         field: 'status',
@@ -251,7 +316,7 @@ describe('filter', () => {
     },
     {
       name: 'not in',
-      create: () => filter.notIn('status', 'CANCELLED'),
+      create: () => filter.notIn('status', ['CANCELLED']),
       expected: {
         op: FilterOperator.NOT_IN,
         field: 'status',
@@ -270,7 +335,7 @@ describe('filter', () => {
     },
     {
       name: 'contains all',
-      create: () => filter.containsAll('tags', 'wow', 'cqrs'),
+      create: () => filter.containsAll('tags', ['wow', 'cqrs']),
       expected: {
         op: FilterOperator.CONTAINS_ALL,
         field: 'tags',
@@ -549,10 +614,10 @@ describe('filter', () => {
   });
 
   it('restricts element predicates recursively', () => {
-    const predicate = filter.and(
+    const predicate = filter.and([
       filter.eq('sku', 'product-1'),
       filter.gt('quantity', 0),
-    );
+    ]);
 
     expectTypeOf(predicate).toMatchTypeOf<
       ElementFilterExpression<'sku' | 'quantity'>
@@ -573,7 +638,7 @@ describe('filter', () => {
       filter.elementMatch(
         'state.items',
         // @ts-expect-error Unsupported filters remain invalid inside logical predicates.
-        filter.and(filter.eq('sku', 'product-1'), filter.search('wow')),
+        filter.and([filter.eq('sku', 'product-1'), filter.search('wow')]),
       );
     };
     expectTypeOf(invalidElementPredicates).toBeFunction();
@@ -581,10 +646,10 @@ describe('filter', () => {
 
   it('rejects unsupported element predicates at runtime', () => {
     const deletion = filter.deletion(DeletionState.ACTIVE);
-    const nestedSearch = filter.and(
+    const nestedSearch = filter.and([
       filter.eq('sku', 'product-1'),
       filter.search('wow'),
-    );
+    ]);
     const metadata = filter.id('snapshot-1');
 
     expect(() =>
@@ -614,28 +679,25 @@ describe('filter', () => {
   });
 
   it.each([
-    ['empty logical operands', () => Reflect.apply(filter.and, null, [])],
+    ['empty logical operands', () => filter.and([])],
     [
       'undefined AND operand',
-      () => Reflect.apply(filter.and, null, [undefined]),
+      () => Reflect.apply(filter.and, null, [[undefined]]),
     ],
-    ['null OR operand', () => Reflect.apply(filter.or, null, [null])],
+    ['null OR operand', () => Reflect.apply(filter.or, null, [[null]])],
     [
       'undefined NOR operand',
-      () => Reflect.apply(filter.nor, null, [undefined]),
+      () => Reflect.apply(filter.nor, null, [[undefined]]),
     ],
-    [
-      'empty collection values',
-      () => Reflect.apply(filter.isIn, null, ['status']),
-    ],
-    ['empty ids', () => Reflect.apply(filter.ids, null, [])],
+    ['empty collection values', () => filter.isIn('status', [])],
+    ['empty ids', () => filter.ids([])],
     [
       'non-string aggregate ID',
       () => Reflect.apply(filter.aggregateId, null, [1]),
     ],
     [
       'non-string aggregate IDs value',
-      () => Reflect.apply(filter.aggregateIds, null, ['order-1', 2]),
+      () => Reflect.apply(filter.aggregateIds, null, [['order-1', 2]]),
     ],
     ['invalid logical field', () => filter.eq('bad field', 'value')],
     [
@@ -657,7 +719,7 @@ describe('filter', () => {
     ['non-finite value', () => filter.gt('score', Number.POSITIVE_INFINITY)],
     [
       'null collection value',
-      () => Reflect.apply(filter.isIn, null, ['status', null]),
+      () => Reflect.apply(filter.isIn, null, ['status', [null]]),
     ],
     ['blank search query', () => filter.search(' ')],
     ['non-string search query', () => Reflect.apply(filter.search, null, [1])],

--- a/packages/wow/test/query/snapshot/snapshotQueryApi.test.ts
+++ b/packages/wow/test/query/snapshot/snapshotQueryApi.test.ts
@@ -105,3 +105,58 @@ describe('SnapshotQueryEndpointPaths', () => {
     expect(exchange).toHaveBeenCalledOnce();
   });
 });
+
+describe('SnapshotQueryClient ID helpers', () => {
+  it.each(['getByIds', 'getStateByIds'] as const)(
+    '%s sends a FilterExpression request',
+    async method => {
+      const fetcher = new NamedFetcher(`${method}-filter-test`);
+      const bodies: unknown[] = [];
+      vi.spyOn(fetcher.interceptors, 'exchange').mockImplementation(
+        async current => {
+          bodies.push(
+            typeof current.request.body === 'string'
+              ? JSON.parse(current.request.body)
+              : current.request.body,
+          );
+          current.extractResult = vi.fn().mockResolvedValue([]);
+          return current;
+        },
+      );
+      const client = new SnapshotQueryClient<unknown>({
+        basePath: '/order',
+        fetcher,
+      });
+
+      await client[method](['order-1', 'order-2']);
+
+      expect(bodies).toEqual([
+        {
+          filter: {
+            op: 'AGGREGATE_IDS',
+            values: ['order-1', 'order-2'],
+          },
+          limit: 2,
+        },
+      ]);
+    },
+  );
+});
+
+describe('SnapshotQueryClient empty ID helpers', () => {
+  it.each(['getByIds', 'getStateByIds'] as const)(
+    '%s returns locally for empty IDs',
+    async method => {
+      const fetcher = new NamedFetcher(`${method}-empty-test`);
+      vi.spyOn(fetcher.interceptors, 'exchange').mockRejectedValue(
+        new Error('unexpected HTTP exchange'),
+      );
+      const client = new SnapshotQueryClient<unknown>({
+        basePath: '/order',
+        fetcher,
+      });
+
+      await expect(client[method]([])).resolves.toEqual([]);
+    },
+  );
+});

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -554,7 +554,7 @@ wire discriminator. Builders are grouped under `filter` so they do not collide
 with the legacy `Condition` helpers:
 
 ```typescript
-const expression = filter.and(
+const expression = filter.and([
   filter.deletion(DeletionState.ACTIVE),
   filter.eq('state.status', 'PAID'),
   filter.elementMatch('state.items', filter.gt('quantity', 0)),
@@ -566,7 +566,7 @@ const expression = filter.and(
     zoneId: 'Asia/Shanghai',
     timeUnit: TimeUnit.MILLISECONDS,
   }),
-);
+]);
 
 await snapshotClient.count(expression);
 await snapshotClient.list({ filter: expression, limit: 10 });
@@ -587,6 +587,18 @@ Available builders:
 - Presence: `isEmpty`, `isNull`, `isNotNull`, `exists`, `notExists`
 - Scope/search: `deletion`, `elementMatch`, `search(query, options?: SearchFilterOptions)`
 - Relative time: `today`, `beforeToday`, `tomorrow`, `thisWeek`, `nextWeek`, `lastWeek`, `thisMonth`, `lastMonth`, `yesterday`, `nextMonth`, `lastYear`, `thisYear`, `nextYear`, `recentDays`, `earlierDays`
+
+Multi-operand and multi-value builders accept one `readonly` array:
+
+```typescript
+const statuses = ['PAID', 'SHIPPED'] as const;
+filter.and([filter.eq('state.status', 'PAID')]);
+filter.ids(['snapshot-1', 'snapshot-2']);
+filter.aggregateIds(['cart-1', 'cart-2']);
+filter.isIn('state.status', statuses);
+filter.notIn('state.status', ['CANCELLED']);
+filter.containsAll('state.tags', ['wow', 'cqrs']);
+```
 
 `eq` and `ne` accept a JSON scalar or an array of JSON scalars. Logical field
 segments may start with `@`.

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -588,7 +588,8 @@ Available builders:
 - Scope/search: `deletion`, `elementMatch`, `search(query, options?: SearchFilterOptions)`
 - Relative time: `today`, `beforeToday`, `tomorrow`, `thisWeek`, `nextWeek`, `lastWeek`, `thisMonth`, `lastMonth`, `yesterday`, `nextMonth`, `lastYear`, `thisYear`, `nextYear`, `recentDays`, `earlierDays`
 
-Multi-operand and multi-value builders accept one `readonly` array:
+`and`, `or`, `nor`, `ids`, `aggregateIds`, `isIn`, `notIn`, and `containsAll`
+accept one non-empty `readonly` array and throw `TypeError` for an empty array:
 
 ```typescript
 const statuses = ['PAID', 'SHIPPED'] as const;

--- a/wiki/packages/wow.md
+++ b/wiki/packages/wow.md
@@ -327,11 +327,11 @@ import {
   TimeUnit,
 } from '@ahoo-wang/fetcher-wow';
 
-const activeCarts = filter.and(
-  filter.isIn('state.status', 'ACTIVE', 'PENDING'),
+const activeCarts = filter.and([
+  filter.isIn('state.status', ['ACTIVE', 'PENDING']),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
   filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
-);
+]);
 
 const request = { filter: activeCarts, limit: 100 };
 
@@ -348,11 +348,11 @@ const yesterday = filter.yesterday('state.createdAt', {
 
 | Category | `filter` builders | Notes |
 |----------|-------------------|-------|
-| Logical | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)` | Logical builders require one or more operands. |
-| Metadata | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | Scope a root snapshot by Wow metadata. |
+| Logical | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)` | Logical builders accept one `readonly` array with at least one operand. |
+| Metadata | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | Plural builders accept one non-empty `readonly` array. |
 | Comparison | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | Values are JSON scalar values; equality also accepts `null` and arrays. |
 | String | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`. |
-| Collection | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | Collection builders require at least one value. |
+| Collection | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)` | Collection builders accept one non-empty `readonly` array. |
 | Presence | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | Field presence builders. |
 | Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)` | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; `SearchFilterOptions` accepts `fields` and `mode` (`SearchMode.TERMS` by default); element predicates cannot contain root metadata, deletion, or search filters. |
 | Relative time | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId`, `datePattern`, and `timeUnit` (`TimeUnit.MILLISECONDS` by default); `days` must be a positive JVM `Int`. |

--- a/wiki/zh/packages/wow.md
+++ b/wiki/zh/packages/wow.md
@@ -325,11 +325,11 @@ import {
   TimeUnit,
 } from '@ahoo-wang/fetcher-wow';
 
-const activeCarts = filter.and(
-  filter.isIn('state.status', 'ACTIVE', 'PENDING'),
+const activeCarts = filter.and([
+  filter.isIn('state.status', ['ACTIVE', 'PENDING']),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
   filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
-);
+]);
 
 const request = { filter: activeCarts, limit: 100 };
 
@@ -346,11 +346,11 @@ const yesterday = filter.yesterday('state.createdAt', {
 
 | 分类 | `filter` 构建器 | 说明 |
 |------|-----------------|------|
-| 逻辑 | `matchAll()`, `matchNone()`, `and(...)`, `or(...)`, `nor(...)` | 逻辑构建器至少需要一个操作数。 |
-| 元数据 | `id(value)`, `ids(...values)`, `aggregateId(value)`, `aggregateIds(...values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | 按 Wow 元数据约束根快照范围。 |
+| 逻辑 | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)` | 逻辑构建器接收一个至少含一个操作数的 `readonly` 数组。 |
+| 元数据 | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | 复数构建器接收一个非空 `readonly` 数组。 |
 | 比较 | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | 值为 JSON 标量；相等比较也接受 `null` 和数组。 |
 | 字符串 | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。 |
-| 集合 | `isIn(field, ...values)`, `notIn(field, ...values)`, `containsAll(field, ...values)` | 集合构建器至少需要一个值。 |
+| 集合 | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)` | 集合构建器接收一个非空 `readonly` 数组。 |
 | 存在性 | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | 字段存在性构建器。 |
 | 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)` | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；`SearchFilterOptions` 接受 `fields` 和 `mode`（默认 `SearchMode.TERMS`）；元素谓词不能包含根元数据、删除或搜索筛选器。 |
 | 相对时间 | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId`、`datePattern` 和 `timeUnit`（默认 `TimeUnit.MILLISECONDS`）；`days` 必须为正的 JVM `Int`。 |


### PR DESCRIPTION
## Description

- make `SnapshotQueryClient.getByIds` and `getStateByIds` send `filter.aggregateIds(ids)` instead of the deprecated `condition`
- return `[]` locally for empty ID arrays without issuing an HTTP request
- make all multi-operand and multi-value filter builders accept one non-empty `readonly` array:
  - `and`, `or`, `nor`
  - `ids`, `aggregateIds`
  - `isIn`, `notIn`, `containsAll`
- copy input arrays before storing them in expressions and throw `TypeError` for empty arrays
- keep the deprecated `Condition` API unchanged and intentionally provide no compatibility overloads for the new filter DSL
- synchronize source call sites, tests, package READMEs, the Wow CQRS skill API, and English/Chinese Wiki pages

This is an intentional breaking API refinement for the unreleased `3.18.0` line.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## How Has This Been Tested?

- [x] Focused Wow query tests: 3 files / 120 tests passed
- [x] Wow package suite: 23 files / 343 tests passed, including TypeScript type tests
- [x] Full workspace unit suite passed
- [x] Full workspace build passed
- [x] Wiki build passed
- [x] Workspace lint passed with 0 errors (existing warnings remain)
- [x] Prettier checks for changed non-Wiki files and `git diff --check` passed
- [x] Independent code review completed; no Critical or Important findings

## Checklist

- [x] Code follows the project style
- [x] Tests cover the behavior and edge cases
- [x] New and existing unit tests pass locally
- [x] Public API documentation is synchronized
- [x] No dependencies were added
