### PR TITLE
feat(wow): add aggregation ANY metric

### DIFF
--- a/packages/wow/README.md
+++ b/packages/wow/README.md
@@ -435,6 +435,7 @@ type ItemFields = 'productId' | 'price' | 'quantity';
 
 type ProductSummary = {
   product: string;
+  representativeProduct: string | null;
   itemCount: number;
   revenue: number;
 };
@@ -449,6 +450,7 @@ const aggregationQuery: AggregationQuery<CartFields, ItemFields> = {
   elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
   groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
+    aggregation.any('productId', 'representativeProduct'),
     aggregation.count('itemCount'),
     aggregation.sum(revenue, 'revenue'),
   ],
@@ -464,6 +466,13 @@ for await (const event of summaryStream) {
   console.log(event.data);
 }
 ```
+
+`aggregation.any(field, alias)` adds a metric, not another group. It returns one
+non-null scalar from the current group, or `null` when no value exists. The
+selected value is intentionally unspecified and may differ across backends or
+executions; use it only when every candidate is interchangeable. Its field is
+relative to the innermost element, and Wow rejects collection or non-terms-capable
+fields at runtime. Sorting by an `ANY` alias is an expensive metric sort.
 
 ##### Methods
 

--- a/packages/wow/README.zh-CN.md
+++ b/packages/wow/README.zh-CN.md
@@ -425,6 +425,7 @@ type ItemFields = 'productId' | 'price' | 'quantity';
 
 type ProductSummary = {
   product: string;
+  representativeProduct: string | null;
   itemCount: number;
   revenue: number;
 };
@@ -439,6 +440,7 @@ const aggregationQuery: AggregationQuery<CartFields, ItemFields> = {
   elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
   groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
+    aggregation.any('productId', 'representativeProduct'),
     aggregation.count('itemCount'),
     aggregation.sum(revenue, 'revenue'),
   ],
@@ -454,6 +456,11 @@ for await (const event of summaryStream) {
   console.log(event.data);
 }
 ```
+
+`aggregation.any(field, alias)` 增加的是指标，不是新的分组。它从当前分组返回一个
+非空标量；没有值时返回 `null`。具体选择哪个值不属于契约，可能随后端或执行变化；
+只有候选值可互换时才应使用。字段相对最内层 Element，集合字段或不具备 terms 聚合
+能力的字段由 Wow 在运行时拒绝。按 `ANY` alias 排序属于昂贵的指标排序。
 
 ##### 方法
 

--- a/packages/wow/docs/superpowers/specs/2026-08-27-wow-aggregation-any-design.md
+++ b/packages/wow/docs/superpowers/specs/2026-08-27-wow-aggregation-any-design.md
@@ -1,0 +1,144 @@
+# Fetcher Wow 聚合 ANY 指标对齐设计
+
+## 状态
+
+已确认，待实施计划。
+
+## 背景
+
+本次以 Wow `main@0e3dfbadc` 为协议基线。相对 Wow `v8.13.0`，唯一新增的公开查询
+线协议是聚合指标 `ANY`；同一区间的其他查询提交只调整服务端反序列化和 Query
+Schema 校验，不需要 Fetcher 增加对应 API。
+
+Fetcher `3.18.0` 已提供 `AggregationMetric` 判别联合与 `aggregation.*` 函数式
+DSL，但当前仅覆盖 `COUNT` 和 `NUMERIC` 指标。
+
+## 目标
+
+- 对齐 Wow 的 `ANY` 聚合指标线格式。
+- 保持现有字段泛型推导与普通对象 DSL 风格。
+- 复用现有字段路径和聚合 alias 校验。
+- 同步公开 API 的包文档、Skill API 与双语 Wiki。
+- 验证 Generator 能消费 Wow 当前 OpenAPI，但不主动修改 Generator。
+
+## 非目标
+
+- 不新增或调用 `snapshot/schema`、`snapshot/schema/refresh`。
+- 不增加客户端 Schema 缓存、能力校验、结果选择逻辑或动态 DSL。
+- 不修改 `SnapshotQueryApi`、`SnapshotQueryClient` 或查询端点。
+- 不修改 Generator、集成测试工作流或 Wow 镜像版本；若真实 Generator 验证失败，
+  回到设计阶段重新确认范围。
+- 不新增依赖、文件级抽象、链式 Builder 或兼容别名。
+- 不再次更新 monorepo 版本；当前未发布版本保持 `3.18.0`。
+
+## 公开 API
+
+在现有 `packages/wow/src/query/aggregation.ts` 中扩展：
+
+```ts
+export enum AggregationMetricType {
+  COUNT = 'COUNT',
+  NUMERIC = 'NUMERIC',
+  ANY = 'ANY',
+}
+
+export interface AnyAggregationMetric<FIELDS extends string = string> {
+  type: AggregationMetricType.ANY;
+  field: LogicalField<FIELDS>;
+  alias: string;
+}
+
+export type AggregationMetric<FIELDS extends string = string> =
+  | CountAggregationMetric
+  | NumericAggregationMetric<FIELDS>
+  | AnyAggregationMetric<FIELDS>;
+```
+
+`aggregation` 增加一个无状态构造函数：
+
+```ts
+aggregation.any('productName', 'productName');
+```
+
+它返回：
+
+```json
+{
+  "type": "ANY",
+  "field": "productName",
+  "alias": "productName"
+}
+```
+
+实现直接复用 `aggregationField(field)` 和 `aggregationAlias(alias)`。不新增通用
+validator，也不复制路径或 alias 规则。
+
+## Wow 源码语义
+
+`ANY` 是指标而不是分组：它在当前聚合范围或每个现有分组中返回一个非空标量，
+不会增加分组键或拆分结果行。
+
+字段解析遵循现有聚合相对路径规则：没有 Element 时是快照绝对路径；有 Element 时，
+字段相对最内层 Element。Wow Query Schema Resolver 要求字段具备
+`AGGREGATE_TERMS` 能力且 `cardinality` 不是 `MANY`，因此集合字段不属于有效输入。
+
+后端实现有意不同：
+
+- MongoDB 使用 `$max` accumulator。
+- Elasticsearch 使用 `terms` aggregation，`size = 1`。
+
+所以契约只保证返回一个非空值，不保证选择哪个值。调用方不得依赖跨后端、数据变化
+前后或重复执行时返回相同代表值。缺失、全为 `null`、未映射或空数据集时结果为
+`null`，结果 alias 仍存在。字符串、数字和布尔值按现有后端中立结果转换返回。
+
+按 `ANY` alias 排序属于 metric sort，继续受 Wow 的昂贵查询护栏控制。
+
+Fetcher 不具备且本次不引入运行时 Query Schema，因此只校验本地可准确判断的字段路径
+语法和 alias 规则。字段能力、基数、存储映射及昂贵查询策略仍由 Wow 服务端判定，错误
+沿现有 Fetcher 请求流程返回。
+
+## 数据流
+
+1. 调用方使用 `aggregation.any(field, alias)` 构造普通对象。
+2. `AggregationQuery` 通过现有 `SnapshotQueryClient.aggregate()` 或
+   `aggregateStream()` 原样序列化。
+3. Wow 按 Query Schema 解析字段并选择 MongoDB 或 Elasticsearch 实现。
+4. 结果继续由调用方通过现有 `Row extends DynamicDocument` 泛型声明；Fetcher 不从
+   alias 自动推导返回行类型。
+
+## 修改范围
+
+实现阶段只修改现有文件：
+
+- `packages/wow/src/query/aggregation.ts`
+- `packages/wow/test/query/aggregation.test.ts`
+- `packages/wow/README.md`
+- `packages/wow/README.zh-CN.md`
+- `skills/fetcher-wow-cqrs/references/api.md`
+- `wiki/packages/wow.md`
+- `wiki/zh/packages/wow.md`
+
+若实现发现必须修改列表外的源码、配置或 Generator，立即停止并重新确认设计。
+
+## 测试与验证
+
+包级测试覆盖：
+
+- `AggregationMetricType` 包含 `ANY`。
+- `aggregation.any()` 生成精确线格式。
+- 字段泛型限制保持有效。
+- 非法字段路径、含点 alias 与 `__wow` 保留前缀继续被现有校验拒绝。
+- `ANY` 与 `COUNT`、`NUMERIC` 能共存于同一非空 metrics tuple。
+
+验证顺序：
+
+1. `pnpm --filter @ahoo-wang/fetcher-wow test`
+2. `pnpm build`
+3. `pnpm test:unit`
+4. `pnpm --dir wiki build`
+5. 对变更 Markdown 运行 Prettier check，并执行 `git diff --check`
+6. 构建 Generator 后，以 Wow
+   `wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json` 运行真实 CLI
+   生成；只验证兼容性，不因成功验证产生 Generator 源码 diff
+
+实现完成不等于发布。本设计不授权创建 PR、合并、发布或部署。

--- a/packages/wow/src/query/aggregation.ts
+++ b/packages/wow/src/query/aggregation.ts
@@ -28,6 +28,7 @@ export enum AggregationGroupType {
 export enum AggregationMetricType {
   COUNT = 'COUNT',
   NUMERIC = 'NUMERIC',
+  ANY = 'ANY',
 }
 
 export enum AggregationExpressionType {
@@ -131,8 +132,16 @@ export interface NumericAggregationMetric<FIELDS extends string = string> {
   alias: string;
 }
 
+export interface AnyAggregationMetric<FIELDS extends string = string> {
+  type: AggregationMetricType.ANY;
+  field: LogicalField<FIELDS>;
+  alias: string;
+}
+
 export type AggregationMetric<FIELDS extends string = string> =
-  CountAggregationMetric | NumericAggregationMetric<FIELDS>;
+  | CountAggregationMetric
+  | NumericAggregationMetric<FIELDS>
+  | AnyAggregationMetric<FIELDS>;
 
 export interface AggregationQuery<
   ROOT_FIELDS extends string = string,
@@ -280,6 +289,16 @@ export const aggregation = {
       unit,
       alias: aggregationAlias(alias),
       timeZone,
+    };
+  },
+  any<FIELDS extends string>(
+    field: FIELDS,
+    alias: string,
+  ): AnyAggregationMetric<FIELDS> {
+    return {
+      type: AggregationMetricType.ANY,
+      field: aggregationField(field),
+      alias: aggregationAlias(alias),
     };
   },
   count(alias: string): CountAggregationMetric {

--- a/packages/wow/test/query/aggregation.test.ts
+++ b/packages/wow/test/query/aggregation.test.ts
@@ -27,7 +27,13 @@ import {
 } from '../../src';
 
 type RootFields = 'state.status' | 'state.orders';
-type ItemFields = 'status' | 'quantity' | 'productId' | 'amount' | 'createdAt';
+type ItemFields =
+  | 'status'
+  | 'quantity'
+  | 'productId'
+  | 'productName'
+  | 'amount'
+  | 'createdAt';
 
 describe('AggregationQuery', () => {
   it('uses the Wow wire enum values', () => {
@@ -40,7 +46,7 @@ describe('AggregationQuery', () => {
       function: Object.values(AggregationFunction),
     }).toEqual({
       group: ['TERMS', 'HISTOGRAM', 'DATE_HISTOGRAM'],
-      metric: ['COUNT', 'NUMERIC'],
+      metric: ['COUNT', 'NUMERIC', 'ANY'],
       expression: ['FIELD', 'CONSTANT', 'BINARY'],
       operator: ['ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE'],
       dateUnit: [
@@ -170,6 +176,31 @@ describe('AggregationQuery', () => {
     });
   });
 
+  it('builds an ANY metric without adding a group', () => {
+    const query: AggregationQuery<RootFields, ItemFields> = {
+      groupBy: [aggregation.terms('productId', 'product')],
+      metrics: [
+        aggregation.any('productName', 'productName'),
+        aggregation.count('count'),
+        aggregation.sum(aggregation.field('amount'), 'total'),
+      ],
+    };
+
+    expect(query).toStrictEqual({
+      groupBy: [{ type: 'TERMS', field: 'productId', alias: 'product' }],
+      metrics: [
+        { type: 'ANY', field: 'productName', alias: 'productName' },
+        { type: 'COUNT', alias: 'count' },
+        {
+          type: 'NUMERIC',
+          function: 'SUM',
+          expression: { type: 'FIELD', field: 'amount' },
+          alias: 'total',
+        },
+      ],
+    });
+  });
+
   it.each([
     ['invalid field', () => aggregation.field('bad field')],
     ['non-finite constant', () => aggregation.constant(Number.NaN)],
@@ -179,6 +210,15 @@ describe('AggregationQuery', () => {
     ],
     ['multi-segment alias', () => aggregation.terms('status', 'group.status')],
     ['reserved alias', () => aggregation.count('__wow_count')],
+    ['invalid ANY field', () => aggregation.any('bad field', 'productName')],
+    [
+      'multi-segment ANY alias',
+      () => aggregation.any('productName', 'product.name'),
+    ],
+    [
+      'reserved ANY alias',
+      () => aggregation.any('productName', '__wow_productName'),
+    ],
     [
       'blank time zone',
       () =>
@@ -260,12 +300,19 @@ describe('AggregationQuery', () => {
         aggregation.sum(aggregation.field('unknown'), 'total'),
       ],
     };
+    const invalidAnyMetric: AggregationQuery<RootFields, ItemFields> = {
+      metrics: [
+        // @ts-expect-error unknown is not an ItemFields member.
+        aggregation.any('unknown', 'name'),
+      ],
+    };
     void valid;
     void invalidAggregationField;
     void invalidRootFilter;
     void invalidElementFilter;
     void emptyMetrics;
     void invalidMetricExpression;
+    void invalidAnyMetric;
   };
   expectTypeOf(assertAggregationFields).toBeFunction();
 });

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -694,6 +694,7 @@ to the current innermost element.
 
 - `COUNT`: `alias`
 - `NUMERIC`: `function`, `expression`, `alias`
+- `ANY`: `field`, `alias`
 
 `AggregationFunction` values are `SUM`, `AVG`, `MIN`, and `MAX`.
 `AggregationDateUnit` values are `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`,
@@ -718,6 +719,7 @@ aggregation.divide(left, right);
 aggregation.terms(field, alias);
 aggregation.histogram(field, { interval, alias });
 aggregation.dateHistogram(field, { unit, alias, timeZone }); // timeZone defaults to UTC
+aggregation.any(field, alias);
 aggregation.count(alias);
 aggregation.sum(expression, alias);
 aggregation.avg(expression, alias);
@@ -725,9 +727,17 @@ aggregation.min(expression, alias);
 aggregation.max(expression, alias);
 ```
 
-Wow validates the complete aggregation's aliases, sort fields, and expression
-depth on the server. The `Row` generic describes aggregation result rows only;
-Fetcher does not perform runtime decoding.
+`ANY` is a metric, not a group. It returns one non-null scalar from the current
+group, or `null` when no value exists. Its field is relative to the innermost
+element. Wow requires the field to support `AGGREGATE_TERMS` and rejects
+collection cardinality. MongoDB uses a `$max` accumulator while Elasticsearch
+uses a one-bucket `terms` aggregation, so the selected value is intentionally
+unspecified. Sorting by an `ANY` alias is an expensive metric sort.
+
+Wow validates the complete aggregation's field capabilities, cardinality,
+aliases, sort fields, and expression depth on the server. Fetcher only validates
+field-path and alias syntax that can be known locally. The `Row` generic describes
+aggregation result rows only; Fetcher does not perform runtime decoding.
 
 ## Query DSL Conditions (Deprecated)
 

--- a/wiki/packages/wow.md
+++ b/wiki/packages/wow.md
@@ -1,6 +1,6 @@
 ---
-title: "@ahoo-wang/fetcher-wow"
-description: "Wow framework integration for Fetcher providing DDD + Event Sourcing + CQRS support with typed command clients, snapshot query clients, event stream queries, and aggregate root interaction patterns."
+title: '@ahoo-wang/fetcher-wow'
+description: 'Wow framework integration for Fetcher providing DDD + Event Sourcing + CQRS support with typed command clients, snapshot query clients, event stream queries, and aggregate root interaction patterns.'
 ---
 
 # @ahoo-wang/fetcher-wow
@@ -110,18 +110,18 @@ Commands are wrapped in a `CommandRequest` that supports:
 
 ### Command Headers
 
-| Header | Constant | Description |
-|--------|----------|-------------|
-| `Command-Tenant-Id` | `CommandHeaders.TENANT_ID` | Tenant identifier |
-| `Command-Owner-Id` | `CommandHeaders.OWNER_ID` | Owner identifier |
-| `Command-Space-Id` | `CommandHeaders.SPACE_ID` | Space identifier |
-| `Command-Aggregate-Id` | `CommandHeaders.AGGREGATE_ID` | Aggregate instance ID |
+| Header                      | Constant                           | Description                |
+| --------------------------- | ---------------------------------- | -------------------------- |
+| `Command-Tenant-Id`         | `CommandHeaders.TENANT_ID`         | Tenant identifier          |
+| `Command-Owner-Id`          | `CommandHeaders.OWNER_ID`          | Owner identifier           |
+| `Command-Space-Id`          | `CommandHeaders.SPACE_ID`          | Space identifier           |
+| `Command-Aggregate-Id`      | `CommandHeaders.AGGREGATE_ID`      | Aggregate instance ID      |
 | `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | Expected aggregate version |
-| `Command-Wait-Stage` | `CommandHeaders.WAIT_STAGE` | Wait processing stage |
-| `Command-Wait-Timeout` | `CommandHeaders.WAIT_TIME_OUT` | Wait timeout duration |
-| `Command-Wait-Context` | `CommandHeaders.WAIT_CONTEXT` | Wait processing context |
-| `Command-Request-Id` | `CommandHeaders.REQUEST_ID` | Request correlation ID |
-| `Command-Local-First` | `CommandHeaders.LOCAL_FIRST` | Execute locally first |
+| `Command-Wait-Stage`        | `CommandHeaders.WAIT_STAGE`        | Wait processing stage      |
+| `Command-Wait-Timeout`      | `CommandHeaders.WAIT_TIME_OUT`     | Wait timeout duration      |
+| `Command-Wait-Context`      | `CommandHeaders.WAIT_CONTEXT`      | Wait processing context    |
+| `Command-Request-Id`        | `CommandHeaders.REQUEST_ID`        | Request correlation ID     |
+| `Command-Local-First`       | `CommandHeaders.LOCAL_FIRST`       | Execute locally first      |
 
 Source: [packages/wow/src/command/commandHeaders.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/commandHeaders.ts)
 
@@ -164,14 +164,14 @@ Source: [packages/wow/src/command/commandResult.ts:74-110](https://github.com/Ah
 
 The `CommandStage` enum defines the processing stages at which a command's wait-strategy can signal completion. It is used as the value of the `Command-Wait-Stage` header and the `CommandResult.stage` field:
 
-| Stage | Value | Completion Signal |
-|-------|-------|-------------------|
-| `SENT` | `'SENT'` | Command published to the command bus/queue |
-| `PROCESSED` | `'PROCESSED'` | Command processed by the aggregate root |
-| `SNAPSHOT` | `'SNAPSHOT'` | Snapshot generated (aggregate state materialized) |
-| `PROJECTED` | `'PROJECTED'` | Events projected to read models |
-| `EVENT_HANDLED` | `'EVENT_HANDLED'` | Events processed by event handlers |
-| `SAGA_HANDLED` | `'SAGA_HANDLED'` | Events processed by Saga processes |
+| Stage           | Value             | Completion Signal                                 |
+| --------------- | ----------------- | ------------------------------------------------- |
+| `SENT`          | `'SENT'`          | Command published to the command bus/queue        |
+| `PROCESSED`     | `'PROCESSED'`     | Command processed by the aggregate root           |
+| `SNAPSHOT`      | `'SNAPSHOT'`      | Snapshot generated (aggregate state materialized) |
+| `PROJECTED`     | `'PROJECTED'`     | Events projected to read models                   |
+| `EVENT_HANDLED` | `'EVENT_HANDLED'` | Events processed by event handlers                |
+| `SAGA_HANDLED`  | `'SAGA_HANDLED'`  | Events processed by Saga processes                |
 
 Source: [packages/wow/src/command/types.ts:54-84](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/types.ts#L54-L84)
 
@@ -231,23 +231,23 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 #### SnapshotQueryClient Methods
 
-| Method | Endpoint | Returns | Description |
-|--------|----------|---------|-------------|
-| `count(filter)` | `/snapshot/count` | `Promise<number>` | Count matching aggregates |
-| `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | List snapshots |
-| `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream |
-| `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | List state only |
-| `listStateStream(listQuery)` | `/snapshot/list/state` | `Promise<ReadableStream<JsonServerSentEvent<S>>>` | State as SSE stream |
-| `paged(pagedQuery)` | `/snapshot/paged` | `Promise<PagedList<MaterializedSnapshot<S>>>` | Paginated snapshots |
-| `pagedState(pagedQuery)` | `/snapshot/paged/state` | `Promise<PagedList<S>>` | Paginated state |
-| `single(singleQuery)` | `/snapshot/single` | `Promise<MaterializedSnapshot<S>>` | Single snapshot |
-| `singleState(singleQuery)` | `/snapshot/single/state` | `Promise<S>` | Single state |
-| `getById(id)` | -- | `Promise<MaterializedSnapshot<S>>` | Get by aggregate ID |
-| `getStateById(id)` | -- | `Promise<S>` | Get state by ID |
-| `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | Get multiple by IDs |
-| `getStateByIds(ids)` | -- | `Promise<S[]>` | Get multiple states |
-| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | Aggregate snapshots |
-| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | Aggregate snapshots as SSE |
+| Method                       | Endpoint                 | Returns                                                                 | Description                |
+| ---------------------------- | ------------------------ | ----------------------------------------------------------------------- | -------------------------- |
+| `count(filter)`              | `/snapshot/count`        | `Promise<number>`                                                       | Count matching aggregates  |
+| `list(listQuery)`            | `/snapshot/list`         | `Promise<MaterializedSnapshot<S>[]>`                                    | List snapshots             |
+| `listStream(listQuery)`      | `/snapshot/list`         | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream         |
+| `listState(listQuery)`       | `/snapshot/list/state`   | `Promise<S[]>`                                                          | List state only            |
+| `listStateStream(listQuery)` | `/snapshot/list/state`   | `Promise<ReadableStream<JsonServerSentEvent<S>>>`                       | State as SSE stream        |
+| `paged(pagedQuery)`          | `/snapshot/paged`        | `Promise<PagedList<MaterializedSnapshot<S>>>`                           | Paginated snapshots        |
+| `pagedState(pagedQuery)`     | `/snapshot/paged/state`  | `Promise<PagedList<S>>`                                                 | Paginated state            |
+| `single(singleQuery)`        | `/snapshot/single`       | `Promise<MaterializedSnapshot<S>>`                                      | Single snapshot            |
+| `singleState(singleQuery)`   | `/snapshot/single/state` | `Promise<S>`                                                            | Single state               |
+| `getById(id)`                | --                       | `Promise<MaterializedSnapshot<S>>`                                      | Get by aggregate ID        |
+| `getStateById(id)`           | --                       | `Promise<S>`                                                            | Get state by ID            |
+| `getByIds(ids)`              | --                       | `Promise<MaterializedSnapshot<S>[]>`                                    | Get multiple by IDs        |
+| `getStateByIds(ids)`         | --                       | `Promise<S[]>`                                                          | Get multiple states        |
+| `aggregate(query)`           | `/snapshot/aggregation`  | `Promise<Row[]>`                                                        | Aggregate snapshots        |
+| `aggregateStream(query)`     | `/snapshot/aggregation`  | `Promise<ReadableStream<JsonServerSentEvent<Row>>>`                     | Aggregate snapshots as SSE |
 
 For compatibility with existing implementations, `SnapshotQueryApi` declares
 `aggregate?` and `aggregateStream?` as optional. `SnapshotQueryClient`
@@ -258,11 +258,20 @@ Source: [packages/wow/src/query/snapshot/snapshotQueryClient.ts:119-516](https:/
 #### Snapshot Aggregation
 
 ```typescript
-import { aggregation, filter, type AggregationQuery } from '@ahoo-wang/fetcher-wow';
+import {
+  aggregation,
+  filter,
+  type AggregationQuery,
+} from '@ahoo-wang/fetcher-wow';
 
 type CartFields = 'state.status' | 'state.items';
 type ItemFields = 'productId' | 'price' | 'quantity';
-type ProductSummary = { product: string; itemCount: number; revenue: number };
+type ProductSummary = {
+  product: string;
+  representativeProduct: string | null;
+  itemCount: number;
+  revenue: number;
+};
 
 const revenue = aggregation.multiply(
   aggregation.field<ItemFields>('price'),
@@ -274,6 +283,7 @@ const query: AggregationQuery<CartFields, ItemFields> = {
   elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
   groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
+    aggregation.any('productId', 'representativeProduct'),
     aggregation.count('itemCount'),
     aggregation.sum(revenue, 'revenue'),
   ],
@@ -283,12 +293,21 @@ const summaries = await client.aggregate<ProductSummary>(query);
 const summaryStream = await client.aggregateStream<ProductSummary>(query);
 ```
 
+`aggregation.any(field, alias)` returns one non-null scalar per current group,
+or `null` when no value exists, without adding a group key. Selection is
+intentionally unspecified across backends and executions. The field is relative
+to the innermost element; Wow rejects collection or non-terms-capable fields.
+Sorting by an `ANY` alias is an expensive metric sort.
+
 ### QueryClientFactory
 
 A factory that creates all query clients for a given aggregate, pre-configured with the correct base path:
 
 ```typescript
-import { QueryClientFactory, ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow';
+import {
+  QueryClientFactory,
+  ResourceAttributionPathSpec,
+} from '@ahoo-wang/fetcher-wow';
 
 const factory = new QueryClientFactory<CartState, CartFields, CartDomainEvent>({
   contextAlias: 'example',
@@ -303,12 +322,12 @@ const ownerStateClient = factory.createOwnerLoadStateAggregateClient();
 const eventClient = factory.createEventStreamQueryClient();
 ```
 
-| Factory Method | Creates | Description |
-|----------------|---------|-------------|
-| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | Snapshot queries with filters |
-| `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | Load by ID, version, or time |
-| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state |
-| `createEventStreamQueryClient()` | `EventStreamQueryClient` | Domain event stream queries |
+| Factory Method                          | Creates                            | Description                   |
+| --------------------------------------- | ---------------------------------- | ----------------------------- |
+| `createSnapshotQueryClient()`           | `SnapshotQueryClient<S, FIELDS>`   | Snapshot queries with filters |
+| `createLoadStateAggregateClient()`      | `LoadStateAggregateClient<S>`      | Load by ID, version, or time  |
+| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state  |
+| `createEventStreamQueryClient()`        | `EventStreamQueryClient`           | Domain event stream queries   |
 
 Source: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/queryClients.ts#L62-L214)
 
@@ -330,7 +349,11 @@ import {
 const activeCarts = filter.and([
   filter.isIn('state.status', ['ACTIVE', 'PENDING']),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
-  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
+  filter.contains(
+    'state.ownerName',
+    'ahoowang',
+    StringComparison.CASE_INSENSITIVE,
+  ),
 ]);
 
 const request = { filter: activeCarts, limit: 100 };
@@ -346,16 +369,16 @@ const yesterday = filter.yesterday('state.createdAt', {
 });
 ```
 
-| Category | `filter` builders | Notes |
-|----------|-------------------|-------|
-| Logical | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)` | Logical builders accept one `readonly` array with at least one operand. |
-| Metadata | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | Plural builders accept one non-empty `readonly` array. |
-| Comparison | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | Values are JSON scalar values; equality also accepts `null` and arrays. |
-| String | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`. |
-| Collection | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)` | Collection builders accept one non-empty `readonly` array. |
-| Presence | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | Field presence builders. |
-| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)` | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; `SearchFilterOptions` accepts `fields` and `mode` (`SearchMode.TERMS` by default); element predicates cannot contain root metadata, deletion, or search filters. |
-| Relative time | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId`, `datePattern`, and `timeUnit` (`TimeUnit.MILLISECONDS` by default); `days` must be a positive JVM `Int`. |
+| Category       | `filter` builders                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Notes                                                                                                                                                                                                                            |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Logical        | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)`                                                                                                                                                                                                                                                                                                                                                                                                | Logical builders accept one `readonly` array with at least one operand.                                                                                                                                                          |
+| Metadata       | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)`                                                                                                                                                                                                                                                                                                                                              | Plural builders accept one non-empty `readonly` array.                                                                                                                                                                           |
+| Comparison     | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)`                                                                                                                                                                                                                                                                                                           | Values are JSON scalar values; equality also accepts `null` and arrays.                                                                                                                                                          |
+| String         | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)`                                                                                                                                                                                                                                                                                                                                                                                              | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`.                                                                                                                                                                |
+| Collection     | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)`                                                                                                                                                                                                                                                                                                                                                                                                  | Collection builders accept one non-empty `readonly` array.                                                                                                                                                                       |
+| Presence       | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`                                                                                                                                                                                                                                                                                                                                                                                   | Field presence builders.                                                                                                                                                                                                         |
+| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)`                                                                                                                                                                                                                                                                                                                                                                                               | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; `SearchFilterOptions` accepts `fields` and `mode` (`SearchMode.TERMS` by default); element predicates cannot contain root metadata, deletion, or search filters. |
+| Relative time  | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId`, `datePattern`, and `timeUnit` (`TimeUnit.MILLISECONDS` by default); `days` must be a positive JVM `Int`.                                                                                         |
 
 Source: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
@@ -390,12 +413,21 @@ const list = {
 For large datasets, cursor-based pagination is more efficient than offset-based pagination. It avoids the performance degradation of deep offset queries by using a cursor ID to track position:
 
 ```typescript
-import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
+import {
+  cursorQuery,
+  CURSOR_ID_START,
+  filter,
+  SortDirection,
+} from '@ahoo-wang/fetcher-wow';
 
 // First page — start from the beginning
 const firstPage = cursorQuery({
-  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
-  cursorId: CURSOR_ID_START,  // '~' — start from the beginning
+  query: {
+    filter: filter.matchAll(),
+    limit: 50,
+    projection: { include: ['id', 'name'] },
+  },
+  cursorId: CURSOR_ID_START, // '~' — start from the beginning
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -403,7 +435,7 @@ const firstPage = cursorQuery({
 // Subsequent pages — use the last item's cursor ID from the previous result
 const nextPage = cursorQuery({
   query: { filter: filter.matchAll(), limit: 50 },
-  cursorId: lastItemId,  // cursor ID from the previous page
+  cursorId: lastItemId, // cursor ID from the previous page
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -469,34 +501,34 @@ Source: [packages/wow/src/index.ts](https://github.com/Ahoo-Wang/fetcher/blob/ma
 
 ## Key Exports
 
-| Export | Module | Description |
-|--------|--------|-------------|
-| `CommandClient` | `command/` | Decorator-based command sending client |
-| `CommandRequest` | `command/` | Typed command request with headers |
-| `CommandResult` | `command/` | Command execution result |
-| `CommandResultEventStream` | `command/` | SSE stream of command results |
-| `CommandBody<C>` | `command/` | Command body wrapper type |
-| `CommandHeaders` | `command/` | Header name constants |
-| `QueryClientFactory` | `query/` | Factory for creating all query clients |
-| `QueryClientOptions` | `query/` | Configuration for query clients |
-| `SnapshotQueryClient` | `query/snapshot/` | Snapshot query operations |
-| `EventStreamQueryClient` | `query/event/` | Domain event stream queries |
-| `LoadStateAggregateClient` | `query/state/` | Load aggregate state by ID/version/time |
-| `LoadOwnerStateAggregateClient` | `query/state/` | Load owner's aggregate state |
-| `FilterExpression` | `query/` | Typed query-filter union |
-| `filter` | `query/` | `FilterExpression` builders for new queries |
-| `SearchMode`, `TimeUnit` | `query/` | Search and relative-time option enums |
-| `AggregationQuery` | `query/` | Typed snapshot aggregation request |
-| `aggregation` | `query/` | Aggregation query builders |
-| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/` | Aggregation schema enums |
-| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | Run an aggregation and return result rows |
-| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
-| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | Deprecated compatibility API |
-| `listQuery()` | `query/` | Create a list query |
-| `pagedQuery()` | `query/` | Create a paged query |
-| `singleQuery()` | `query/` | Create a single query |
-| `FieldSort` | `query/` | Sort specification |
-| `ResourceAttributionPathSpec` | `types/` | Path spec for tenant/owner scoping |
+| Export                                                                                                                                                      | Module            | Description                                      |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------------------------------------------ |
+| `CommandClient`                                                                                                                                             | `command/`        | Decorator-based command sending client           |
+| `CommandRequest`                                                                                                                                            | `command/`        | Typed command request with headers               |
+| `CommandResult`                                                                                                                                             | `command/`        | Command execution result                         |
+| `CommandResultEventStream`                                                                                                                                  | `command/`        | SSE stream of command results                    |
+| `CommandBody<C>`                                                                                                                                            | `command/`        | Command body wrapper type                        |
+| `CommandHeaders`                                                                                                                                            | `command/`        | Header name constants                            |
+| `QueryClientFactory`                                                                                                                                        | `query/`          | Factory for creating all query clients           |
+| `QueryClientOptions`                                                                                                                                        | `query/`          | Configuration for query clients                  |
+| `SnapshotQueryClient`                                                                                                                                       | `query/snapshot/` | Snapshot query operations                        |
+| `EventStreamQueryClient`                                                                                                                                    | `query/event/`    | Domain event stream queries                      |
+| `LoadStateAggregateClient`                                                                                                                                  | `query/state/`    | Load aggregate state by ID/version/time          |
+| `LoadOwnerStateAggregateClient`                                                                                                                             | `query/state/`    | Load owner's aggregate state                     |
+| `FilterExpression`                                                                                                                                          | `query/`          | Typed query-filter union                         |
+| `filter`                                                                                                                                                    | `query/`          | `FilterExpression` builders for new queries      |
+| `SearchMode`, `TimeUnit`                                                                                                                                    | `query/`          | Search and relative-time option enums            |
+| `AggregationQuery`                                                                                                                                          | `query/`          | Typed snapshot aggregation request               |
+| `aggregation`                                                                                                                                               | `query/`          | Aggregation query builders                       |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/`          | Aggregation schema enums                         |
+| `SnapshotQueryClient.aggregate()`                                                                                                                           | `query/snapshot/` | Run an aggregation and return result rows        |
+| `SnapshotQueryClient.aggregateStream()`                                                                                                                     | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
+| `Condition`, `all()`, `and(...)`, `Operator`                                                                                                                | `query/`          | Deprecated compatibility API                     |
+| `listQuery()`                                                                                                                                               | `query/`          | Create a list query                              |
+| `pagedQuery()`                                                                                                                                              | `query/`          | Create a paged query                             |
+| `singleQuery()`                                                                                                                                             | `query/`          | Create a single query                            |
+| `FieldSort`                                                                                                                                                 | `query/`          | Sort specification                               |
+| `ResourceAttributionPathSpec`                                                                                                                               | `types/`          | Path spec for tenant/owner scoping               |
 
 ## Generated Clients
 

--- a/wiki/packages/wow.md
+++ b/wiki/packages/wow.md
@@ -1,6 +1,6 @@
 ---
-title: '@ahoo-wang/fetcher-wow'
-description: 'Wow framework integration for Fetcher providing DDD + Event Sourcing + CQRS support with typed command clients, snapshot query clients, event stream queries, and aggregate root interaction patterns.'
+title: "@ahoo-wang/fetcher-wow"
+description: "Wow framework integration for Fetcher providing DDD + Event Sourcing + CQRS support with typed command clients, snapshot query clients, event stream queries, and aggregate root interaction patterns."
 ---
 
 # @ahoo-wang/fetcher-wow
@@ -110,18 +110,18 @@ Commands are wrapped in a `CommandRequest` that supports:
 
 ### Command Headers
 
-| Header                      | Constant                           | Description                |
-| --------------------------- | ---------------------------------- | -------------------------- |
-| `Command-Tenant-Id`         | `CommandHeaders.TENANT_ID`         | Tenant identifier          |
-| `Command-Owner-Id`          | `CommandHeaders.OWNER_ID`          | Owner identifier           |
-| `Command-Space-Id`          | `CommandHeaders.SPACE_ID`          | Space identifier           |
-| `Command-Aggregate-Id`      | `CommandHeaders.AGGREGATE_ID`      | Aggregate instance ID      |
+| Header | Constant | Description |
+|--------|----------|-------------|
+| `Command-Tenant-Id` | `CommandHeaders.TENANT_ID` | Tenant identifier |
+| `Command-Owner-Id` | `CommandHeaders.OWNER_ID` | Owner identifier |
+| `Command-Space-Id` | `CommandHeaders.SPACE_ID` | Space identifier |
+| `Command-Aggregate-Id` | `CommandHeaders.AGGREGATE_ID` | Aggregate instance ID |
 | `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | Expected aggregate version |
-| `Command-Wait-Stage`        | `CommandHeaders.WAIT_STAGE`        | Wait processing stage      |
-| `Command-Wait-Timeout`      | `CommandHeaders.WAIT_TIME_OUT`     | Wait timeout duration      |
-| `Command-Wait-Context`      | `CommandHeaders.WAIT_CONTEXT`      | Wait processing context    |
-| `Command-Request-Id`        | `CommandHeaders.REQUEST_ID`        | Request correlation ID     |
-| `Command-Local-First`       | `CommandHeaders.LOCAL_FIRST`       | Execute locally first      |
+| `Command-Wait-Stage` | `CommandHeaders.WAIT_STAGE` | Wait processing stage |
+| `Command-Wait-Timeout` | `CommandHeaders.WAIT_TIME_OUT` | Wait timeout duration |
+| `Command-Wait-Context` | `CommandHeaders.WAIT_CONTEXT` | Wait processing context |
+| `Command-Request-Id` | `CommandHeaders.REQUEST_ID` | Request correlation ID |
+| `Command-Local-First` | `CommandHeaders.LOCAL_FIRST` | Execute locally first |
 
 Source: [packages/wow/src/command/commandHeaders.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/commandHeaders.ts)
 
@@ -164,14 +164,14 @@ Source: [packages/wow/src/command/commandResult.ts:74-110](https://github.com/Ah
 
 The `CommandStage` enum defines the processing stages at which a command's wait-strategy can signal completion. It is used as the value of the `Command-Wait-Stage` header and the `CommandResult.stage` field:
 
-| Stage           | Value             | Completion Signal                                 |
-| --------------- | ----------------- | ------------------------------------------------- |
-| `SENT`          | `'SENT'`          | Command published to the command bus/queue        |
-| `PROCESSED`     | `'PROCESSED'`     | Command processed by the aggregate root           |
-| `SNAPSHOT`      | `'SNAPSHOT'`      | Snapshot generated (aggregate state materialized) |
-| `PROJECTED`     | `'PROJECTED'`     | Events projected to read models                   |
-| `EVENT_HANDLED` | `'EVENT_HANDLED'` | Events processed by event handlers                |
-| `SAGA_HANDLED`  | `'SAGA_HANDLED'`  | Events processed by Saga processes                |
+| Stage | Value | Completion Signal |
+|-------|-------|-------------------|
+| `SENT` | `'SENT'` | Command published to the command bus/queue |
+| `PROCESSED` | `'PROCESSED'` | Command processed by the aggregate root |
+| `SNAPSHOT` | `'SNAPSHOT'` | Snapshot generated (aggregate state materialized) |
+| `PROJECTED` | `'PROJECTED'` | Events projected to read models |
+| `EVENT_HANDLED` | `'EVENT_HANDLED'` | Events processed by event handlers |
+| `SAGA_HANDLED` | `'SAGA_HANDLED'` | Events processed by Saga processes |
 
 Source: [packages/wow/src/command/types.ts:54-84](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/types.ts#L54-L84)
 
@@ -231,23 +231,23 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 #### SnapshotQueryClient Methods
 
-| Method                       | Endpoint                 | Returns                                                                 | Description                |
-| ---------------------------- | ------------------------ | ----------------------------------------------------------------------- | -------------------------- |
-| `count(filter)`              | `/snapshot/count`        | `Promise<number>`                                                       | Count matching aggregates  |
-| `list(listQuery)`            | `/snapshot/list`         | `Promise<MaterializedSnapshot<S>[]>`                                    | List snapshots             |
-| `listStream(listQuery)`      | `/snapshot/list`         | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream         |
-| `listState(listQuery)`       | `/snapshot/list/state`   | `Promise<S[]>`                                                          | List state only            |
-| `listStateStream(listQuery)` | `/snapshot/list/state`   | `Promise<ReadableStream<JsonServerSentEvent<S>>>`                       | State as SSE stream        |
-| `paged(pagedQuery)`          | `/snapshot/paged`        | `Promise<PagedList<MaterializedSnapshot<S>>>`                           | Paginated snapshots        |
-| `pagedState(pagedQuery)`     | `/snapshot/paged/state`  | `Promise<PagedList<S>>`                                                 | Paginated state            |
-| `single(singleQuery)`        | `/snapshot/single`       | `Promise<MaterializedSnapshot<S>>`                                      | Single snapshot            |
-| `singleState(singleQuery)`   | `/snapshot/single/state` | `Promise<S>`                                                            | Single state               |
-| `getById(id)`                | --                       | `Promise<MaterializedSnapshot<S>>`                                      | Get by aggregate ID        |
-| `getStateById(id)`           | --                       | `Promise<S>`                                                            | Get state by ID            |
-| `getByIds(ids)`              | --                       | `Promise<MaterializedSnapshot<S>[]>`                                    | Get multiple by IDs        |
-| `getStateByIds(ids)`         | --                       | `Promise<S[]>`                                                          | Get multiple states        |
-| `aggregate(query)`           | `/snapshot/aggregation`  | `Promise<Row[]>`                                                        | Aggregate snapshots        |
-| `aggregateStream(query)`     | `/snapshot/aggregation`  | `Promise<ReadableStream<JsonServerSentEvent<Row>>>`                     | Aggregate snapshots as SSE |
+| Method | Endpoint | Returns | Description |
+|--------|----------|---------|-------------|
+| `count(filter)` | `/snapshot/count` | `Promise<number>` | Count matching aggregates |
+| `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | List snapshots |
+| `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | List as SSE stream |
+| `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | List state only |
+| `listStateStream(listQuery)` | `/snapshot/list/state` | `Promise<ReadableStream<JsonServerSentEvent<S>>>` | State as SSE stream |
+| `paged(pagedQuery)` | `/snapshot/paged` | `Promise<PagedList<MaterializedSnapshot<S>>>` | Paginated snapshots |
+| `pagedState(pagedQuery)` | `/snapshot/paged/state` | `Promise<PagedList<S>>` | Paginated state |
+| `single(singleQuery)` | `/snapshot/single` | `Promise<MaterializedSnapshot<S>>` | Single snapshot |
+| `singleState(singleQuery)` | `/snapshot/single/state` | `Promise<S>` | Single state |
+| `getById(id)` | -- | `Promise<MaterializedSnapshot<S>>` | Get by aggregate ID |
+| `getStateById(id)` | -- | `Promise<S>` | Get state by ID |
+| `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | Get multiple by IDs |
+| `getStateByIds(ids)` | -- | `Promise<S[]>` | Get multiple states |
+| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | Aggregate snapshots |
+| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | Aggregate snapshots as SSE |
 
 For compatibility with existing implementations, `SnapshotQueryApi` declares
 `aggregate?` and `aggregateStream?` as optional. `SnapshotQueryClient`
@@ -258,11 +258,7 @@ Source: [packages/wow/src/query/snapshot/snapshotQueryClient.ts:119-516](https:/
 #### Snapshot Aggregation
 
 ```typescript
-import {
-  aggregation,
-  filter,
-  type AggregationQuery,
-} from '@ahoo-wang/fetcher-wow';
+import { aggregation, filter, type AggregationQuery } from '@ahoo-wang/fetcher-wow';
 
 type CartFields = 'state.status' | 'state.items';
 type ItemFields = 'productId' | 'price' | 'quantity';
@@ -304,10 +300,7 @@ Sorting by an `ANY` alias is an expensive metric sort.
 A factory that creates all query clients for a given aggregate, pre-configured with the correct base path:
 
 ```typescript
-import {
-  QueryClientFactory,
-  ResourceAttributionPathSpec,
-} from '@ahoo-wang/fetcher-wow';
+import { QueryClientFactory, ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow';
 
 const factory = new QueryClientFactory<CartState, CartFields, CartDomainEvent>({
   contextAlias: 'example',
@@ -322,12 +315,12 @@ const ownerStateClient = factory.createOwnerLoadStateAggregateClient();
 const eventClient = factory.createEventStreamQueryClient();
 ```
 
-| Factory Method                          | Creates                            | Description                   |
-| --------------------------------------- | ---------------------------------- | ----------------------------- |
-| `createSnapshotQueryClient()`           | `SnapshotQueryClient<S, FIELDS>`   | Snapshot queries with filters |
-| `createLoadStateAggregateClient()`      | `LoadStateAggregateClient<S>`      | Load by ID, version, or time  |
-| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state  |
-| `createEventStreamQueryClient()`        | `EventStreamQueryClient`           | Domain event stream queries   |
+| Factory Method | Creates | Description |
+|----------------|---------|-------------|
+| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | Snapshot queries with filters |
+| `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | Load by ID, version, or time |
+| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | Load owner's aggregate state |
+| `createEventStreamQueryClient()` | `EventStreamQueryClient` | Domain event stream queries |
 
 Source: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/queryClients.ts#L62-L214)
 
@@ -349,11 +342,7 @@ import {
 const activeCarts = filter.and([
   filter.isIn('state.status', ['ACTIVE', 'PENDING']),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
-  filter.contains(
-    'state.ownerName',
-    'ahoowang',
-    StringComparison.CASE_INSENSITIVE,
-  ),
+  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
 ]);
 
 const request = { filter: activeCarts, limit: 100 };
@@ -369,16 +358,16 @@ const yesterday = filter.yesterday('state.createdAt', {
 });
 ```
 
-| Category       | `filter` builders                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Notes                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Logical        | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)`                                                                                                                                                                                                                                                                                                                                                                                                | Logical builders accept one `readonly` array with at least one operand.                                                                                                                                                          |
-| Metadata       | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)`                                                                                                                                                                                                                                                                                                                                              | Plural builders accept one non-empty `readonly` array.                                                                                                                                                                           |
-| Comparison     | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)`                                                                                                                                                                                                                                                                                                           | Values are JSON scalar values; equality also accepts `null` and arrays.                                                                                                                                                          |
-| String         | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)`                                                                                                                                                                                                                                                                                                                                                                                              | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`.                                                                                                                                                                |
-| Collection     | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)`                                                                                                                                                                                                                                                                                                                                                                                                  | Collection builders accept one non-empty `readonly` array.                                                                                                                                                                       |
-| Presence       | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`                                                                                                                                                                                                                                                                                                                                                                                   | Field presence builders.                                                                                                                                                                                                         |
-| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)`                                                                                                                                                                                                                                                                                                                                                                                               | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; `SearchFilterOptions` accepts `fields` and `mode` (`SearchMode.TERMS` by default); element predicates cannot contain root metadata, deletion, or search filters. |
-| Relative time  | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId`, `datePattern`, and `timeUnit` (`TimeUnit.MILLISECONDS` by default); `days` must be a positive JVM `Int`.                                                                                         |
+| Category | `filter` builders | Notes |
+|----------|-------------------|-------|
+| Logical | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)` | Logical builders accept one `readonly` array with at least one operand. |
+| Metadata | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | Plural builders accept one non-empty `readonly` array. |
+| Comparison | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | Values are JSON scalar values; equality also accepts `null` and arrays. |
+| String | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` defaults to `StringComparison.CASE_SENSITIVE`. |
+| Collection | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)` | Collection builders accept one non-empty `readonly` array. |
+| Presence | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | Field presence builders. |
+| Scope / search | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)` | `deletion` accepts `DeletionState.ACTIVE`, `DELETED`, or `ALL`; `SearchFilterOptions` accepts `fields` and `mode` (`SearchMode.TERMS` by default); element predicates cannot contain root metadata, deletion, or search filters. |
+| Relative time | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` may contain `zoneId`, `datePattern`, and `timeUnit` (`TimeUnit.MILLISECONDS` by default); `days` must be a positive JVM `Int`. |
 
 Source: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
@@ -413,21 +402,12 @@ const list = {
 For large datasets, cursor-based pagination is more efficient than offset-based pagination. It avoids the performance degradation of deep offset queries by using a cursor ID to track position:
 
 ```typescript
-import {
-  cursorQuery,
-  CURSOR_ID_START,
-  filter,
-  SortDirection,
-} from '@ahoo-wang/fetcher-wow';
+import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
 
 // First page — start from the beginning
 const firstPage = cursorQuery({
-  query: {
-    filter: filter.matchAll(),
-    limit: 50,
-    projection: { include: ['id', 'name'] },
-  },
-  cursorId: CURSOR_ID_START, // '~' — start from the beginning
+  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
+  cursorId: CURSOR_ID_START,  // '~' — start from the beginning
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -435,7 +415,7 @@ const firstPage = cursorQuery({
 // Subsequent pages — use the last item's cursor ID from the previous result
 const nextPage = cursorQuery({
   query: { filter: filter.matchAll(), limit: 50 },
-  cursorId: lastItemId, // cursor ID from the previous page
+  cursorId: lastItemId,  // cursor ID from the previous page
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -501,34 +481,34 @@ Source: [packages/wow/src/index.ts](https://github.com/Ahoo-Wang/fetcher/blob/ma
 
 ## Key Exports
 
-| Export                                                                                                                                                      | Module            | Description                                      |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------------------------------------------ |
-| `CommandClient`                                                                                                                                             | `command/`        | Decorator-based command sending client           |
-| `CommandRequest`                                                                                                                                            | `command/`        | Typed command request with headers               |
-| `CommandResult`                                                                                                                                             | `command/`        | Command execution result                         |
-| `CommandResultEventStream`                                                                                                                                  | `command/`        | SSE stream of command results                    |
-| `CommandBody<C>`                                                                                                                                            | `command/`        | Command body wrapper type                        |
-| `CommandHeaders`                                                                                                                                            | `command/`        | Header name constants                            |
-| `QueryClientFactory`                                                                                                                                        | `query/`          | Factory for creating all query clients           |
-| `QueryClientOptions`                                                                                                                                        | `query/`          | Configuration for query clients                  |
-| `SnapshotQueryClient`                                                                                                                                       | `query/snapshot/` | Snapshot query operations                        |
-| `EventStreamQueryClient`                                                                                                                                    | `query/event/`    | Domain event stream queries                      |
-| `LoadStateAggregateClient`                                                                                                                                  | `query/state/`    | Load aggregate state by ID/version/time          |
-| `LoadOwnerStateAggregateClient`                                                                                                                             | `query/state/`    | Load owner's aggregate state                     |
-| `FilterExpression`                                                                                                                                          | `query/`          | Typed query-filter union                         |
-| `filter`                                                                                                                                                    | `query/`          | `FilterExpression` builders for new queries      |
-| `SearchMode`, `TimeUnit`                                                                                                                                    | `query/`          | Search and relative-time option enums            |
-| `AggregationQuery`                                                                                                                                          | `query/`          | Typed snapshot aggregation request               |
-| `aggregation`                                                                                                                                               | `query/`          | Aggregation query builders                       |
-| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/`          | Aggregation schema enums                         |
-| `SnapshotQueryClient.aggregate()`                                                                                                                           | `query/snapshot/` | Run an aggregation and return result rows        |
-| `SnapshotQueryClient.aggregateStream()`                                                                                                                     | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
-| `Condition`, `all()`, `and(...)`, `Operator`                                                                                                                | `query/`          | Deprecated compatibility API                     |
-| `listQuery()`                                                                                                                                               | `query/`          | Create a list query                              |
-| `pagedQuery()`                                                                                                                                              | `query/`          | Create a paged query                             |
-| `singleQuery()`                                                                                                                                             | `query/`          | Create a single query                            |
-| `FieldSort`                                                                                                                                                 | `query/`          | Sort specification                               |
-| `ResourceAttributionPathSpec`                                                                                                                               | `types/`          | Path spec for tenant/owner scoping               |
+| Export | Module | Description |
+|--------|--------|-------------|
+| `CommandClient` | `command/` | Decorator-based command sending client |
+| `CommandRequest` | `command/` | Typed command request with headers |
+| `CommandResult` | `command/` | Command execution result |
+| `CommandResultEventStream` | `command/` | SSE stream of command results |
+| `CommandBody<C>` | `command/` | Command body wrapper type |
+| `CommandHeaders` | `command/` | Header name constants |
+| `QueryClientFactory` | `query/` | Factory for creating all query clients |
+| `QueryClientOptions` | `query/` | Configuration for query clients |
+| `SnapshotQueryClient` | `query/snapshot/` | Snapshot query operations |
+| `EventStreamQueryClient` | `query/event/` | Domain event stream queries |
+| `LoadStateAggregateClient` | `query/state/` | Load aggregate state by ID/version/time |
+| `LoadOwnerStateAggregateClient` | `query/state/` | Load owner's aggregate state |
+| `FilterExpression` | `query/` | Typed query-filter union |
+| `filter` | `query/` | `FilterExpression` builders for new queries |
+| `SearchMode`, `TimeUnit` | `query/` | Search and relative-time option enums |
+| `AggregationQuery` | `query/` | Typed snapshot aggregation request |
+| `aggregation` | `query/` | Aggregation query builders |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/` | Aggregation schema enums |
+| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | Run an aggregation and return result rows |
+| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | Run an aggregation and stream result rows as SSE |
+| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | Deprecated compatibility API |
+| `listQuery()` | `query/` | Create a list query |
+| `pagedQuery()` | `query/` | Create a paged query |
+| `singleQuery()` | `query/` | Create a single query |
+| `FieldSort` | `query/` | Sort specification |
+| `ResourceAttributionPathSpec` | `types/` | Path spec for tenant/owner scoping |
 
 ## Generated Clients
 

--- a/wiki/zh/packages/wow.md
+++ b/wiki/zh/packages/wow.md
@@ -1,6 +1,6 @@
 ---
-title: '@ahoo-wang/fetcher-wow'
-description: 'Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS 支持，包括类型化命令客户端、快照查询客户端、事件流查询和聚合根交互模式。'
+title: "@ahoo-wang/fetcher-wow"
+description: "Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS 支持，包括类型化命令客户端、快照查询客户端、事件流查询和聚合根交互模式。"
 ---
 
 # @ahoo-wang/fetcher-wow
@@ -110,18 +110,18 @@ console.log('Command ID:', result.commandId);
 
 ### 命令头
 
-| 请求头                      | 常量                               | 描述           |
-| --------------------------- | ---------------------------------- | -------------- |
-| `Command-Tenant-Id`         | `CommandHeaders.TENANT_ID`         | 租户标识符     |
-| `Command-Owner-Id`          | `CommandHeaders.OWNER_ID`          | 所有者标识符   |
-| `Command-Space-Id`          | `CommandHeaders.SPACE_ID`          | 空间标识符     |
-| `Command-Aggregate-Id`      | `CommandHeaders.AGGREGATE_ID`      | 聚合实例 ID    |
-| `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | 预期聚合版本   |
-| `Command-Wait-Stage`        | `CommandHeaders.WAIT_STAGE`        | 等待处理阶段   |
-| `Command-Wait-Timeout`      | `CommandHeaders.WAIT_TIME_OUT`     | 等待超时时长   |
-| `Command-Wait-Context`      | `CommandHeaders.WAIT_CONTEXT`      | 等待处理上下文 |
-| `Command-Request-Id`        | `CommandHeaders.REQUEST_ID`        | 请求关联 ID    |
-| `Command-Local-First`       | `CommandHeaders.LOCAL_FIRST`       | 优先本地执行   |
+| 请求头 | 常量 | 描述 |
+|--------|----------|-------------|
+| `Command-Tenant-Id` | `CommandHeaders.TENANT_ID` | 租户标识符 |
+| `Command-Owner-Id` | `CommandHeaders.OWNER_ID` | 所有者标识符 |
+| `Command-Space-Id` | `CommandHeaders.SPACE_ID` | 空间标识符 |
+| `Command-Aggregate-Id` | `CommandHeaders.AGGREGATE_ID` | 聚合实例 ID |
+| `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | 预期聚合版本 |
+| `Command-Wait-Stage` | `CommandHeaders.WAIT_STAGE` | 等待处理阶段 |
+| `Command-Wait-Timeout` | `CommandHeaders.WAIT_TIME_OUT` | 等待超时时长 |
+| `Command-Wait-Context` | `CommandHeaders.WAIT_CONTEXT` | 等待处理上下文 |
+| `Command-Request-Id` | `CommandHeaders.REQUEST_ID` | 请求关联 ID |
+| `Command-Local-First` | `CommandHeaders.LOCAL_FIRST` | 优先本地执行 |
 
 来源: [packages/wow/src/command/commandHeaders.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/commandHeaders.ts)
 
@@ -164,14 +164,14 @@ classDiagram
 
 `CommandStage` 枚举定义了命令等待策略可以发出完成信号的处理阶段。它用作 `Command-Wait-Stage` 头的值和 `CommandResult.stage` 字段：
 
-| 阶段            | 值                | 完成信号                     |
-| --------------- | ----------------- | ---------------------------- |
-| `SENT`          | `'SENT'`          | 命令已发布到命令总线/队列    |
-| `PROCESSED`     | `'PROCESSED'`     | 命令已被聚合根处理           |
-| `SNAPSHOT`      | `'SNAPSHOT'`      | 已生成快照（聚合状态已物化） |
-| `PROJECTED`     | `'PROJECTED'`     | 事件已投射到读模型           |
-| `EVENT_HANDLED` | `'EVENT_HANDLED'` | 事件已被事件处理器处理       |
-| `SAGA_HANDLED`  | `'SAGA_HANDLED'`  | 事件已被 Saga 处理           |
+| 阶段 | 值 | 完成信号 |
+|------|-----|---------|
+| `SENT` | `'SENT'` | 命令已发布到命令总线/队列 |
+| `PROCESSED` | `'PROCESSED'` | 命令已被聚合根处理 |
+| `SNAPSHOT` | `'SNAPSHOT'` | 已生成快照（聚合状态已物化） |
+| `PROJECTED` | `'PROJECTED'` | 事件已投射到读模型 |
+| `EVENT_HANDLED` | `'EVENT_HANDLED'` | 事件已被事件处理器处理 |
+| `SAGA_HANDLED` | `'SAGA_HANDLED'` | 事件已被 Saga 处理 |
 
 源码: [packages/wow/src/command/types.ts:54-84](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/types.ts#L54-L84)
 
@@ -231,23 +231,23 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 #### SnapshotQueryClient 方法
 
-| 方法                         | 端点                     | 返回类型                                                                | 描述                  |
-| ---------------------------- | ------------------------ | ----------------------------------------------------------------------- | --------------------- |
-| `count(filter)`              | `/snapshot/count`        | `Promise<number>`                                                       | 统计匹配的聚合数量    |
-| `list(listQuery)`            | `/snapshot/list`         | `Promise<MaterializedSnapshot<S>[]>`                                    | 列表查询快照          |
-| `listStream(listQuery)`      | `/snapshot/list`         | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
-| `listState(listQuery)`       | `/snapshot/list/state`   | `Promise<S[]>`                                                          | 仅列出状态            |
-| `listStateStream(listQuery)` | `/snapshot/list/state`   | `Promise<ReadableStream<JsonServerSentEvent<S>>>`                       | 以 SSE 流形式列出状态 |
-| `paged(pagedQuery)`          | `/snapshot/paged`        | `Promise<PagedList<MaterializedSnapshot<S>>>`                           | 分页查询快照          |
-| `pagedState(pagedQuery)`     | `/snapshot/paged/state`  | `Promise<PagedList<S>>`                                                 | 分页查询状态          |
-| `single(singleQuery)`        | `/snapshot/single`       | `Promise<MaterializedSnapshot<S>>`                                      | 单个快照查询          |
-| `singleState(singleQuery)`   | `/snapshot/single/state` | `Promise<S>`                                                            | 单个状态查询          |
-| `getById(id)`                | --                       | `Promise<MaterializedSnapshot<S>>`                                      | 通过聚合 ID 获取      |
-| `getStateById(id)`           | --                       | `Promise<S>`                                                            | 通过 ID 获取状态      |
-| `getByIds(ids)`              | --                       | `Promise<MaterializedSnapshot<S>[]>`                                    | 通过多个 ID 获取      |
-| `getStateByIds(ids)`         | --                       | `Promise<S[]>`                                                          | 通过多个 ID 获取状态  |
-| `aggregate(query)`           | `/snapshot/aggregation`  | `Promise<Row[]>`                                                        | 聚合快照              |
-| `aggregateStream(query)`     | `/snapshot/aggregation`  | `Promise<ReadableStream<JsonServerSentEvent<Row>>>`                     | 以 SSE 聚合快照       |
+| 方法 | 端点 | 返回类型 | 描述 |
+|------|------|----------|------|
+| `count(filter)` | `/snapshot/count` | `Promise<number>` | 统计匹配的聚合数量 |
+| `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | 列表查询快照 |
+| `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
+| `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | 仅列出状态 |
+| `listStateStream(listQuery)` | `/snapshot/list/state` | `Promise<ReadableStream<JsonServerSentEvent<S>>>` | 以 SSE 流形式列出状态 |
+| `paged(pagedQuery)` | `/snapshot/paged` | `Promise<PagedList<MaterializedSnapshot<S>>>` | 分页查询快照 |
+| `pagedState(pagedQuery)` | `/snapshot/paged/state` | `Promise<PagedList<S>>` | 分页查询状态 |
+| `single(singleQuery)` | `/snapshot/single` | `Promise<MaterializedSnapshot<S>>` | 单个快照查询 |
+| `singleState(singleQuery)` | `/snapshot/single/state` | `Promise<S>` | 单个状态查询 |
+| `getById(id)` | -- | `Promise<MaterializedSnapshot<S>>` | 通过聚合 ID 获取 |
+| `getStateById(id)` | -- | `Promise<S>` | 通过 ID 获取状态 |
+| `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | 通过多个 ID 获取 |
+| `getStateByIds(ids)` | -- | `Promise<S[]>` | 通过多个 ID 获取状态 |
+| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | 聚合快照 |
+| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | 以 SSE 聚合快照 |
 
 为兼容既有实现，`SnapshotQueryApi` 将 `aggregate?` 和 `aggregateStream?`
 声明为可选方法；`SnapshotQueryClient` 将两者实现为必需方法。
@@ -257,11 +257,7 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 #### 快照聚合
 
 ```typescript
-import {
-  aggregation,
-  filter,
-  type AggregationQuery,
-} from '@ahoo-wang/fetcher-wow';
+import { aggregation, filter, type AggregationQuery } from '@ahoo-wang/fetcher-wow';
 
 type CartFields = 'state.status' | 'state.items';
 type ItemFields = 'productId' | 'price' | 'quantity';
@@ -302,10 +298,7 @@ Element；集合字段或不具备 terms 聚合能力的字段由 Wow 拒绝。�
 为给定聚合创建所有查询客户端的工厂，预配置了正确的基本路径：
 
 ```typescript
-import {
-  QueryClientFactory,
-  ResourceAttributionPathSpec,
-} from '@ahoo-wang/fetcher-wow';
+import { QueryClientFactory, ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow';
 
 const factory = new QueryClientFactory<CartState, CartFields, CartDomainEvent>({
   contextAlias: 'example',
@@ -320,12 +313,12 @@ const ownerStateClient = factory.createOwnerLoadStateAggregateClient();
 const eventClient = factory.createEventStreamQueryClient();
 ```
 
-| 工厂方法                                | 创建的客户端                       | 描述                    |
-| --------------------------------------- | ---------------------------------- | ----------------------- |
-| `createSnapshotQueryClient()`           | `SnapshotQueryClient<S, FIELDS>`   | 带筛选器的快照查询      |
-| `createLoadStateAggregateClient()`      | `LoadStateAggregateClient<S>`      | 通过 ID、版本或时间加载 |
-| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态    |
-| `createEventStreamQueryClient()`        | `EventStreamQueryClient`           | 领域事件流查询          |
+| 工厂方法 | 创建的客户端 | 描述 |
+|----------|-------------|------|
+| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | 带筛选器的快照查询 |
+| `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | 通过 ID、版本或时间加载 |
+| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态 |
+| `createEventStreamQueryClient()` | `EventStreamQueryClient` | 领域事件流查询 |
 
 来源: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/queryClients.ts#L62-L214)
 
@@ -346,11 +339,7 @@ import {
 const activeCarts = filter.and([
   filter.isIn('state.status', ['ACTIVE', 'PENDING']),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
-  filter.contains(
-    'state.ownerName',
-    'ahoowang',
-    StringComparison.CASE_INSENSITIVE,
-  ),
+  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
 ]);
 
 const request = { filter: activeCarts, limit: 100 };
@@ -366,16 +355,16 @@ const yesterday = filter.yesterday('state.createdAt', {
 });
 ```
 
-| 分类          | `filter` 构建器                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 说明                                                                                                                                                                               |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 逻辑          | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)`                                                                                                                                                                                                                                                                                                                                                                                                | 逻辑构建器接收一个至少含一个操作数的 `readonly` 数组。                                                                                                                             |
-| 元数据        | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)`                                                                                                                                                                                                                                                                                                                                              | 复数构建器接收一个非空 `readonly` 数组。                                                                                                                                           |
-| 比较          | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)`                                                                                                                                                                                                                                                                                                           | 值为 JSON 标量；相等比较也接受 `null` 和数组。                                                                                                                                     |
-| 字符串        | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)`                                                                                                                                                                                                                                                                                                                                                                                              | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。                                                                                                                      |
-| 集合          | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)`                                                                                                                                                                                                                                                                                                                                                                                                  | 集合构建器接收一个非空 `readonly` 数组。                                                                                                                                           |
-| 存在性        | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`                                                                                                                                                                                                                                                                                                                                                                                   | 字段存在性构建器。                                                                                                                                                                 |
-| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)`                                                                                                                                                                                                                                                                                                                                                                                               | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；`SearchFilterOptions` 接受 `fields` 和 `mode`（默认 `SearchMode.TERMS`）；元素谓词不能包含根元数据、删除或搜索筛选器。 |
-| 相对时间      | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId`、`datePattern` 和 `timeUnit`（默认 `TimeUnit.MILLISECONDS`）；`days` 必须为正的 JVM `Int`。                                                              |
+| 分类 | `filter` 构建器 | 说明 |
+|------|-----------------|------|
+| 逻辑 | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)` | 逻辑构建器接收一个至少含一个操作数的 `readonly` 数组。 |
+| 元数据 | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | 复数构建器接收一个非空 `readonly` 数组。 |
+| 比较 | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | 值为 JSON 标量；相等比较也接受 `null` 和数组。 |
+| 字符串 | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。 |
+| 集合 | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)` | 集合构建器接收一个非空 `readonly` 数组。 |
+| 存在性 | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | 字段存在性构建器。 |
+| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)` | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；`SearchFilterOptions` 接受 `fields` 和 `mode`（默认 `SearchMode.TERMS`）；元素谓词不能包含根元数据、删除或搜索筛选器。 |
+| 相对时间 | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId`、`datePattern` 和 `timeUnit`（默认 `TimeUnit.MILLISECONDS`）；`days` 必须为正的 JVM `Int`。 |
 
 来源: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
@@ -407,21 +396,12 @@ const list = {
 对于大型数据集，基于游标的分页比基于偏移量的分页更高效。它通过使用游标 ID 跟踪位置，避免了深偏移查询的性能退化：
 
 ```typescript
-import {
-  cursorQuery,
-  CURSOR_ID_START,
-  filter,
-  SortDirection,
-} from '@ahoo-wang/fetcher-wow';
+import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
 
 // 第一页——从头开始
 const firstPage = cursorQuery({
-  query: {
-    filter: filter.matchAll(),
-    limit: 50,
-    projection: { include: ['id', 'name'] },
-  },
-  cursorId: CURSOR_ID_START, // '~'——从头开始
+  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
+  cursorId: CURSOR_ID_START,  // '~'——从头开始
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -429,7 +409,7 @@ const firstPage = cursorQuery({
 // 后续页——使用前一个结果的最后一条记录的游标 ID
 const nextPage = cursorQuery({
   query: { filter: filter.matchAll(), limit: 50 },
-  cursorId: lastItemId, // 上一页的游标 ID
+  cursorId: lastItemId,  // 上一页的游标 ID
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -495,34 +475,34 @@ graph TB
 
 ## 主要导出
 
-| 导出                                                                                                                                                        | 模块              | 描述                                   |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | -------------------------------------- |
-| `CommandClient`                                                                                                                                             | `command/`        | 基于装饰器的命令发送客户端             |
-| `CommandRequest`                                                                                                                                            | `command/`        | 带请求头的类型化命令请求               |
-| `CommandResult`                                                                                                                                             | `command/`        | 命令执行结果                           |
-| `CommandResultEventStream`                                                                                                                                  | `command/`        | 命令结果的 SSE 流                      |
-| `CommandBody<C>`                                                                                                                                            | `command/`        | 命令体包装类型                         |
-| `CommandHeaders`                                                                                                                                            | `command/`        | 请求头名称常量                         |
-| `QueryClientFactory`                                                                                                                                        | `query/`          | 创建所有查询客户端的工厂               |
-| `QueryClientOptions`                                                                                                                                        | `query/`          | 查询客户端配置                         |
-| `SnapshotQueryClient`                                                                                                                                       | `query/snapshot/` | 快照查询操作                           |
-| `EventStreamQueryClient`                                                                                                                                    | `query/event/`    | 领域事件流查询                         |
-| `LoadStateAggregateClient`                                                                                                                                  | `query/state/`    | 通过 ID/版本/时间加载聚合状态          |
-| `LoadOwnerStateAggregateClient`                                                                                                                             | `query/state/`    | 加载所有者的聚合状态                   |
-| `FilterExpression`                                                                                                                                          | `query/`          | 类型化查询筛选器联合类型               |
-| `filter`                                                                                                                                                    | `query/`          | 用于新查询的 `FilterExpression` 构建器 |
-| `SearchMode`, `TimeUnit`                                                                                                                                    | `query/`          | 搜索与相对时间选项枚举                 |
-| `AggregationQuery`                                                                                                                                          | `query/`          | 类型化快照聚合请求                     |
-| `aggregation`                                                                                                                                               | `query/`          | 聚合查询构建器                         |
-| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/`          | 聚合结构枚举                           |
-| `SnapshotQueryClient.aggregate()`                                                                                                                           | `query/snapshot/` | 执行聚合并返回结果行                   |
-| `SnapshotQueryClient.aggregateStream()`                                                                                                                     | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行          |
-| `Condition`, `all()`, `and(...)`, `Operator`                                                                                                                | `query/`          | 已弃用的兼容 API                       |
-| `listQuery()`                                                                                                                                               | `query/`          | 创建列表查询                           |
-| `pagedQuery()`                                                                                                                                              | `query/`          | 创建分页查询                           |
-| `singleQuery()`                                                                                                                                             | `query/`          | 创建单条查询                           |
-| `FieldSort`                                                                                                                                                 | `query/`          | 排序规范                               |
-| `ResourceAttributionPathSpec`                                                                                                                               | `types/`          | 租户/所有者范围的路径规范              |
+| 导出 | 模块 | 描述 |
+|------|------|------|
+| `CommandClient` | `command/` | 基于装饰器的命令发送客户端 |
+| `CommandRequest` | `command/` | 带请求头的类型化命令请求 |
+| `CommandResult` | `command/` | 命令执行结果 |
+| `CommandResultEventStream` | `command/` | 命令结果的 SSE 流 |
+| `CommandBody<C>` | `command/` | 命令体包装类型 |
+| `CommandHeaders` | `command/` | 请求头名称常量 |
+| `QueryClientFactory` | `query/` | 创建所有查询客户端的工厂 |
+| `QueryClientOptions` | `query/` | 查询客户端配置 |
+| `SnapshotQueryClient` | `query/snapshot/` | 快照查询操作 |
+| `EventStreamQueryClient` | `query/event/` | 领域事件流查询 |
+| `LoadStateAggregateClient` | `query/state/` | 通过 ID/版本/时间加载聚合状态 |
+| `LoadOwnerStateAggregateClient` | `query/state/` | 加载所有者的聚合状态 |
+| `FilterExpression` | `query/` | 类型化查询筛选器联合类型 |
+| `filter` | `query/` | 用于新查询的 `FilterExpression` 构建器 |
+| `SearchMode`, `TimeUnit` | `query/` | 搜索与相对时间选项枚举 |
+| `AggregationQuery` | `query/` | 类型化快照聚合请求 |
+| `aggregation` | `query/` | 聚合查询构建器 |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/` | 聚合结构枚举 |
+| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | 执行聚合并返回结果行 |
+| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行 |
+| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | 已弃用的兼容 API |
+| `listQuery()` | `query/` | 创建列表查询 |
+| `pagedQuery()` | `query/` | 创建分页查询 |
+| `singleQuery()` | `query/` | 创建单条查询 |
+| `FieldSort` | `query/` | 排序规范 |
+| `ResourceAttributionPathSpec` | `types/` | 租户/所有者范围的路径规范 |
 
 ## 生成的客户端
 

--- a/wiki/zh/packages/wow.md
+++ b/wiki/zh/packages/wow.md
@@ -1,6 +1,6 @@
 ---
-title: "@ahoo-wang/fetcher-wow"
-description: "Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS 支持，包括类型化命令客户端、快照查询客户端、事件流查询和聚合根交互模式。"
+title: '@ahoo-wang/fetcher-wow'
+description: 'Wow 框架集成，为 Fetcher 提供 DDD + 事件溯源 + CQRS 支持，包括类型化命令客户端、快照查询客户端、事件流查询和聚合根交互模式。'
 ---
 
 # @ahoo-wang/fetcher-wow
@@ -110,18 +110,18 @@ console.log('Command ID:', result.commandId);
 
 ### 命令头
 
-| 请求头 | 常量 | 描述 |
-|--------|----------|-------------|
-| `Command-Tenant-Id` | `CommandHeaders.TENANT_ID` | 租户标识符 |
-| `Command-Owner-Id` | `CommandHeaders.OWNER_ID` | 所有者标识符 |
-| `Command-Space-Id` | `CommandHeaders.SPACE_ID` | 空间标识符 |
-| `Command-Aggregate-Id` | `CommandHeaders.AGGREGATE_ID` | 聚合实例 ID |
-| `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | 预期聚合版本 |
-| `Command-Wait-Stage` | `CommandHeaders.WAIT_STAGE` | 等待处理阶段 |
-| `Command-Wait-Timeout` | `CommandHeaders.WAIT_TIME_OUT` | 等待超时时长 |
-| `Command-Wait-Context` | `CommandHeaders.WAIT_CONTEXT` | 等待处理上下文 |
-| `Command-Request-Id` | `CommandHeaders.REQUEST_ID` | 请求关联 ID |
-| `Command-Local-First` | `CommandHeaders.LOCAL_FIRST` | 优先本地执行 |
+| 请求头                      | 常量                               | 描述           |
+| --------------------------- | ---------------------------------- | -------------- |
+| `Command-Tenant-Id`         | `CommandHeaders.TENANT_ID`         | 租户标识符     |
+| `Command-Owner-Id`          | `CommandHeaders.OWNER_ID`          | 所有者标识符   |
+| `Command-Space-Id`          | `CommandHeaders.SPACE_ID`          | 空间标识符     |
+| `Command-Aggregate-Id`      | `CommandHeaders.AGGREGATE_ID`      | 聚合实例 ID    |
+| `Command-Aggregate-Version` | `CommandHeaders.AGGREGATE_VERSION` | 预期聚合版本   |
+| `Command-Wait-Stage`        | `CommandHeaders.WAIT_STAGE`        | 等待处理阶段   |
+| `Command-Wait-Timeout`      | `CommandHeaders.WAIT_TIME_OUT`     | 等待超时时长   |
+| `Command-Wait-Context`      | `CommandHeaders.WAIT_CONTEXT`      | 等待处理上下文 |
+| `Command-Request-Id`        | `CommandHeaders.REQUEST_ID`        | 请求关联 ID    |
+| `Command-Local-First`       | `CommandHeaders.LOCAL_FIRST`       | 优先本地执行   |
 
 来源: [packages/wow/src/command/commandHeaders.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/commandHeaders.ts)
 
@@ -164,14 +164,14 @@ classDiagram
 
 `CommandStage` 枚举定义了命令等待策略可以发出完成信号的处理阶段。它用作 `Command-Wait-Stage` 头的值和 `CommandResult.stage` 字段：
 
-| 阶段 | 值 | 完成信号 |
-|------|-----|---------|
-| `SENT` | `'SENT'` | 命令已发布到命令总线/队列 |
-| `PROCESSED` | `'PROCESSED'` | 命令已被聚合根处理 |
-| `SNAPSHOT` | `'SNAPSHOT'` | 已生成快照（聚合状态已物化） |
-| `PROJECTED` | `'PROJECTED'` | 事件已投射到读模型 |
-| `EVENT_HANDLED` | `'EVENT_HANDLED'` | 事件已被事件处理器处理 |
-| `SAGA_HANDLED` | `'SAGA_HANDLED'` | 事件已被 Saga 处理 |
+| 阶段            | 值                | 完成信号                     |
+| --------------- | ----------------- | ---------------------------- |
+| `SENT`          | `'SENT'`          | 命令已发布到命令总线/队列    |
+| `PROCESSED`     | `'PROCESSED'`     | 命令已被聚合根处理           |
+| `SNAPSHOT`      | `'SNAPSHOT'`      | 已生成快照（聚合状态已物化） |
+| `PROJECTED`     | `'PROJECTED'`     | 事件已投射到读模型           |
+| `EVENT_HANDLED` | `'EVENT_HANDLED'` | 事件已被事件处理器处理       |
+| `SAGA_HANDLED`  | `'SAGA_HANDLED'`  | 事件已被 Saga 处理           |
 
 源码: [packages/wow/src/command/types.ts:54-84](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/command/types.ts#L54-L84)
 
@@ -231,23 +231,23 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 
 #### SnapshotQueryClient 方法
 
-| 方法 | 端点 | 返回类型 | 描述 |
-|------|------|----------|------|
-| `count(filter)` | `/snapshot/count` | `Promise<number>` | 统计匹配的聚合数量 |
-| `list(listQuery)` | `/snapshot/list` | `Promise<MaterializedSnapshot<S>[]>` | 列表查询快照 |
-| `listStream(listQuery)` | `/snapshot/list` | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
-| `listState(listQuery)` | `/snapshot/list/state` | `Promise<S[]>` | 仅列出状态 |
-| `listStateStream(listQuery)` | `/snapshot/list/state` | `Promise<ReadableStream<JsonServerSentEvent<S>>>` | 以 SSE 流形式列出状态 |
-| `paged(pagedQuery)` | `/snapshot/paged` | `Promise<PagedList<MaterializedSnapshot<S>>>` | 分页查询快照 |
-| `pagedState(pagedQuery)` | `/snapshot/paged/state` | `Promise<PagedList<S>>` | 分页查询状态 |
-| `single(singleQuery)` | `/snapshot/single` | `Promise<MaterializedSnapshot<S>>` | 单个快照查询 |
-| `singleState(singleQuery)` | `/snapshot/single/state` | `Promise<S>` | 单个状态查询 |
-| `getById(id)` | -- | `Promise<MaterializedSnapshot<S>>` | 通过聚合 ID 获取 |
-| `getStateById(id)` | -- | `Promise<S>` | 通过 ID 获取状态 |
-| `getByIds(ids)` | -- | `Promise<MaterializedSnapshot<S>[]>` | 通过多个 ID 获取 |
-| `getStateByIds(ids)` | -- | `Promise<S[]>` | 通过多个 ID 获取状态 |
-| `aggregate(query)` | `/snapshot/aggregation` | `Promise<Row[]>` | 聚合快照 |
-| `aggregateStream(query)` | `/snapshot/aggregation` | `Promise<ReadableStream<JsonServerSentEvent<Row>>>` | 以 SSE 聚合快照 |
+| 方法                         | 端点                     | 返回类型                                                                | 描述                  |
+| ---------------------------- | ------------------------ | ----------------------------------------------------------------------- | --------------------- |
+| `count(filter)`              | `/snapshot/count`        | `Promise<number>`                                                       | 统计匹配的聚合数量    |
+| `list(listQuery)`            | `/snapshot/list`         | `Promise<MaterializedSnapshot<S>[]>`                                    | 列表查询快照          |
+| `listStream(listQuery)`      | `/snapshot/list`         | `Promise<ReadableStream<JsonServerSentEvent<MaterializedSnapshot<S>>>>` | 以 SSE 流形式列出快照 |
+| `listState(listQuery)`       | `/snapshot/list/state`   | `Promise<S[]>`                                                          | 仅列出状态            |
+| `listStateStream(listQuery)` | `/snapshot/list/state`   | `Promise<ReadableStream<JsonServerSentEvent<S>>>`                       | 以 SSE 流形式列出状态 |
+| `paged(pagedQuery)`          | `/snapshot/paged`        | `Promise<PagedList<MaterializedSnapshot<S>>>`                           | 分页查询快照          |
+| `pagedState(pagedQuery)`     | `/snapshot/paged/state`  | `Promise<PagedList<S>>`                                                 | 分页查询状态          |
+| `single(singleQuery)`        | `/snapshot/single`       | `Promise<MaterializedSnapshot<S>>`                                      | 单个快照查询          |
+| `singleState(singleQuery)`   | `/snapshot/single/state` | `Promise<S>`                                                            | 单个状态查询          |
+| `getById(id)`                | --                       | `Promise<MaterializedSnapshot<S>>`                                      | 通过聚合 ID 获取      |
+| `getStateById(id)`           | --                       | `Promise<S>`                                                            | 通过 ID 获取状态      |
+| `getByIds(ids)`              | --                       | `Promise<MaterializedSnapshot<S>[]>`                                    | 通过多个 ID 获取      |
+| `getStateByIds(ids)`         | --                       | `Promise<S[]>`                                                          | 通过多个 ID 获取状态  |
+| `aggregate(query)`           | `/snapshot/aggregation`  | `Promise<Row[]>`                                                        | 聚合快照              |
+| `aggregateStream(query)`     | `/snapshot/aggregation`  | `Promise<ReadableStream<JsonServerSentEvent<Row>>>`                     | 以 SSE 聚合快照       |
 
 为兼容既有实现，`SnapshotQueryApi` 将 `aggregate?` 和 `aggregateStream?`
 声明为可选方法；`SnapshotQueryClient` 将两者实现为必需方法。
@@ -257,11 +257,20 @@ const carts = await client.getStateByIds(['cart-1', 'cart-2']);
 #### 快照聚合
 
 ```typescript
-import { aggregation, filter, type AggregationQuery } from '@ahoo-wang/fetcher-wow';
+import {
+  aggregation,
+  filter,
+  type AggregationQuery,
+} from '@ahoo-wang/fetcher-wow';
 
 type CartFields = 'state.status' | 'state.items';
 type ItemFields = 'productId' | 'price' | 'quantity';
-type ProductSummary = { product: string; itemCount: number; revenue: number };
+type ProductSummary = {
+  product: string;
+  representativeProduct: string | null;
+  itemCount: number;
+  revenue: number;
+};
 
 const revenue = aggregation.multiply(
   aggregation.field<ItemFields>('price'),
@@ -273,6 +282,7 @@ const query: AggregationQuery<CartFields, ItemFields> = {
   elements: [aggregation.element('state.items', filter.gt('quantity', 0))],
   groupBy: [aggregation.terms('productId', 'product')],
   metrics: [
+    aggregation.any('productId', 'representativeProduct'),
     aggregation.count('itemCount'),
     aggregation.sum(revenue, 'revenue'),
   ],
@@ -282,12 +292,20 @@ const summaries = await client.aggregate<ProductSummary>(query);
 const summaryStream = await client.aggregateStream<ProductSummary>(query);
 ```
 
+`aggregation.any(field, alias)` 在每个当前分组中返回一个非空标量；没有值时返回
+`null`，且不会增加分组键。跨后端或多次执行时具体选择值不属于契约。字段相对最内层
+Element；集合字段或不具备 terms 聚合能力的字段由 Wow 拒绝。按 `ANY` alias 排序属于
+昂贵的指标排序。
+
 ### QueryClientFactory
 
 为给定聚合创建所有查询客户端的工厂，预配置了正确的基本路径：
 
 ```typescript
-import { QueryClientFactory, ResourceAttributionPathSpec } from '@ahoo-wang/fetcher-wow';
+import {
+  QueryClientFactory,
+  ResourceAttributionPathSpec,
+} from '@ahoo-wang/fetcher-wow';
 
 const factory = new QueryClientFactory<CartState, CartFields, CartDomainEvent>({
   contextAlias: 'example',
@@ -302,12 +320,12 @@ const ownerStateClient = factory.createOwnerLoadStateAggregateClient();
 const eventClient = factory.createEventStreamQueryClient();
 ```
 
-| 工厂方法 | 创建的客户端 | 描述 |
-|----------|-------------|------|
-| `createSnapshotQueryClient()` | `SnapshotQueryClient<S, FIELDS>` | 带筛选器的快照查询 |
-| `createLoadStateAggregateClient()` | `LoadStateAggregateClient<S>` | 通过 ID、版本或时间加载 |
-| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态 |
-| `createEventStreamQueryClient()` | `EventStreamQueryClient` | 领域事件流查询 |
+| 工厂方法                                | 创建的客户端                       | 描述                    |
+| --------------------------------------- | ---------------------------------- | ----------------------- |
+| `createSnapshotQueryClient()`           | `SnapshotQueryClient<S, FIELDS>`   | 带筛选器的快照查询      |
+| `createLoadStateAggregateClient()`      | `LoadStateAggregateClient<S>`      | 通过 ID、版本或时间加载 |
+| `createOwnerLoadStateAggregateClient()` | `LoadOwnerStateAggregateClient<S>` | 加载所有者的聚合状态    |
+| `createEventStreamQueryClient()`        | `EventStreamQueryClient`           | 领域事件流查询          |
 
 来源: [packages/wow/src/query/queryClients.ts:62-214](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/queryClients.ts#L62-L214)
 
@@ -328,7 +346,11 @@ import {
 const activeCarts = filter.and([
   filter.isIn('state.status', ['ACTIVE', 'PENDING']),
   filter.between('state.createdAt', '2024-01-01', '2024-12-31'),
-  filter.contains('state.ownerName', 'ahoowang', StringComparison.CASE_INSENSITIVE),
+  filter.contains(
+    'state.ownerName',
+    'ahoowang',
+    StringComparison.CASE_INSENSITIVE,
+  ),
 ]);
 
 const request = { filter: activeCarts, limit: 100 };
@@ -344,16 +366,16 @@ const yesterday = filter.yesterday('state.createdAt', {
 });
 ```
 
-| 分类 | `filter` 构建器 | 说明 |
-|------|-----------------|------|
-| 逻辑 | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)` | 逻辑构建器接收一个至少含一个操作数的 `readonly` 数组。 |
-| 元数据 | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)` | 复数构建器接收一个非空 `readonly` 数组。 |
-| 比较 | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)` | 值为 JSON 标量；相等比较也接受 `null` 和数组。 |
-| 字符串 | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)` | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。 |
-| 集合 | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)` | 集合构建器接收一个非空 `readonly` 数组。 |
-| 存在性 | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)` | 字段存在性构建器。 |
-| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)` | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；`SearchFilterOptions` 接受 `fields` 和 `mode`（默认 `SearchMode.TERMS`）；元素谓词不能包含根元数据、删除或搜索筛选器。 |
-| 相对时间 | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId`、`datePattern` 和 `timeUnit`（默认 `TimeUnit.MILLISECONDS`）；`days` 必须为正的 JVM `Int`。 |
+| 分类          | `filter` 构建器                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 说明                                                                                                                                                                               |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 逻辑          | `matchAll()`, `matchNone()`, `and(operands)`, `or(operands)`, `nor(operands)`                                                                                                                                                                                                                                                                                                                                                                                                | 逻辑构建器接收一个至少含一个操作数的 `readonly` 数组。                                                                                                                             |
+| 元数据        | `id(value)`, `ids(values)`, `aggregateId(value)`, `aggregateIds(values)`, `tenantId(value)`, `ownerId(value)`, `spaceId(value)`                                                                                                                                                                                                                                                                                                                                              | 复数构建器接收一个非空 `readonly` 数组。                                                                                                                                           |
+| 比较          | `eq(field, value)`, `ne(field, value)`, `gt(field, value)`, `gte(field, value)`, `lt(field, value)`, `lte(field, value)`, `between(field, lowerBound, upperBound)`                                                                                                                                                                                                                                                                                                           | 值为 JSON 标量；相等比较也接受 `null` 和数组。                                                                                                                                     |
+| 字符串        | `contains(field, value, stringComparison?)`, `startsWith(...)`, `endsWith(...)`                                                                                                                                                                                                                                                                                                                                                                                              | `stringComparison` 默认是 `StringComparison.CASE_SENSITIVE`。                                                                                                                      |
+| 集合          | `isIn(field, values)`, `notIn(field, values)`, `containsAll(field, values)`                                                                                                                                                                                                                                                                                                                                                                                                  | 集合构建器接收一个非空 `readonly` 数组。                                                                                                                                           |
+| 存在性        | `isEmpty(field)`, `isNull(field)`, `isNotNull(field)`, `exists(field)`, `notExists(field)`                                                                                                                                                                                                                                                                                                                                                                                   | 字段存在性构建器。                                                                                                                                                                 |
+| 作用域 / 搜索 | `deletion(state)`, `elementMatch(field, predicate)`, `search(query, options?)`                                                                                                                                                                                                                                                                                                                                                                                               | `deletion` 接受 `DeletionState.ACTIVE`、`DELETED` 或 `ALL`；`SearchFilterOptions` 接受 `fields` 和 `mode`（默认 `SearchMode.TERMS`）；元素谓词不能包含根元数据、删除或搜索筛选器。 |
+| 相对时间      | `today(field, options?)`, `beforeToday(field, time, options?)`, `tomorrow(field, options?)`, `thisWeek(field, options?)`, `nextWeek(field, options?)`, `lastWeek(field, options?)`, `thisMonth(field, options?)`, `lastMonth(field, options?)`, `yesterday(field, options?)`, `nextMonth(field, options?)`, `lastYear(field, options?)`, `thisYear(field, options?)`, `nextYear(field, options?)`, `recentDays(field, days, options?)`, `earlierDays(field, days, options?)` | `options` 可包含 `zoneId`、`datePattern` 和 `timeUnit`（默认 `TimeUnit.MILLISECONDS`）；`days` 必须为正的 JVM `Int`。                                                              |
 
 来源: [packages/wow/src/query/filter.ts](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts)
 
@@ -385,12 +407,21 @@ const list = {
 对于大型数据集，基于游标的分页比基于偏移量的分页更高效。它通过使用游标 ID 跟踪位置，避免了深偏移查询的性能退化：
 
 ```typescript
-import { cursorQuery, CURSOR_ID_START, filter, SortDirection } from '@ahoo-wang/fetcher-wow';
+import {
+  cursorQuery,
+  CURSOR_ID_START,
+  filter,
+  SortDirection,
+} from '@ahoo-wang/fetcher-wow';
 
 // 第一页——从头开始
 const firstPage = cursorQuery({
-  query: { filter: filter.matchAll(), limit: 50, projection: { include: ['id', 'name'] } },
-  cursorId: CURSOR_ID_START,  // '~'——从头开始
+  query: {
+    filter: filter.matchAll(),
+    limit: 50,
+    projection: { include: ['id', 'name'] },
+  },
+  cursorId: CURSOR_ID_START, // '~'——从头开始
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -398,7 +429,7 @@ const firstPage = cursorQuery({
 // 后续页——使用前一个结果的最后一条记录的游标 ID
 const nextPage = cursorQuery({
   query: { filter: filter.matchAll(), limit: 50 },
-  cursorId: lastItemId,  // 上一页的游标 ID
+  cursorId: lastItemId, // 上一页的游标 ID
   field: 'id',
   direction: SortDirection.ASC,
 });
@@ -464,34 +495,34 @@ graph TB
 
 ## 主要导出
 
-| 导出 | 模块 | 描述 |
-|------|------|------|
-| `CommandClient` | `command/` | 基于装饰器的命令发送客户端 |
-| `CommandRequest` | `command/` | 带请求头的类型化命令请求 |
-| `CommandResult` | `command/` | 命令执行结果 |
-| `CommandResultEventStream` | `command/` | 命令结果的 SSE 流 |
-| `CommandBody<C>` | `command/` | 命令体包装类型 |
-| `CommandHeaders` | `command/` | 请求头名称常量 |
-| `QueryClientFactory` | `query/` | 创建所有查询客户端的工厂 |
-| `QueryClientOptions` | `query/` | 查询客户端配置 |
-| `SnapshotQueryClient` | `query/snapshot/` | 快照查询操作 |
-| `EventStreamQueryClient` | `query/event/` | 领域事件流查询 |
-| `LoadStateAggregateClient` | `query/state/` | 通过 ID/版本/时间加载聚合状态 |
-| `LoadOwnerStateAggregateClient` | `query/state/` | 加载所有者的聚合状态 |
-| `FilterExpression` | `query/` | 类型化查询筛选器联合类型 |
-| `filter` | `query/` | 用于新查询的 `FilterExpression` 构建器 |
-| `SearchMode`, `TimeUnit` | `query/` | 搜索与相对时间选项枚举 |
-| `AggregationQuery` | `query/` | 类型化快照聚合请求 |
-| `aggregation` | `query/` | 聚合查询构建器 |
-| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/` | 聚合结构枚举 |
-| `SnapshotQueryClient.aggregate()` | `query/snapshot/` | 执行聚合并返回结果行 |
-| `SnapshotQueryClient.aggregateStream()` | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行 |
-| `Condition`, `all()`, `and(...)`, `Operator` | `query/` | 已弃用的兼容 API |
-| `listQuery()` | `query/` | 创建列表查询 |
-| `pagedQuery()` | `query/` | 创建分页查询 |
-| `singleQuery()` | `query/` | 创建单条查询 |
-| `FieldSort` | `query/` | 排序规范 |
-| `ResourceAttributionPathSpec` | `types/` | 租户/所有者范围的路径规范 |
+| 导出                                                                                                                                                        | 模块              | 描述                                   |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | -------------------------------------- |
+| `CommandClient`                                                                                                                                             | `command/`        | 基于装饰器的命令发送客户端             |
+| `CommandRequest`                                                                                                                                            | `command/`        | 带请求头的类型化命令请求               |
+| `CommandResult`                                                                                                                                             | `command/`        | 命令执行结果                           |
+| `CommandResultEventStream`                                                                                                                                  | `command/`        | 命令结果的 SSE 流                      |
+| `CommandBody<C>`                                                                                                                                            | `command/`        | 命令体包装类型                         |
+| `CommandHeaders`                                                                                                                                            | `command/`        | 请求头名称常量                         |
+| `QueryClientFactory`                                                                                                                                        | `query/`          | 创建所有查询客户端的工厂               |
+| `QueryClientOptions`                                                                                                                                        | `query/`          | 查询客户端配置                         |
+| `SnapshotQueryClient`                                                                                                                                       | `query/snapshot/` | 快照查询操作                           |
+| `EventStreamQueryClient`                                                                                                                                    | `query/event/`    | 领域事件流查询                         |
+| `LoadStateAggregateClient`                                                                                                                                  | `query/state/`    | 通过 ID/版本/时间加载聚合状态          |
+| `LoadOwnerStateAggregateClient`                                                                                                                             | `query/state/`    | 加载所有者的聚合状态                   |
+| `FilterExpression`                                                                                                                                          | `query/`          | 类型化查询筛选器联合类型               |
+| `filter`                                                                                                                                                    | `query/`          | 用于新查询的 `FilterExpression` 构建器 |
+| `SearchMode`, `TimeUnit`                                                                                                                                    | `query/`          | 搜索与相对时间选项枚举                 |
+| `AggregationQuery`                                                                                                                                          | `query/`          | 类型化快照聚合请求                     |
+| `aggregation`                                                                                                                                               | `query/`          | 聚合查询构建器                         |
+| `AggregationGroupType`, `AggregationMetricType`, `AggregationExpressionType`, `AggregationExpressionOperator`, `AggregationDateUnit`, `AggregationFunction` | `query/`          | 聚合结构枚举                           |
+| `SnapshotQueryClient.aggregate()`                                                                                                                           | `query/snapshot/` | 执行聚合并返回结果行                   |
+| `SnapshotQueryClient.aggregateStream()`                                                                                                                     | `query/snapshot/` | 执行聚合并以 SSE 流返回结果行          |
+| `Condition`, `all()`, `and(...)`, `Operator`                                                                                                                | `query/`          | 已弃用的兼容 API                       |
+| `listQuery()`                                                                                                                                               | `query/`          | 创建列表查询                           |
+| `pagedQuery()`                                                                                                                                              | `query/`          | 创建分页查询                           |
+| `singleQuery()`                                                                                                                                             | `query/`          | 创建单条查询                           |
+| `FieldSort`                                                                                                                                                 | `query/`          | 排序规范                               |
+| `ResourceAttributionPathSpec`                                                                                                                               | `types/`          | 租户/所有者范围的路径规范              |
 
 ## 生成的客户端
 


### PR DESCRIPTION
## Description

- add the Wow `ANY` aggregation metric wire type and `aggregation.any(field, alias)` DSL helper
- preserve existing field and alias validation and aggregation field inference
- document `ANY` semantics in the package READMEs, Fetcher Wow skill reference, and bilingual Wiki
- keep Snapshot Schema APIs and Generator source unchanged

Targets Wow `main@0e3dfbadc`; `ANY` is additive and remains in the unreleased Fetcher `3.18.0` line.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `pnpm --filter @ahoo-wang/fetcher-wow test` — 23 files, 347 tests passed; type checks passed
- [x] `pnpm --dir wiki build`
- [x] `git diff --check`

## Scope note

The full Wow test OpenAPI snapshot exposes a pre-existing Generator assumption for single-event TCK schemas (`body.items.anyOf`). It predates `ANY` and is outside this PR; this PR does not modify Generator behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing affected-package tests pass locally
- [x] I have checked the changed content for misspellings
