### PR TITLE
docs: deepen Wow reference

### DIFF
--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -2855,8 +2855,13 @@ assembly.
 
 # `@ahoo-wang/fetcher-wow`
 
-The Wow integration maps Wow command and query HTTP contracts to typed Fetcher
-clients. Use it only against a server that exposes Wow endpoints.
+`@ahoo-wang/fetcher-wow` maps Wow command and query HTTP contracts to typed
+Fetcher clients. It is the low-level client package used by generated Wow
+clients and by applications that call Wow endpoints directly.
+
+Use the [Wow CQRS recipe](../recipes/wow-cqrs.md) for a guided end-to-end flow.
+Use this page when you need an exact client, method, query shape, default, or
+return type.
 
 ## Install
 
@@ -2865,119 +2870,569 @@ pnpm add @ahoo-wang/fetcher @ahoo-wang/fetcher-decorator \
   @ahoo-wang/fetcher-eventstream @ahoo-wang/fetcher-wow
 ```
 
-## Commands
+The first three packages are peer dependencies. Streaming methods use the
+event-stream package to decode JSON Server-Sent Events.
+
+## Choose a client
+
+| Goal | Client | Main methods |
+| --- | --- | --- |
+| Send a command | `CommandClient<C>` | `send`, `sendAndWaitStream` |
+| Query materialized snapshots | `SnapshotQueryClient<S, FIELDS>` | `single`, `list`, `paged`, `count`, `aggregate` |
+| Return state without snapshot metadata | `SnapshotQueryClient<S, FIELDS>` | `singleState`, `listState`, `pagedState` |
+| Query domain-event streams | `EventStreamQueryClient<E, FIELDS>` | `list`, `listStream`, `paged`, `count` |
+| Rebuild state by aggregate ID | `LoadStateAggregateClient<S>` | `load`, `loadVersioned`, `loadTimeBased` |
+| Rebuild an owner-scoped aggregate | `LoadOwnerStateAggregateClient<S>` | `load`, `loadVersioned`, `loadTimeBased` |
+| Create related query clients | `QueryClientFactory<S, FIELDS, E>` | `createSnapshotQueryClient` and related factory methods |
+
+## Shared configuration
+
+All clients accept `ApiMetadata` from `@ahoo-wang/fetcher-decorator`. The
+important fields are:
+
+| Field | Purpose |
+| --- | --- |
+| `fetcher` | A `Fetcher` instance or registered Fetcher name |
+| `basePath` | Base URL path prepended to the client's endpoint paths |
+| `urlParams.path` | Values for `{tenantId}`, `{ownerId}`, and other path placeholders |
+| `headers` | Headers inherited by every client request |
+| `timeout` | Default timeout in milliseconds |
+| `attributes` | Values shared with Fetcher interceptors |
 
 ```ts
-import { Fetcher, HttpMethod } from '@ahoo-wang/fetcher';
+import { Fetcher } from '@ahoo-wang/fetcher';
+import {
+  QueryClientFactory,
+  ResourceAttributionPathSpec,
+} from '@ahoo-wang/fetcher-wow';
+
+interface CartItem {
+  productId: string;
+  quantity: number;
+  price: number;
+}
+
+interface CartOrder {
+  status: 'PAID' | 'CANCELLED';
+  lines: CartItem[];
+}
+
+interface CartState {
+  status: 'ACTIVE' | 'CHECKED_OUT';
+  items: CartItem[];
+  orders: CartOrder[];
+}
+
+type CartFields =
+  | 'aggregateId'
+  | 'ownerId'
+  | 'snapshotTime'
+  | 'state.status'
+  | 'state.items'
+  | 'state.orders';
+
+interface CartItemAdded {
+  productId: string;
+  quantity: number;
+}
+
+const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
+
+const factory = new QueryClientFactory<
+  CartState,
+  CartFields,
+  CartItemAdded
+>({
+  fetcher,
+  contextAlias: 'sales',
+  resourceAttribution: ResourceAttributionPathSpec.OWNER,
+  aggregateName: 'cart',
+  urlParams: { path: { ownerId: 'u-42' } },
+});
+
+const snapshots = factory.createSnapshotQueryClient();
+const events = factory.createEventStreamQueryClient();
+const stateLoader = factory.createLoadStateAggregateClient();
+const ownerStateLoader = factory.createOwnerLoadStateAggregateClient();
+```
+
+The factory joins the route in this order:
+`contextAlias/resourceAttribution/aggregateName`. The example therefore uses
+`sales/owner/{ownerId}/cart` before appending a method-specific endpoint.
+
+`ResourceAttributionPathSpec` provides `NONE`, `TENANT`, `OWNER`, and
+`TENANT_OWNER`. Bind every placeholder through `urlParams.path`, either in
+shared metadata or in a command request. Missing values cannot produce a valid
+request URL.
+
+## Commands
+
+Create a command client with the same route metadata used by the query clients:
+
+```ts
+import { HttpMethod } from '@ahoo-wang/fetcher';
 import {
   CommandClient,
   CommandHeaders,
   CommandStage,
+  ErrorCodes,
 } from '@ahoo-wang/fetcher-wow';
 
-const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
-const commands = new CommandClient<{ productId: string }>({
+interface AddCartItem {
+  productId: string;
+  quantity: number;
+}
+
+const commands = new CommandClient<AddCartItem>({
   fetcher,
-  basePath: 'owner/{ownerId}/cart',
+  basePath: 'sales/owner/{ownerId}/cart',
   urlParams: { path: { ownerId: 'u-42' } },
 });
 
 const result = await commands.send({
-  path: 'add_item',
+  path: 'add_cart_item',
   method: HttpMethod.POST,
-  headers: { [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT },
-  body: { productId: 'book-1' },
+  headers: {
+    [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT,
+    [CommandHeaders.REQUEST_ID]: crypto.randomUUID(),
+  },
+  body: { productId: 'book-1', quantity: 2 },
 });
+
+if (ErrorCodes.isError(result.errorCode)) {
+  throw new Error(`${result.errorCode}: ${result.errorMsg}`);
+}
 ```
 
-`CommandClient.send(request, attributes?)` waits for a `CommandResult`.
-`sendAndWaitStream()` accepts the same request and returns command-result SSE
-events. The endpoint belongs in `request.path`.
+The endpoint belongs in `request.path`; `send()` does not accept a separate
+endpoint argument.
 
-## Queries and filters
+### Command methods
 
-`SnapshotQueryClient` queries materialized snapshots. `EventStreamQueryClient`
-streams domain events. `QueryClientFactory` creates snapshot, event, and state
-clients from shared bounded-context and aggregate metadata.
+| Method | Return | Use it when |
+| --- | --- | --- |
+| `send(request, attributes?)` | `Promise<CommandResult>` | One wait result is enough |
+| `sendAndWaitStream(request, attributes?)` | `Promise<CommandResultEventStream>` | You need every wait signal as SSE |
 
 ```ts
-import { filter, listQuery } from '@ahoo-wang/fetcher-wow';
-
-const query = listQuery({
-  filter: filter.and([
-    filter.ownerId('u-42'),
-    filter.eq('state.status', 'ACTIVE'),
-  ]),
-  limit: 50,
+const stream = await commands.sendAndWaitStream({
+  path: 'add_cart_item',
+  method: HttpMethod.POST,
+  headers: { [CommandHeaders.WAIT_STAGE]: CommandStage.PROJECTED },
+  body: { productId: 'book-1', quantity: 2 },
 });
+
+for await (const event of stream) {
+  console.log(event.data.stage, event.data.aggregateVersion);
+}
 ```
 
-`filter` is the primary `FilterExpression` builder. Collection and logical
-operators accept one non-empty readonly array and validate before the request.
-The older `Condition` builders remain useful where a component API explicitly
-requires `Condition`.
+`CommandResult` includes `stage`, `aggregateId`, `aggregateVersion`,
+`commandId`, `requestId`, `errorCode`, `errorMsg`, optional `bindingErrors`,
+`result`, and `signalTime` together with bounded-context and function metadata.
 
-## Query shapes
+### Command stages
 
-| Builder                                           | Result                                            |
-| ------------------------------------------------- | ------------------------------------------------- |
-| `singleQuery()`                                   | One matching document                             |
-| `listQuery()`                                     | Bounded list                                      |
-| `pagedQuery()`                                    | `PagedList<T>` with pagination                    |
-| `cursorQuery()`                                   | Stable cursor traversal                           |
-| `pagination()`, `projection()`, `asc()`, `desc()` | Reusable query parts                              |
-| `aggregation`                                     | Groups, expressions, metrics, and nested elements |
+| Stage | Waits until |
+| --- | --- |
+| `SENT` | The command is published |
+| `PROCESSED` | The aggregate processes the command |
+| `SNAPSHOT` | The materialized snapshot is generated |
+| `PROJECTED` | Projection processing completes |
+| `EVENT_HANDLED` | Event handlers complete |
+| `SAGA_HANDLED` | Saga handlers complete |
 
-Metadata, modeling, messaging, ABAC, command result, snapshot, and domain-event
-types are also exported for generated clients and application contracts.
+### Command headers
 
-## Client map
+| Concern | Constants |
+| --- | --- |
+| Attribution | `TENANT_ID`, `OWNER_ID`, `SPACE_ID` |
+| Aggregate | `AGGREGATE_ID`, `AGGREGATE_VERSION`, `COMMAND_AGGREGATE_CONTEXT`, `COMMAND_AGGREGATE_NAME` |
+| Waiting | `WAIT_STAGE`, `WAIT_TIME_OUT`, `WAIT_CONTEXT`, `WAIT_PROCESSOR`, `WAIT_FUNCTION` |
+| Wait-chain tail | `WAIT_TAIL_STAGE`, `WAIT_TAIL_CONTEXT`, `WAIT_TAIL_PROCESSOR`, `WAIT_TAIL_FUNCTION` |
+| Correlation and routing | `REQUEST_ID`, `LOCAL_FIRST`, `COMMAND_TYPE` |
 
-| Client                              | Primary job                                                         |
-| ----------------------------------- | ------------------------------------------------------------------- |
-| `CommandClient<C>`                  | Send a command or wait for command-result SSE stages                |
-| `SnapshotQueryClient<S, FIELDS>`    | Single, list, paged, count, cursor, stream, and aggregation queries |
-| `EventStreamQueryClient<E, FIELDS>` | Query and stream domain events                                      |
-| `LoadStateAggregateClient<S>`       | Load aggregate state by aggregate ID                                |
-| `LoadOwnerStateAggregateClient<S>`  | Load state by owner-scoped route                                    |
-| `QueryClientFactory`                | Build related clients from shared `ApiMetadata`                     |
+Pass an `AbortController` as `request.abortController` when a command must be
+cancellable.
 
-All constructors consume `ApiMetadata`-shaped configuration. Put route
-parameters such as `{ownerId}` in `urlParams.path`; unresolved placeholders are
-a request-construction error, not a server-side query.
+## Snapshot queries
 
-## Filter expression families
+Snapshot methods post to paths below the client's `basePath`.
 
-| Family     | Representative builders                                               |
-| ---------- | --------------------------------------------------------------------- |
-| Comparison | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between`                       |
-| String     | `contains`, `startsWith`, `endsWith` with optional `StringComparison` |
-| Collection | `isIn`, `notIn`, `containsAll`, `elementMatch`                        |
-| Presence   | `isEmpty`, null/existence checks, `search`, relative-time builders    |
-| Logic      | `and`, `or`, `nor`, each validating its operand shape                 |
+| Method | Endpoint | Return |
+| --- | --- | --- |
+| `single<T>(query)` | `snapshot/single` | `T`; defaults to `MaterializedSnapshot<S>` |
+| `singleState<T>(query)` | `snapshot/single/state` | `T`; defaults to `S` |
+| `list<T>(query)` | `snapshot/list` | `T[]`; defaults to full snapshots |
+| `listState<T>(query)` | `snapshot/list/state` | `T[]`; defaults to `S[]` |
+| `listStream<T>(query)` | `snapshot/list` | SSE of `T` snapshots |
+| `listStateStream<T>(query)` | `snapshot/list/state` | SSE of `T` states |
+| `paged<T>(query)` | `snapshot/paged` | `PagedList<T>`; defaults to full snapshots |
+| `pagedState<T>(query)` | `snapshot/paged/state` | `PagedList<T>`; defaults to `S` |
+| `count(filter)` | `snapshot/count` | `number` |
+| `aggregate<Row>(query)` | `snapshot/aggregation` | `Row[]` |
+| `aggregateStream<Row>(query)` | `snapshot/aggregation` | SSE of `Row` |
 
-Array-first builders accept one readonly tuple or array. This keeps nested
-expressions composable and allows validation before a network request.
+All network query methods accept shared interceptor attributes as the second
+argument and an `AbortController` as the third argument.
 
-## Aggregation contract
+```ts
+import {
+  desc,
+  filter,
+  listQuery,
+  projection,
+  singleQuery,
+} from '@ahoo-wang/fetcher-wow';
 
-An aggregation query contains optional ordered `elements`, optional `filter`,
-`groupBy`, one or more `metrics`, optional sort, and a limit. `TERMS`,
-`HISTOGRAM`, and `DATE_HISTOGRAM` group values; `COUNT` and `NUMERIC` produce
-metrics.
+type CartListItem = Pick<CartState, 'status' | 'items'>;
 
-For nested arrays, the first element path is relative to snapshot root. Later
-element paths, filters, group fields, and metric fields are relative to the
-current innermost element. Make that change of scope visible in examples.
+const activeStates = await snapshots.listState<CartListItem>(
+  listQuery<CartFields>({
+    filter: filter.and([
+      filter.ownerId('u-42'),
+      filter.eq('state.status', 'ACTIVE'),
+    ]),
+    projection: projection({ include: ['state.status', 'state.items'] }),
+    sort: [desc('snapshotTime')],
+    limit: 50,
+  }),
+);
 
-## Source and agent reference
+const oneSnapshot = await snapshots.single(
+  singleQuery<CartFields>({
+    filter: filter.aggregateId('cart-1'),
+  }),
+);
+```
 
-- Public exports: [`packages/wow/src/index.ts`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/index.ts)
-- Detailed agent API: [`skills/fetcher-wow-cqrs/references/api.md`](https://github.com/Ahoo-Wang/fetcher/blob/main/skills/fetcher-wow-cqrs/references/api.md)
-- Skill: [`$fetcher-wow-cqrs`](../skills/react-and-integrations.md#fetcher-wow-cqrs)
+Use `single`/`list` when metadata such as version, owner, timestamps, tags, or
+deletion state matters. Use the `*State` variants when the state value alone is
+the application contract. Projection does not infer the method's return type;
+pass `T` explicitly when the selected fields form a partial object.
 
-See [Build a Wow CQRS client](../recipes/wow-cqrs.md) for streaming and nested
-aggregation examples.
+### ID helpers
+
+| Method | Behavior |
+| --- | --- |
+| `getById(id)` | Returns one full snapshot |
+| `getStateById(id)` | Returns one state |
+| `getByIds(ids)` | Returns full snapshots and short-circuits an empty array |
+| `getStateByIds(ids)` | Returns states and short-circuits an empty array |
+
+The helpers match Wow aggregate IDs. They are convenience methods over
+`single`, `list`, `filter.aggregateId`, and `filter.aggregateIds`.
+
+## Query builders and defaults
+
+| Builder | Shape | Defaults |
+| --- | --- | --- |
+| `singleQuery()` | filter/condition, projection, sort | Legacy no-argument form uses match-all |
+| `listQuery()` | filter/condition, projection, sort, limit | Filter form uses `limit: 0` (unlimited); legacy condition form uses `10` |
+| `pagedQuery()` | filter/condition, projection, sort, pagination | Page `1`, size `10` |
+| `pagination()` | `{ index, size }` | Page `1`, size `10` |
+| `projection()` | `{ include?, exclude? }` | No projection restriction |
+| `asc(field)`, `desc(field)` | `{ field, direction }` | Direction is explicit |
+
+Prefer the `filter` property. The `condition` property and standalone
+`Condition` builders are deprecated compatibility APIs.
+
+### Cursor traversal
+
+`cursorQuery()` turns a list query into an exclusive, single-field cursor
+query. It adds `gt` for ascending traversal or `lt` for descending traversal
+and replaces the query sort with the cursor field.
+
+```ts
+import {
+  CURSOR_ID_START,
+  SortDirection,
+  cursorQuery,
+  filter,
+  listQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const page = await snapshots.list(
+  cursorQuery<CartFields>({
+    field: 'aggregateId',
+    cursorId: CURSOR_ID_START,
+    direction: SortDirection.DESC,
+    query: listQuery({
+      filter: filter.eq('state.status', 'ACTIVE'),
+      limit: 100,
+    }),
+  }),
+);
+
+const nextCursor = page.at(-1)?.aggregateId;
+```
+
+Use the last returned cursor field as the next `cursorId`. Choose a stable,
+unique field; the helper intentionally produces one cursor sort.
+`CURSOR_ID_START` (`~`) is the start sentinel for the default descending
+direction. An ascending traversal needs a domain-specific sentinel that sorts
+below every real ID.
+
+## `FilterExpression`
+
+`filter` is the primary builder. It produces serializable discriminated unions
+and validates malformed fields, empty operands, empty collection values,
+supported enums, and relative-time option shapes before a request is sent.
+
+| Family | Builders |
+| --- | --- |
+| Match | `matchAll`, `matchNone` |
+| Metadata | `id`, `ids`, `aggregateId`, `aggregateIds`, `tenantId`, `ownerId`, `spaceId` |
+| Logic | `and`, `or`, `nor` |
+| Equality/comparison | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between` |
+| String | `contains`, `startsWith`, `endsWith` |
+| Collection | `isIn`, `notIn`, `containsAll` |
+| Presence | `isEmpty`, `isNull`, `isNotNull`, `exists`, `notExists` |
+| Lifecycle | `deletion` with `DeletionState.ACTIVE`, `DELETED`, or `ALL` |
+| Nested arrays | `elementMatch` |
+| Search | `search` with optional fields and `SearchMode` |
+| Relative time | `today`, `beforeToday`, `tomorrow`, week/month/year helpers, `recentDays`, `earlierDays` |
+
+```ts
+import {
+  DeletionState,
+  SearchMode,
+  StringComparison,
+  TimeUnit,
+  filter,
+} from '@ahoo-wang/fetcher-wow';
+
+const cartFilter = filter.and<CartFields>([
+  filter.deletion(DeletionState.ACTIVE),
+  filter.contains(
+    'state.status',
+    'active',
+    StringComparison.CASE_INSENSITIVE,
+  ),
+  filter.elementMatch('state.items',
+    filter.and([
+      filter.eq('productId', 'book-1'),
+      filter.gt('quantity', 0),
+    ]),
+  ),
+  filter.search('book', {
+    fields: ['state.status'],
+    mode: SearchMode.TERMS,
+  }),
+  filter.recentDays('snapshotTime', 30, {
+    zoneId: 'Asia/Shanghai',
+    timeUnit: TimeUnit.MILLISECONDS,
+  }),
+]);
+```
+
+Rules that commonly affect application code:
+
+- `and`, `or`, `nor`, `ids`, `aggregateIds`, `isIn`, `notIn`, and
+  `containsAll` require one non-empty readonly array.
+- `eq` and `ne` accept JSON scalars, `null`, or an array of JSON scalars.
+- Comparison and collection values cannot be `null` or non-finite numbers.
+- `elementMatch` predicates use element-relative fields and cannot contain
+  root metadata, deletion, or search filters.
+- Snapshot state fields are normally addressed through `state.*`; metadata
+  fields such as `aggregateId` and `snapshotTime` live at the root.
+- Relative-time builders accept `zoneId`, `datePattern`, and `timeUnit`.
+  The client validates offset-zone syntax, date-pattern shape, and `timeUnit`;
+  the server performs final validation of named IANA zones.
+
+## Aggregation
+
+`AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS>` separates root filter fields
+from fields visible inside an element expansion.
+
+| Property | Required | Meaning |
+| --- | --- | --- |
+| `filter` | No | Root-level `FilterExpression` |
+| `elements` | No | Ordered parent-to-child array expansion chain |
+| `groupBy` | No | Terms, numeric histogram, or date histogram groups |
+| `metrics` | Yes | Non-empty tuple of count, numeric, or any-value metrics |
+| `sort` | No | Sorts result rows, usually by an alias |
+| `limit` | No | Maximum aggregation rows |
+
+### Flat aggregation
+
+```ts
+import {
+  type AggregationQuery,
+  aggregation,
+  desc,
+  filter,
+} from '@ahoo-wang/fetcher-wow';
+
+type CartAggregationFields = 'state.status' | 'ownerId';
+type CartSummary = {
+  status: string;
+  carts: number;
+  sampleOwner: string;
+};
+
+const summaryQuery: AggregationQuery<
+  CartFields,
+  CartAggregationFields
+> = {
+  filter: filter.deletion(DeletionState.ACTIVE),
+  groupBy: [aggregation.terms('state.status', 'status')],
+  metrics: [
+    aggregation.count('carts'),
+    aggregation.any('ownerId', 'sampleOwner'),
+  ],
+  sort: [desc('carts')],
+  limit: 20,
+};
+
+const summary = await snapshots.aggregate<CartSummary>(summaryQuery);
+```
+
+### Nested element aggregation
+
+The first element path is relative to the snapshot root. Each later element
+path, its predicate, group field, and metric field is relative to the current
+innermost element.
+
+```ts
+type LineFields = 'sku' | 'quantity' | 'price';
+type RevenueRow = { sku: string; lines: number; revenue: number };
+
+const revenueQuery: AggregationQuery<CartFields, LineFields> = {
+  filter: filter.eq('state.status', 'ACTIVE'),
+  elements: [
+    aggregation.element('state.orders', filter.eq('status', 'PAID')),
+    aggregation.element('lines', filter.gt('quantity', 0)),
+  ],
+  groupBy: [aggregation.terms('sku', 'sku')],
+  metrics: [
+    aggregation.count('lines'),
+    aggregation.sum(
+      aggregation.multiply(
+        aggregation.field('price'),
+        aggregation.field('quantity'),
+      ),
+      'revenue',
+    ),
+  ],
+  sort: [desc('revenue')],
+  limit: 20,
+};
+
+const revenue = await snapshots.aggregate<RevenueRow>(revenueQuery);
+```
+
+### Aggregation builders
+
+| Builder | Output |
+| --- | --- |
+| `element(path, predicate?)` | One element-expansion step |
+| `terms(field, alias)` | Exact-value group |
+| `histogram(field, { interval, alias })` | Numeric buckets; interval must be greater than zero |
+| `dateHistogram(field, { unit, alias, timeZone? })` | Calendar buckets; default time zone is `UTC` |
+| `field`, `constant` | Expression leaves |
+| `add`, `subtract`, `multiply`, `divide` | Binary numeric expressions |
+| `count(alias)` | Row count |
+| `any(field, alias)` | Any representative field value |
+| `sum`, `avg`, `min`, `max` | Numeric expression metrics |
+
+Aliases must be one non-empty field segment and cannot start with the reserved
+`__wow` prefix. Constants must be finite numbers.
+
+To stream large result sets, replace `aggregate` with `aggregateStream` and
+iterate `event.data`:
+
+```ts
+const controller = new AbortController();
+const rows = await snapshots.aggregateStream<RevenueRow>(
+  revenueQuery,
+  undefined,
+  controller,
+);
+
+for await (const event of rows) {
+  console.log(event.data);
+}
+```
+
+## Domain-event queries
+
+`EventStreamQueryClient<E, FIELDS>` uses the same filter, projection, sort,
+pagination, attributes, and cancellation conventions as snapshot queries.
+
+| Method | Endpoint | Return |
+| --- | --- | --- |
+| `list(query)` | `event/list` | `DomainEventStream<E>[]` |
+| `listStream(query)` | `event/list` | SSE of `DomainEventStream<E>` |
+| `paged(query)` | `event/paged` | `PagedList<DomainEventStream<E>>` |
+| `count(filter)` | `event/count` | `number` |
+
+A `DomainEventStream` contains aggregate, owner, space, command, request,
+version, timestamp, header, and event-body data. Event metadata field constants
+are available through `DomainEventStreamMetadataFields`.
+
+```ts
+import { pagedQuery, pagination } from '@ahoo-wang/fetcher-wow';
+
+const eventPage = await events.paged(
+  pagedQuery({
+    filter: filter.aggregateId('cart-1'),
+    pagination: pagination({ index: 1, size: 20 }),
+    sort: [desc('version')],
+  }),
+);
+```
+
+There is no `single` event-stream method; event streams are collection
+resources.
+
+## Historical state loading
+
+| Client | Method | Endpoint below `basePath` |
+| --- | --- | --- |
+| `LoadStateAggregateClient` | `load(id)` | `{id}/state` |
+| `LoadStateAggregateClient` | `loadVersioned(id, version)` | `{id}/state/{version}` |
+| `LoadStateAggregateClient` | `loadTimeBased(id, createTime)` | `{id}/state/time/{createTime}` |
+| `LoadOwnerStateAggregateClient` | `load()` | `state` |
+| `LoadOwnerStateAggregateClient` | `loadVersioned(version)` | `state/{version}` |
+| `LoadOwnerStateAggregateClient` | `loadTimeBased(createTime)` | `state/time/{createTime}` |
+
+`createTime` is a numeric timestamp expected by the Wow endpoint. All methods
+accept attributes followed by an optional `AbortController`.
+
+## Return shapes
+
+| Type | Key fields |
+| --- | --- |
+| `MaterializedSnapshot<S>` | `state`, aggregate identity, tenant/owner/space, version, event and snapshot times, operators, tags, deletion state |
+| `PagedList<T>` | `total`, `list` |
+| `DomainEventStream<E>` | aggregate identity, owner/space, command/request IDs, `version`, `header`, `body`, `createTime` |
+| `CommandResult` | wait stage, aggregate version, error information, command result, signal metadata |
+
+Use `SnapshotMetadataFields` and `DomainEventStreamMetadataFields` when a UI or
+query builder needs stable metadata field names.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| URL still contains `{ownerId}` or `{tenantId}` | Bind the value in `apiMetadata.urlParams.path` or `request.urlParams.path` |
+| `listQuery({ filter })` returns more rows than expected | Filter-based list queries default to `limit: 0`; set an explicit limit |
+| State filter matches nothing | Snapshot state fields normally require the `state.` prefix |
+| `elementMatch` throws before sending | Keep root metadata, deletion, and search filters outside the element predicate |
+| Logical or collection builder throws | Pass one non-empty array, for example `filter.and([a, b])` |
+| Command returned but the operation failed | Test `ErrorCodes.isError(result.errorCode)` and inspect `bindingErrors` |
+| SSE method cannot be consumed | Install the event-stream peer dependency and iterate the returned stream with `for await` |
+| UI request must cancel stale work | Pass an `AbortController` as the third query argument, then call `abort()` |
+
+## Source references
+
+- [`packages/wow/src/index.ts:14`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/index.ts#L14)
+- [`packages/wow/src/query/snapshot/snapshotQueryClient.ts:121`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/snapshot/snapshotQueryClient.ts#L121)
+- [`packages/wow/src/query/filter.ts:582`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts#L582)
+- [`packages/wow/src/query/aggregation.ts:210`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
+- [`skills/fetcher-wow-cqrs/references/api.md:1`](https://github.com/Ahoo-Wang/fetcher/blob/main/skills/fetcher-wow-cqrs/references/api.md#L1)
+- [Fetcher Wow skill](../skills/react-and-integrations.md#fetcher-wow-cqrs)
 
 </doc>
 
@@ -6236,8 +6691,11 @@ Promise 已经完成之后，也就是消费 Stream 时。初始调用与 `for a
 
 # `@ahoo-wang/fetcher-wow`
 
-Wow 集成把 Wow 命令和查询 HTTP 契约映射为类型化 Fetcher 客户端。它只适用于暴露
-Wow 端点的服务端。
+`@ahoo-wang/fetcher-wow` 把 Wow 的命令和查询 HTTP 契约映射为类型化 Fetcher
+客户端。生成的 Wow 客户端和直接调用 Wow 端点的应用都以这个底层包为基础。
+
+需要完整上手流程时阅读 [Wow CQRS 实战](../recipes/wow-cqrs.md)；需要查找准确的
+Client、方法、查询结构、默认值或返回类型时使用本页。
 
 ## 安装
 
@@ -6246,111 +6704,554 @@ pnpm add @ahoo-wang/fetcher @ahoo-wang/fetcher-decorator \
   @ahoo-wang/fetcher-eventstream @ahoo-wang/fetcher-wow
 ```
 
-## 命令
+前三个包是 Peer Dependency。流式方法使用 EventStream 包解码 JSON Server-Sent
+Events。
+
+## 选择 Client
+
+| 目标 | Client | 主要方法 |
+| --- | --- | --- |
+| 发送命令 | `CommandClient<C>` | `send`、`sendAndWaitStream` |
+| 查询物化快照 | `SnapshotQueryClient<S, FIELDS>` | `single`、`list`、`paged`、`count`、`aggregate` |
+| 只返回 State，不带快照元数据 | `SnapshotQueryClient<S, FIELDS>` | `singleState`、`listState`、`pagedState` |
+| 查询领域事件流 | `EventStreamQueryClient<E, FIELDS>` | `list`、`listStream`、`paged`、`count` |
+| 按 Aggregate ID 重建状态 | `LoadStateAggregateClient<S>` | `load`、`loadVersioned`、`loadTimeBased` |
+| 重建 Owner-scoped Aggregate | `LoadOwnerStateAggregateClient<S>` | `load`、`loadVersioned`、`loadTimeBased` |
+| 创建一组关联查询 Client | `QueryClientFactory<S, FIELDS, E>` | `createSnapshotQueryClient` 等 Factory 方法 |
+
+## 共享配置
+
+所有 Client 都接收 `@ahoo-wang/fetcher-decorator` 的 `ApiMetadata`。关键字段如下：
+
+| 字段 | 用途 |
+| --- | --- |
+| `fetcher` | `Fetcher` 实例或已注册的 Fetcher 名称 |
+| `basePath` | 添加在 Client Endpoint 之前的基础路径 |
+| `urlParams.path` | `{tenantId}`、`{ownerId}` 等路径占位符的值 |
+| `headers` | 每个 Client 请求继承的 Header |
+| `timeout` | 默认超时毫秒数 |
+| `attributes` | 与 Fetcher Interceptor 共享的值 |
 
 ```ts
-import { Fetcher, HttpMethod } from '@ahoo-wang/fetcher';
+import { Fetcher } from '@ahoo-wang/fetcher';
+import {
+  QueryClientFactory,
+  ResourceAttributionPathSpec,
+} from '@ahoo-wang/fetcher-wow';
+
+interface CartItem {
+  productId: string;
+  quantity: number;
+  price: number;
+}
+
+interface CartOrder {
+  status: 'PAID' | 'CANCELLED';
+  lines: CartItem[];
+}
+
+interface CartState {
+  status: 'ACTIVE' | 'CHECKED_OUT';
+  items: CartItem[];
+  orders: CartOrder[];
+}
+
+type CartFields =
+  | 'aggregateId'
+  | 'ownerId'
+  | 'snapshotTime'
+  | 'state.status'
+  | 'state.items'
+  | 'state.orders';
+
+interface CartItemAdded {
+  productId: string;
+  quantity: number;
+}
+
+const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
+
+const factory = new QueryClientFactory<
+  CartState,
+  CartFields,
+  CartItemAdded
+>({
+  fetcher,
+  contextAlias: 'sales',
+  resourceAttribution: ResourceAttributionPathSpec.OWNER,
+  aggregateName: 'cart',
+  urlParams: { path: { ownerId: 'u-42' } },
+});
+
+const snapshots = factory.createSnapshotQueryClient();
+const events = factory.createEventStreamQueryClient();
+const stateLoader = factory.createLoadStateAggregateClient();
+const ownerStateLoader = factory.createOwnerLoadStateAggregateClient();
+```
+
+Factory 按 `contextAlias/resourceAttribution/aggregateName` 的顺序拼接路径。所以上例在
+追加具体方法的 Endpoint 前使用 `sales/owner/{ownerId}/cart`。
+
+`ResourceAttributionPathSpec` 提供 `NONE`、`TENANT`、`OWNER` 和
+`TENANT_OWNER`。每个占位符都必须通过共享 Metadata 或 Command Request 的
+`urlParams.path` 绑定；缺少值时无法构造有效请求 URL。
+
+## 命令
+
+使用与查询 Client 相同的路由元数据创建 Command Client：
+
+```ts
+import { HttpMethod } from '@ahoo-wang/fetcher';
 import {
   CommandClient,
   CommandHeaders,
   CommandStage,
+  ErrorCodes,
 } from '@ahoo-wang/fetcher-wow';
 
-const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
-const commands = new CommandClient<{ productId: string }>({
+interface AddCartItem {
+  productId: string;
+  quantity: number;
+}
+
+const commands = new CommandClient<AddCartItem>({
   fetcher,
-  basePath: 'owner/{ownerId}/cart',
+  basePath: 'sales/owner/{ownerId}/cart',
   urlParams: { path: { ownerId: 'u-42' } },
 });
 
 const result = await commands.send({
-  path: 'add_item',
+  path: 'add_cart_item',
   method: HttpMethod.POST,
-  headers: { [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT },
-  body: { productId: 'book-1' },
+  headers: {
+    [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT,
+    [CommandHeaders.REQUEST_ID]: crypto.randomUUID(),
+  },
+  body: { productId: 'book-1', quantity: 2 },
 });
+
+if (ErrorCodes.isError(result.errorCode)) {
+  throw new Error(`${result.errorCode}: ${result.errorMsg}`);
+}
 ```
 
-`CommandClient.send(request, attributes?)` 等待 `CommandResult`。
-`sendAndWaitStream()` 接收相同请求并返回命令结果 SSE 事件。端点应写入 `request.path`。
+Endpoint 写在 `request.path`；`send()` 不再单独接收 Endpoint 参数。
 
-## 查询与过滤
+### Command 方法
 
-`SnapshotQueryClient` 查询物化快照；`EventStreamQueryClient` 流式读取领域事件；
-`QueryClientFactory` 从共享 bounded-context 和聚合元数据创建快照、事件与状态客户端。
+| 方法 | 返回值 | 使用场景 |
+| --- | --- | --- |
+| `send(request, attributes?)` | `Promise<CommandResult>` | 一个等待结果就足够 |
+| `sendAndWaitStream(request, attributes?)` | `Promise<CommandResultEventStream>` | 需要通过 SSE 接收每个等待信号 |
 
 ```ts
-import { filter, listQuery } from '@ahoo-wang/fetcher-wow';
-
-const query = listQuery({
-  filter: filter.and([
-    filter.ownerId('u-42'),
-    filter.eq('state.status', 'ACTIVE'),
-  ]),
-  limit: 50,
+const stream = await commands.sendAndWaitStream({
+  path: 'add_cart_item',
+  method: HttpMethod.POST,
+  headers: { [CommandHeaders.WAIT_STAGE]: CommandStage.PROJECTED },
+  body: { productId: 'book-1', quantity: 2 },
 });
+
+for await (const event of stream) {
+  console.log(event.data.stage, event.data.aggregateVersion);
+}
 ```
 
-`filter` 是主要 `FilterExpression` 构建器。集合和逻辑操作符接收一个非空 readonly
-数组，并在请求前校验。旧 `Condition` 构建器仍适用于显式要求 `Condition` 的组件 API。
+`CommandResult` 包含 `stage`、`aggregateId`、`aggregateVersion`、
+`commandId`、`requestId`、`errorCode`、`errorMsg`、可选 `bindingErrors`、
+`result` 和 `signalTime`，以及 Bounded Context 与 Function 元数据。
 
-## 查询形状
+### Command Stage
 
-| 构建器                                            | 结果                         |
-| ------------------------------------------------- | ---------------------------- |
-| `singleQuery()`                                   | 一个匹配文档                 |
-| `listQuery()`                                     | 有界列表                     |
-| `pagedQuery()`                                    | 带分页信息的 `PagedList<T>`  |
-| `cursorQuery()`                                   | 稳定游标遍历                 |
-| `pagination()`、`projection()`、`asc()`、`desc()` | 可复用查询部分               |
-| `aggregation`                                     | 分组、表达式、指标与嵌套元素 |
+| Stage | 等待到 |
+| --- | --- |
+| `SENT` | 命令已经发布 |
+| `PROCESSED` | Aggregate 完成命令处理 |
+| `SNAPSHOT` | 物化快照已经生成 |
+| `PROJECTED` | Projection 处理完成 |
+| `EVENT_HANDLED` | Event Handler 处理完成 |
+| `SAGA_HANDLED` | Saga Handler 处理完成 |
 
-包还导出元数据、建模、消息、ABAC、命令结果、快照和领域事件类型，供生成客户端和应用
-契约使用。
+### Command Header
 
-## Client 导航
+| 用途 | 常量 |
+| --- | --- |
+| 归属 | `TENANT_ID`、`OWNER_ID`、`SPACE_ID` |
+| Aggregate | `AGGREGATE_ID`、`AGGREGATE_VERSION`、`COMMAND_AGGREGATE_CONTEXT`、`COMMAND_AGGREGATE_NAME` |
+| 等待 | `WAIT_STAGE`、`WAIT_TIME_OUT`、`WAIT_CONTEXT`、`WAIT_PROCESSOR`、`WAIT_FUNCTION` |
+| 等待链尾部 | `WAIT_TAIL_STAGE`、`WAIT_TAIL_CONTEXT`、`WAIT_TAIL_PROCESSOR`、`WAIT_TAIL_FUNCTION` |
+| 关联与路由 | `REQUEST_ID`、`LOCAL_FIRST`、`COMMAND_TYPE` |
 
-| Client                              | 主要任务                                                        |
-| ----------------------------------- | --------------------------------------------------------------- |
-| `CommandClient<C>`                  | 发送命令，或等待命令结果 SSE Stage                              |
-| `SnapshotQueryClient<S, FIELDS>`    | Single、List、Paged、Count、Cursor、Stream 与 Aggregation Query |
-| `EventStreamQueryClient<E, FIELDS>` | 查询和流式读取领域事件                                          |
-| `LoadStateAggregateClient<S>`       | 按 Aggregate ID 加载聚合状态                                    |
-| `LoadOwnerStateAggregateClient<S>`  | 按 Owner-scoped Route 加载状态                                  |
-| `QueryClientFactory`                | 根据共享 `ApiMetadata` 构建相关 Client                          |
+命令需要支持取消时，把 `AbortController` 放入 `request.abortController`。
 
-所有构造函数都消费 `ApiMetadata` 形状的配置。`{ownerId}` 等路由参数放入
-`urlParams.path`；未解析 Placeholder 属于请求构造错误，不是服务端 Query。
+## Snapshot Query
 
-## FilterExpression 家族
+Snapshot 方法都向 Client `basePath` 下的以下路径发送 POST 请求。
 
-| 家族   | 代表 Builder                                                  |
-| ------ | ------------------------------------------------------------- |
-| 比较   | `eq`、`ne`、`gt`、`gte`、`lt`、`lte`、`between`               |
-| 字符串 | `contains`、`startsWith`、`endsWith`，可传 `StringComparison` |
-| 集合   | `isIn`、`notIn`、`containsAll`、`elementMatch`                |
-| 存在性 | `isEmpty`、Null/Exists 检查、`search`、相对时间 Builder       |
-| 逻辑   | `and`、`or`、`nor`，都会校验 Operand 形状                     |
+| 方法 | Endpoint | 返回值 |
+| --- | --- | --- |
+| `single<T>(query)` | `snapshot/single` | `T`；默认为 `MaterializedSnapshot<S>` |
+| `singleState<T>(query)` | `snapshot/single/state` | `T`；默认为 `S` |
+| `list<T>(query)` | `snapshot/list` | `T[]`；默认为完整 Snapshot |
+| `listState<T>(query)` | `snapshot/list/state` | `T[]`；默认为 `S[]` |
+| `listStream<T>(query)` | `snapshot/list` | `T` Snapshot SSE |
+| `listStateStream<T>(query)` | `snapshot/list/state` | `T` State SSE |
+| `paged<T>(query)` | `snapshot/paged` | `PagedList<T>`；默认为完整 Snapshot |
+| `pagedState<T>(query)` | `snapshot/paged/state` | `PagedList<T>`；默认为 `S` |
+| `count(filter)` | `snapshot/count` | `number` |
+| `aggregate<Row>(query)` | `snapshot/aggregation` | `Row[]` |
+| `aggregateStream<Row>(query)` | `snapshot/aggregation` | `Row` SSE |
 
-数组优先 Builder 接收一个 Readonly Tuple 或 Array，让嵌套表达式可组合，并在网络请求
-前完成校验。
+所有网络查询方法都把共享 Interceptor Attributes 作为第二个参数，把
+`AbortController` 作为第三个参数。
 
-## Aggregation 契约
+```ts
+import {
+  desc,
+  filter,
+  listQuery,
+  projection,
+  singleQuery,
+} from '@ahoo-wang/fetcher-wow';
 
-Aggregation Query 包含可选的有序 `elements`、可选 `filter`、`groupBy`、一个或多个
-`metrics`、可选 Sort 和 Limit。`TERMS`、`HISTOGRAM`、`DATE_HISTOGRAM` 负责分组；
-`COUNT` 与 `NUMERIC` 产生指标。
+type CartListItem = Pick<CartState, 'status' | 'items'>;
 
-处理嵌套数组时，第一个 Element Path 相对 Snapshot Root。后续 Element Path、Filter、
-Group Field 和 Metric Field 都相对当前最内层 Element。示例必须明确展示作用域变化。
+const activeStates = await snapshots.listState<CartListItem>(
+  listQuery<CartFields>({
+    filter: filter.and([
+      filter.ownerId('u-42'),
+      filter.eq('state.status', 'ACTIVE'),
+    ]),
+    projection: projection({ include: ['state.status', 'state.items'] }),
+    sort: [desc('snapshotTime')],
+    limit: 50,
+  }),
+);
 
-## 源码与 Agent 参考
+const oneSnapshot = await snapshots.single(
+  singleQuery<CartFields>({
+    filter: filter.aggregateId('cart-1'),
+  }),
+);
+```
 
-- 公共导出：[`packages/wow/src/index.ts`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/index.ts)
-- Agent 精确 API：[`skills/fetcher-wow-cqrs/references/api.md`](https://github.com/Ahoo-Wang/fetcher/blob/main/skills/fetcher-wow-cqrs/references/api.md)
-- Skill：[`$fetcher-wow-cqrs`](../skills/react-and-integrations.md#fetcher-wow-cqrs)
+需要 Version、Owner、时间戳、Tag、删除状态等元数据时使用 `single`/`list`；应用契约
+只需要 State 值时使用 `*State` 变体。Projection 不会自动推断方法返回类型；选定字段
+形成部分对象时，应显式传入 `T`。
 
-参阅[构建 Wow CQRS 客户端](../recipes/wow-cqrs.md)，了解流式查询和嵌套聚合。
+### ID Helper
+
+| 方法 | 行为 |
+| --- | --- |
+| `getById(id)` | 返回一个完整 Snapshot |
+| `getStateById(id)` | 返回一个 State |
+| `getByIds(ids)` | 返回完整 Snapshot；空数组直接短路 |
+| `getStateByIds(ids)` | 返回 State；空数组直接短路 |
+
+这些 Helper 匹配 Wow Aggregate ID，是 `single`、`list`、
+`filter.aggregateId` 和 `filter.aggregateIds` 的便捷封装。
+
+## Query Builder 与默认值
+
+| Builder | 结构 | 默认值 |
+| --- | --- | --- |
+| `singleQuery()` | filter/condition、projection、sort | 无参数的旧式调用使用 Match All |
+| `listQuery()` | filter/condition、projection、sort、limit | Filter 形式使用 `limit: 0`（无限制）；旧 Condition 形式使用 `10` |
+| `pagedQuery()` | filter/condition、projection、sort、pagination | 第 `1` 页，每页 `10` 条 |
+| `pagination()` | `{ index, size }` | 第 `1` 页，每页 `10` 条 |
+| `projection()` | `{ include?, exclude? }` | 不限制投影字段 |
+| `asc(field)`、`desc(field)` | `{ field, direction }` | 方向显式指定 |
+
+优先使用 `filter` 属性。`condition` 属性和独立 `Condition` Builder 是已弃用的兼容
+API。
+
+### Cursor 遍历
+
+`cursorQuery()` 把 List Query 转换为排他的单字段 Cursor Query。升序遍历增加 `gt`，
+降序遍历增加 `lt`，并把查询排序替换为 Cursor Field。
+
+```ts
+import {
+  CURSOR_ID_START,
+  SortDirection,
+  cursorQuery,
+  filter,
+  listQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const page = await snapshots.list(
+  cursorQuery<CartFields>({
+    field: 'aggregateId',
+    cursorId: CURSOR_ID_START,
+    direction: SortDirection.DESC,
+    query: listQuery({
+      filter: filter.eq('state.status', 'ACTIVE'),
+      limit: 100,
+    }),
+  }),
+);
+
+const nextCursor = page.at(-1)?.aggregateId;
+```
+
+下一页把最后一条记录的 Cursor Field 作为 `cursorId`。应选择稳定且唯一的字段；该
+Helper 会有意生成唯一的 Cursor Sort。`CURSOR_ID_START`（`~`）是默认降序方向的起始
+哨兵；升序遍历需要传入一个排序在所有真实 ID 之前的领域专用哨兵。
+
+## `FilterExpression`
+
+`filter` 是主 Builder。它生成可序列化的 Discriminated Union，并在发出请求前校验
+非法字段、空 Operand、空集合值、支持的枚举和相对时间选项结构。
+
+| 家族 | Builder |
+| --- | --- |
+| 匹配 | `matchAll`、`matchNone` |
+| 元数据 | `id`、`ids`、`aggregateId`、`aggregateIds`、`tenantId`、`ownerId`、`spaceId` |
+| 逻辑 | `and`、`or`、`nor` |
+| 相等/比较 | `eq`、`ne`、`gt`、`gte`、`lt`、`lte`、`between` |
+| 字符串 | `contains`、`startsWith`、`endsWith` |
+| 集合 | `isIn`、`notIn`、`containsAll` |
+| 存在性 | `isEmpty`、`isNull`、`isNotNull`、`exists`、`notExists` |
+| 生命周期 | `deletion`，接收 `DeletionState.ACTIVE`、`DELETED` 或 `ALL` |
+| 嵌套数组 | `elementMatch` |
+| 搜索 | `search`，可指定 Field 和 `SearchMode` |
+| 相对时间 | `today`、`beforeToday`、`tomorrow`、周/月/年 Helper、`recentDays`、`earlierDays` |
+
+```ts
+import {
+  DeletionState,
+  SearchMode,
+  StringComparison,
+  TimeUnit,
+  filter,
+} from '@ahoo-wang/fetcher-wow';
+
+const cartFilter = filter.and<CartFields>([
+  filter.deletion(DeletionState.ACTIVE),
+  filter.contains(
+    'state.status',
+    'active',
+    StringComparison.CASE_INSENSITIVE,
+  ),
+  filter.elementMatch('state.items',
+    filter.and([
+      filter.eq('productId', 'book-1'),
+      filter.gt('quantity', 0),
+    ]),
+  ),
+  filter.search('book', {
+    fields: ['state.status'],
+    mode: SearchMode.TERMS,
+  }),
+  filter.recentDays('snapshotTime', 30, {
+    zoneId: 'Asia/Shanghai',
+    timeUnit: TimeUnit.MILLISECONDS,
+  }),
+]);
+```
+
+应用代码经常遇到的规则：
+
+- `and`、`or`、`nor`、`ids`、`aggregateIds`、`isIn`、`notIn` 和
+  `containsAll` 接收一个非空 Readonly Array。
+- `eq` 和 `ne` 接收 JSON Scalar、`null` 或 JSON Scalar Array。
+- 比较和集合值不能是 `null` 或非有限数字。
+- `elementMatch` Predicate 使用 Element-relative Field，不能包含根级元数据、删除或
+  Search Filter。
+- Snapshot State Field 通常使用 `state.*`；`aggregateId`、`snapshotTime` 等元数据位于
+  Root。
+- 相对时间 Builder 接收 `zoneId`、`datePattern` 和 `timeUnit`。客户端校验 Offset Zone
+  语法、Date Pattern 结构和 `timeUnit`；命名 IANA Zone 由服务端最终校验。
+
+## Aggregation
+
+`AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS>` 区分 Root Filter Field 和
+Element 展开后可见的 Field。
+
+| 属性 | 必填 | 含义 |
+| --- | --- | --- |
+| `filter` | 否 | Root-level `FilterExpression` |
+| `elements` | 否 | 按 Parent → Child 排列的数组展开链 |
+| `groupBy` | 否 | Terms、数值 Histogram 或 Date Histogram Group |
+| `metrics` | 是 | Count、Numeric 或 Any-value Metric 的非空 Tuple |
+| `sort` | 否 | 对结果 Row 排序，通常使用 Alias |
+| `limit` | 否 | 最大 Aggregation Row 数 |
+
+### 扁平聚合
+
+```ts
+import {
+  type AggregationQuery,
+  aggregation,
+  desc,
+  filter,
+} from '@ahoo-wang/fetcher-wow';
+
+type CartAggregationFields = 'state.status' | 'ownerId';
+type CartSummary = {
+  status: string;
+  carts: number;
+  sampleOwner: string;
+};
+
+const summaryQuery: AggregationQuery<
+  CartFields,
+  CartAggregationFields
+> = {
+  filter: filter.deletion(DeletionState.ACTIVE),
+  groupBy: [aggregation.terms('state.status', 'status')],
+  metrics: [
+    aggregation.count('carts'),
+    aggregation.any('ownerId', 'sampleOwner'),
+  ],
+  sort: [desc('carts')],
+  limit: 20,
+};
+
+const summary = await snapshots.aggregate<CartSummary>(summaryQuery);
+```
+
+### 嵌套 Element 聚合
+
+第一个 Element Path 相对 Snapshot Root。之后每个 Element Path、Predicate、Group
+Field 和 Metric Field 都相对当前最内层 Element。
+
+```ts
+type LineFields = 'sku' | 'quantity' | 'price';
+type RevenueRow = { sku: string; lines: number; revenue: number };
+
+const revenueQuery: AggregationQuery<CartFields, LineFields> = {
+  filter: filter.eq('state.status', 'ACTIVE'),
+  elements: [
+    aggregation.element('state.orders', filter.eq('status', 'PAID')),
+    aggregation.element('lines', filter.gt('quantity', 0)),
+  ],
+  groupBy: [aggregation.terms('sku', 'sku')],
+  metrics: [
+    aggregation.count('lines'),
+    aggregation.sum(
+      aggregation.multiply(
+        aggregation.field('price'),
+        aggregation.field('quantity'),
+      ),
+      'revenue',
+    ),
+  ],
+  sort: [desc('revenue')],
+  limit: 20,
+};
+
+const revenue = await snapshots.aggregate<RevenueRow>(revenueQuery);
+```
+
+### Aggregation Builder
+
+| Builder | 产物 |
+| --- | --- |
+| `element(path, predicate?)` | 一个 Element 展开步骤 |
+| `terms(field, alias)` | 精确值 Group |
+| `histogram(field, { interval, alias })` | 数值 Bucket；Interval 必须大于零 |
+| `dateHistogram(field, { unit, alias, timeZone? })` | 日历 Bucket；默认时区为 `UTC` |
+| `field`、`constant` | Expression Leaf |
+| `add`、`subtract`、`multiply`、`divide` | Binary Numeric Expression |
+| `count(alias)` | Row Count |
+| `any(field, alias)` | 任意一个代表性 Field Value |
+| `sum`、`avg`、`min`、`max` | Numeric Expression Metric |
+
+Alias 必须是非空单段 Field，且不能以保留前缀 `__wow` 开头。Constant 必须是有限数字。
+
+大结果集可以把 `aggregate` 替换为 `aggregateStream`，并迭代 `event.data`：
+
+```ts
+const controller = new AbortController();
+const rows = await snapshots.aggregateStream<RevenueRow>(
+  revenueQuery,
+  undefined,
+  controller,
+);
+
+for await (const event of rows) {
+  console.log(event.data);
+}
+```
+
+## Domain Event Query
+
+`EventStreamQueryClient<E, FIELDS>` 与 Snapshot Query 使用相同的 Filter、Projection、
+Sort、Pagination、Attributes 和取消约定。
+
+| 方法 | Endpoint | 返回值 |
+| --- | --- | --- |
+| `list(query)` | `event/list` | `DomainEventStream<E>[]` |
+| `listStream(query)` | `event/list` | `DomainEventStream<E>` SSE |
+| `paged(query)` | `event/paged` | `PagedList<DomainEventStream<E>>` |
+| `count(filter)` | `event/count` | `number` |
+
+`DomainEventStream` 包含 Aggregate、Owner、Space、Command、Request、Version、
+Timestamp、Header 和 Event Body 数据。可通过 `DomainEventStreamMetadataFields` 使用
+稳定的事件元数据 Field 常量。
+
+```ts
+import { pagedQuery, pagination } from '@ahoo-wang/fetcher-wow';
+
+const eventPage = await events.paged(
+  pagedQuery({
+    filter: filter.aggregateId('cart-1'),
+    pagination: pagination({ index: 1, size: 20 }),
+    sort: [desc('version')],
+  }),
+);
+```
+
+Event Stream 是集合资源，因此没有 `single` 方法。
+
+## 历史状态加载
+
+| Client | 方法 | `basePath` 下的 Endpoint |
+| --- | --- | --- |
+| `LoadStateAggregateClient` | `load(id)` | `{id}/state` |
+| `LoadStateAggregateClient` | `loadVersioned(id, version)` | `{id}/state/{version}` |
+| `LoadStateAggregateClient` | `loadTimeBased(id, createTime)` | `{id}/state/time/{createTime}` |
+| `LoadOwnerStateAggregateClient` | `load()` | `state` |
+| `LoadOwnerStateAggregateClient` | `loadVersioned(version)` | `state/{version}` |
+| `LoadOwnerStateAggregateClient` | `loadTimeBased(createTime)` | `state/time/{createTime}` |
+
+`createTime` 是 Wow Endpoint 所需的数值时间戳。所有方法都先接收 Attributes，然后接收
+可选 `AbortController`。
+
+## 返回结构
+
+| 类型 | 关键字段 |
+| --- | --- |
+| `MaterializedSnapshot<S>` | `state`、Aggregate 标识、Tenant/Owner/Space、Version、Event/Snapshot Time、Operator、Tag、删除状态 |
+| `PagedList<T>` | `total`、`list` |
+| `DomainEventStream<E>` | Aggregate 标识、Owner/Space、Command/Request ID、`version`、`header`、`body`、`createTime` |
+| `CommandResult` | Wait Stage、Aggregate Version、错误信息、命令结果、Signal 元数据 |
+
+UI 或 Query Builder 需要稳定元数据字段名时，使用 `SnapshotMetadataFields` 和
+`DomainEventStreamMetadataFields`。
+
+## 故障定位
+
+| 现象 | 检查项 |
+| --- | --- |
+| URL 仍包含 `{ownerId}` 或 `{tenantId}` | 在 `apiMetadata.urlParams.path` 或 `request.urlParams.path` 中绑定值 |
+| `listQuery({ filter })` 返回数量超出预期 | Filter 形式默认 `limit: 0`；显式设置 Limit |
+| State Filter 没有匹配结果 | Snapshot State Field 通常需要 `state.` 前缀 |
+| `elementMatch` 在发送前抛错 | Root Metadata、Deletion、Search Filter 应放在 Element Predicate 外部 |
+| Logical 或 Collection Builder 抛错 | 传入一个非空数组，例如 `filter.and([a, b])` |
+| Command 已返回但操作失败 | 检查 `ErrorCodes.isError(result.errorCode)` 和 `bindingErrors` |
+| 无法消费 SSE 方法 | 安装 EventStream Peer Dependency，并用 `for await` 迭代返回的 Stream |
+| UI 请求需要取消旧任务 | 把 `AbortController` 作为第三个 Query 参数，然后调用 `abort()` |
+
+## 源码参考
+
+- [`packages/wow/src/index.ts:14`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/index.ts#L14)
+- [`packages/wow/src/query/snapshot/snapshotQueryClient.ts:121`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/snapshot/snapshotQueryClient.ts#L121)
+- [`packages/wow/src/query/filter.ts:582`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts#L582)
+- [`packages/wow/src/query/aggregation.ts:210`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
+- [`skills/fetcher-wow-cqrs/references/api.md:1`](https://github.com/Ahoo-Wang/fetcher/blob/main/skills/fetcher-wow-cqrs/references/api.md#L1)
+- [Fetcher Wow Skill](../skills/react-and-integrations.md#fetcher-wow-cqrs)
 
 </doc>
 

--- a/wiki/llms.txt
+++ b/wiki/llms.txt
@@ -47,7 +47,7 @@
 - [`@ahoo-wang/fetcher-openapi`](/reference/openapi) — Type OpenAPI documents and extensions without adding runtime code.
 - [`@ahoo-wang/fetcher-generator`](/reference/generator) — Generate Fetcher and Wow TypeScript clients from local or remote OpenAPI documents.
 - [`@ahoo-wang/fetcher-openai`](/reference/openai) — Call Chat Completions through Fetcher with conditional typed streaming results.
-- [`@ahoo-wang/fetcher-wow`](/reference/wow) — Send Wow commands and build typed snapshot, event, filter, pagination, and aggregation queries.
+- [`@ahoo-wang/fetcher-wow`](/reference/wow) — Complete reference for Wow commands, typed snapshot and event queries, filters, cursors, aggregation, and state loading.
 - [`@ahoo-wang/fetcher-cosec`](/reference/cosec) — Configure CoSec attribution headers, JWT persistence, refresh, and 401 or 403 handling.
 - [`@ahoo-wang/fetcher-viewer`](/reference/viewer) — Compose filters, tables, saved views, and remote Viewer workflows with React and Ant Design.
 

--- a/wiki/reference/wow.md
+++ b/wiki/reference/wow.md
@@ -1,13 +1,18 @@
 ---
 title: Wow reference
-description: Send Wow commands and build typed snapshot, event, filter, pagination, and aggregation queries.
+description: Complete reference for Wow commands, typed snapshot and event queries, filters, cursors, aggregation, and state loading.
 pageClass: reference-page
 ---
 
 # `@ahoo-wang/fetcher-wow`
 
-The Wow integration maps Wow command and query HTTP contracts to typed Fetcher
-clients. Use it only against a server that exposes Wow endpoints.
+`@ahoo-wang/fetcher-wow` maps Wow command and query HTTP contracts to typed
+Fetcher clients. It is the low-level client package used by generated Wow
+clients and by applications that call Wow endpoints directly.
+
+Use the [Wow CQRS recipe](../recipes/wow-cqrs.md) for a guided end-to-end flow.
+Use this page when you need an exact client, method, query shape, default, or
+return type.
 
 ## Install
 
@@ -16,116 +21,566 @@ pnpm add @ahoo-wang/fetcher @ahoo-wang/fetcher-decorator \
   @ahoo-wang/fetcher-eventstream @ahoo-wang/fetcher-wow
 ```
 
-## Commands
+The first three packages are peer dependencies. Streaming methods use the
+event-stream package to decode JSON Server-Sent Events.
+
+## Choose a client
+
+| Goal | Client | Main methods |
+| --- | --- | --- |
+| Send a command | `CommandClient<C>` | `send`, `sendAndWaitStream` |
+| Query materialized snapshots | `SnapshotQueryClient<S, FIELDS>` | `single`, `list`, `paged`, `count`, `aggregate` |
+| Return state without snapshot metadata | `SnapshotQueryClient<S, FIELDS>` | `singleState`, `listState`, `pagedState` |
+| Query domain-event streams | `EventStreamQueryClient<E, FIELDS>` | `list`, `listStream`, `paged`, `count` |
+| Rebuild state by aggregate ID | `LoadStateAggregateClient<S>` | `load`, `loadVersioned`, `loadTimeBased` |
+| Rebuild an owner-scoped aggregate | `LoadOwnerStateAggregateClient<S>` | `load`, `loadVersioned`, `loadTimeBased` |
+| Create related query clients | `QueryClientFactory<S, FIELDS, E>` | `createSnapshotQueryClient` and related factory methods |
+
+## Shared configuration
+
+All clients accept `ApiMetadata` from `@ahoo-wang/fetcher-decorator`. The
+important fields are:
+
+| Field | Purpose |
+| --- | --- |
+| `fetcher` | A `Fetcher` instance or registered Fetcher name |
+| `basePath` | Base URL path prepended to the client's endpoint paths |
+| `urlParams.path` | Values for `{tenantId}`, `{ownerId}`, and other path placeholders |
+| `headers` | Headers inherited by every client request |
+| `timeout` | Default timeout in milliseconds |
+| `attributes` | Values shared with Fetcher interceptors |
 
 ```ts
-import { Fetcher, HttpMethod } from '@ahoo-wang/fetcher';
+import { Fetcher } from '@ahoo-wang/fetcher';
+import {
+  QueryClientFactory,
+  ResourceAttributionPathSpec,
+} from '@ahoo-wang/fetcher-wow';
+
+interface CartItem {
+  productId: string;
+  quantity: number;
+  price: number;
+}
+
+interface CartOrder {
+  status: 'PAID' | 'CANCELLED';
+  lines: CartItem[];
+}
+
+interface CartState {
+  status: 'ACTIVE' | 'CHECKED_OUT';
+  items: CartItem[];
+  orders: CartOrder[];
+}
+
+type CartFields =
+  | 'aggregateId'
+  | 'ownerId'
+  | 'snapshotTime'
+  | 'state.status'
+  | 'state.items'
+  | 'state.orders';
+
+interface CartItemAdded {
+  productId: string;
+  quantity: number;
+}
+
+const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
+
+const factory = new QueryClientFactory<
+  CartState,
+  CartFields,
+  CartItemAdded
+>({
+  fetcher,
+  contextAlias: 'sales',
+  resourceAttribution: ResourceAttributionPathSpec.OWNER,
+  aggregateName: 'cart',
+  urlParams: { path: { ownerId: 'u-42' } },
+});
+
+const snapshots = factory.createSnapshotQueryClient();
+const events = factory.createEventStreamQueryClient();
+const stateLoader = factory.createLoadStateAggregateClient();
+const ownerStateLoader = factory.createOwnerLoadStateAggregateClient();
+```
+
+The factory joins the route in this order:
+`contextAlias/resourceAttribution/aggregateName`. The example therefore uses
+`sales/owner/{ownerId}/cart` before appending a method-specific endpoint.
+
+`ResourceAttributionPathSpec` provides `NONE`, `TENANT`, `OWNER`, and
+`TENANT_OWNER`. Bind every placeholder through `urlParams.path`, either in
+shared metadata or in a command request. Missing values cannot produce a valid
+request URL.
+
+## Commands
+
+Create a command client with the same route metadata used by the query clients:
+
+```ts
+import { HttpMethod } from '@ahoo-wang/fetcher';
 import {
   CommandClient,
   CommandHeaders,
   CommandStage,
+  ErrorCodes,
 } from '@ahoo-wang/fetcher-wow';
 
-const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
-const commands = new CommandClient<{ productId: string }>({
+interface AddCartItem {
+  productId: string;
+  quantity: number;
+}
+
+const commands = new CommandClient<AddCartItem>({
   fetcher,
-  basePath: 'owner/{ownerId}/cart',
+  basePath: 'sales/owner/{ownerId}/cart',
   urlParams: { path: { ownerId: 'u-42' } },
 });
 
 const result = await commands.send({
-  path: 'add_item',
+  path: 'add_cart_item',
   method: HttpMethod.POST,
-  headers: { [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT },
-  body: { productId: 'book-1' },
+  headers: {
+    [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT,
+    [CommandHeaders.REQUEST_ID]: crypto.randomUUID(),
+  },
+  body: { productId: 'book-1', quantity: 2 },
 });
+
+if (ErrorCodes.isError(result.errorCode)) {
+  throw new Error(`${result.errorCode}: ${result.errorMsg}`);
+}
 ```
 
-`CommandClient.send(request, attributes?)` waits for a `CommandResult`.
-`sendAndWaitStream()` accepts the same request and returns command-result SSE
-events. The endpoint belongs in `request.path`.
+The endpoint belongs in `request.path`; `send()` does not accept a separate
+endpoint argument.
 
-## Queries and filters
+### Command methods
 
-`SnapshotQueryClient` queries materialized snapshots. `EventStreamQueryClient`
-streams domain events. `QueryClientFactory` creates snapshot, event, and state
-clients from shared bounded-context and aggregate metadata.
+| Method | Return | Use it when |
+| --- | --- | --- |
+| `send(request, attributes?)` | `Promise<CommandResult>` | One wait result is enough |
+| `sendAndWaitStream(request, attributes?)` | `Promise<CommandResultEventStream>` | You need every wait signal as SSE |
 
 ```ts
-import { filter, listQuery } from '@ahoo-wang/fetcher-wow';
-
-const query = listQuery({
-  filter: filter.and([
-    filter.ownerId('u-42'),
-    filter.eq('state.status', 'ACTIVE'),
-  ]),
-  limit: 50,
+const stream = await commands.sendAndWaitStream({
+  path: 'add_cart_item',
+  method: HttpMethod.POST,
+  headers: { [CommandHeaders.WAIT_STAGE]: CommandStage.PROJECTED },
+  body: { productId: 'book-1', quantity: 2 },
 });
+
+for await (const event of stream) {
+  console.log(event.data.stage, event.data.aggregateVersion);
+}
 ```
 
-`filter` is the primary `FilterExpression` builder. Collection and logical
-operators accept one non-empty readonly array and validate before the request.
-The older `Condition` builders remain useful where a component API explicitly
-requires `Condition`.
+`CommandResult` includes `stage`, `aggregateId`, `aggregateVersion`,
+`commandId`, `requestId`, `errorCode`, `errorMsg`, optional `bindingErrors`,
+`result`, and `signalTime` together with bounded-context and function metadata.
 
-## Query shapes
+### Command stages
 
-| Builder                                           | Result                                            |
-| ------------------------------------------------- | ------------------------------------------------- |
-| `singleQuery()`                                   | One matching document                             |
-| `listQuery()`                                     | Bounded list                                      |
-| `pagedQuery()`                                    | `PagedList<T>` with pagination                    |
-| `cursorQuery()`                                   | Stable cursor traversal                           |
-| `pagination()`, `projection()`, `asc()`, `desc()` | Reusable query parts                              |
-| `aggregation`                                     | Groups, expressions, metrics, and nested elements |
+| Stage | Waits until |
+| --- | --- |
+| `SENT` | The command is published |
+| `PROCESSED` | The aggregate processes the command |
+| `SNAPSHOT` | The materialized snapshot is generated |
+| `PROJECTED` | Projection processing completes |
+| `EVENT_HANDLED` | Event handlers complete |
+| `SAGA_HANDLED` | Saga handlers complete |
 
-Metadata, modeling, messaging, ABAC, command result, snapshot, and domain-event
-types are also exported for generated clients and application contracts.
+### Command headers
 
-## Client map
+| Concern | Constants |
+| --- | --- |
+| Attribution | `TENANT_ID`, `OWNER_ID`, `SPACE_ID` |
+| Aggregate | `AGGREGATE_ID`, `AGGREGATE_VERSION`, `COMMAND_AGGREGATE_CONTEXT`, `COMMAND_AGGREGATE_NAME` |
+| Waiting | `WAIT_STAGE`, `WAIT_TIME_OUT`, `WAIT_CONTEXT`, `WAIT_PROCESSOR`, `WAIT_FUNCTION` |
+| Wait-chain tail | `WAIT_TAIL_STAGE`, `WAIT_TAIL_CONTEXT`, `WAIT_TAIL_PROCESSOR`, `WAIT_TAIL_FUNCTION` |
+| Correlation and routing | `REQUEST_ID`, `LOCAL_FIRST`, `COMMAND_TYPE` |
 
-| Client                              | Primary job                                                         |
-| ----------------------------------- | ------------------------------------------------------------------- |
-| `CommandClient<C>`                  | Send a command or wait for command-result SSE stages                |
-| `SnapshotQueryClient<S, FIELDS>`    | Single, list, paged, count, cursor, stream, and aggregation queries |
-| `EventStreamQueryClient<E, FIELDS>` | Query and stream domain events                                      |
-| `LoadStateAggregateClient<S>`       | Load aggregate state by aggregate ID                                |
-| `LoadOwnerStateAggregateClient<S>`  | Load state by owner-scoped route                                    |
-| `QueryClientFactory`                | Build related clients from shared `ApiMetadata`                     |
+Pass an `AbortController` as `request.abortController` when a command must be
+cancellable.
 
-All constructors consume `ApiMetadata`-shaped configuration. Put route
-parameters such as `{ownerId}` in `urlParams.path`; unresolved placeholders are
-a request-construction error, not a server-side query.
+## Snapshot queries
 
-## Filter expression families
+Snapshot methods post to paths below the client's `basePath`.
 
-| Family     | Representative builders                                               |
-| ---------- | --------------------------------------------------------------------- |
-| Comparison | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between`                       |
-| String     | `contains`, `startsWith`, `endsWith` with optional `StringComparison` |
-| Collection | `isIn`, `notIn`, `containsAll`, `elementMatch`                        |
-| Presence   | `isEmpty`, null/existence checks, `search`, relative-time builders    |
-| Logic      | `and`, `or`, `nor`, each validating its operand shape                 |
+| Method | Endpoint | Return |
+| --- | --- | --- |
+| `single<T>(query)` | `snapshot/single` | `T`; defaults to `MaterializedSnapshot<S>` |
+| `singleState<T>(query)` | `snapshot/single/state` | `T`; defaults to `S` |
+| `list<T>(query)` | `snapshot/list` | `T[]`; defaults to full snapshots |
+| `listState<T>(query)` | `snapshot/list/state` | `T[]`; defaults to `S[]` |
+| `listStream<T>(query)` | `snapshot/list` | SSE of `T` snapshots |
+| `listStateStream<T>(query)` | `snapshot/list/state` | SSE of `T` states |
+| `paged<T>(query)` | `snapshot/paged` | `PagedList<T>`; defaults to full snapshots |
+| `pagedState<T>(query)` | `snapshot/paged/state` | `PagedList<T>`; defaults to `S` |
+| `count(filter)` | `snapshot/count` | `number` |
+| `aggregate<Row>(query)` | `snapshot/aggregation` | `Row[]` |
+| `aggregateStream<Row>(query)` | `snapshot/aggregation` | SSE of `Row` |
 
-Array-first builders accept one readonly tuple or array. This keeps nested
-expressions composable and allows validation before a network request.
+All network query methods accept shared interceptor attributes as the second
+argument and an `AbortController` as the third argument.
 
-## Aggregation contract
+```ts
+import {
+  desc,
+  filter,
+  listQuery,
+  projection,
+  singleQuery,
+} from '@ahoo-wang/fetcher-wow';
 
-An aggregation query contains optional ordered `elements`, optional `filter`,
-`groupBy`, one or more `metrics`, optional sort, and a limit. `TERMS`,
-`HISTOGRAM`, and `DATE_HISTOGRAM` group values; `COUNT` and `NUMERIC` produce
-metrics.
+type CartListItem = Pick<CartState, 'status' | 'items'>;
 
-For nested arrays, the first element path is relative to snapshot root. Later
-element paths, filters, group fields, and metric fields are relative to the
-current innermost element. Make that change of scope visible in examples.
+const activeStates = await snapshots.listState<CartListItem>(
+  listQuery<CartFields>({
+    filter: filter.and([
+      filter.ownerId('u-42'),
+      filter.eq('state.status', 'ACTIVE'),
+    ]),
+    projection: projection({ include: ['state.status', 'state.items'] }),
+    sort: [desc('snapshotTime')],
+    limit: 50,
+  }),
+);
 
-## Source and agent reference
+const oneSnapshot = await snapshots.single(
+  singleQuery<CartFields>({
+    filter: filter.aggregateId('cart-1'),
+  }),
+);
+```
 
-- Public exports: [`packages/wow/src/index.ts`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/index.ts)
-- Detailed agent API: [`skills/fetcher-wow-cqrs/references/api.md`](https://github.com/Ahoo-Wang/fetcher/blob/main/skills/fetcher-wow-cqrs/references/api.md)
-- Skill: [`$fetcher-wow-cqrs`](../skills/react-and-integrations.md#fetcher-wow-cqrs)
+Use `single`/`list` when metadata such as version, owner, timestamps, tags, or
+deletion state matters. Use the `*State` variants when the state value alone is
+the application contract. Projection does not infer the method's return type;
+pass `T` explicitly when the selected fields form a partial object.
 
-See [Build a Wow CQRS client](../recipes/wow-cqrs.md) for streaming and nested
-aggregation examples.
+### ID helpers
+
+| Method | Behavior |
+| --- | --- |
+| `getById(id)` | Returns one full snapshot |
+| `getStateById(id)` | Returns one state |
+| `getByIds(ids)` | Returns full snapshots and short-circuits an empty array |
+| `getStateByIds(ids)` | Returns states and short-circuits an empty array |
+
+The helpers match Wow aggregate IDs. They are convenience methods over
+`single`, `list`, `filter.aggregateId`, and `filter.aggregateIds`.
+
+## Query builders and defaults
+
+| Builder | Shape | Defaults |
+| --- | --- | --- |
+| `singleQuery()` | filter/condition, projection, sort | Legacy no-argument form uses match-all |
+| `listQuery()` | filter/condition, projection, sort, limit | Filter form uses `limit: 0` (unlimited); legacy condition form uses `10` |
+| `pagedQuery()` | filter/condition, projection, sort, pagination | Page `1`, size `10` |
+| `pagination()` | `{ index, size }` | Page `1`, size `10` |
+| `projection()` | `{ include?, exclude? }` | No projection restriction |
+| `asc(field)`, `desc(field)` | `{ field, direction }` | Direction is explicit |
+
+Prefer the `filter` property. The `condition` property and standalone
+`Condition` builders are deprecated compatibility APIs.
+
+### Cursor traversal
+
+`cursorQuery()` turns a list query into an exclusive, single-field cursor
+query. It adds `gt` for ascending traversal or `lt` for descending traversal
+and replaces the query sort with the cursor field.
+
+```ts
+import {
+  CURSOR_ID_START,
+  SortDirection,
+  cursorQuery,
+  filter,
+  listQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const page = await snapshots.list(
+  cursorQuery<CartFields>({
+    field: 'aggregateId',
+    cursorId: CURSOR_ID_START,
+    direction: SortDirection.DESC,
+    query: listQuery({
+      filter: filter.eq('state.status', 'ACTIVE'),
+      limit: 100,
+    }),
+  }),
+);
+
+const nextCursor = page.at(-1)?.aggregateId;
+```
+
+Use the last returned cursor field as the next `cursorId`. Choose a stable,
+unique field; the helper intentionally produces one cursor sort.
+`CURSOR_ID_START` (`~`) is the start sentinel for the default descending
+direction. An ascending traversal needs a domain-specific sentinel that sorts
+below every real ID.
+
+## `FilterExpression`
+
+`filter` is the primary builder. It produces serializable discriminated unions
+and validates malformed fields, empty operands, empty collection values,
+supported enums, and relative-time option shapes before a request is sent.
+
+| Family | Builders |
+| --- | --- |
+| Match | `matchAll`, `matchNone` |
+| Metadata | `id`, `ids`, `aggregateId`, `aggregateIds`, `tenantId`, `ownerId`, `spaceId` |
+| Logic | `and`, `or`, `nor` |
+| Equality/comparison | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between` |
+| String | `contains`, `startsWith`, `endsWith` |
+| Collection | `isIn`, `notIn`, `containsAll` |
+| Presence | `isEmpty`, `isNull`, `isNotNull`, `exists`, `notExists` |
+| Lifecycle | `deletion` with `DeletionState.ACTIVE`, `DELETED`, or `ALL` |
+| Nested arrays | `elementMatch` |
+| Search | `search` with optional fields and `SearchMode` |
+| Relative time | `today`, `beforeToday`, `tomorrow`, week/month/year helpers, `recentDays`, `earlierDays` |
+
+```ts
+import {
+  DeletionState,
+  SearchMode,
+  StringComparison,
+  TimeUnit,
+  filter,
+} from '@ahoo-wang/fetcher-wow';
+
+const cartFilter = filter.and<CartFields>([
+  filter.deletion(DeletionState.ACTIVE),
+  filter.contains(
+    'state.status',
+    'active',
+    StringComparison.CASE_INSENSITIVE,
+  ),
+  filter.elementMatch('state.items',
+    filter.and([
+      filter.eq('productId', 'book-1'),
+      filter.gt('quantity', 0),
+    ]),
+  ),
+  filter.search('book', {
+    fields: ['state.status'],
+    mode: SearchMode.TERMS,
+  }),
+  filter.recentDays('snapshotTime', 30, {
+    zoneId: 'Asia/Shanghai',
+    timeUnit: TimeUnit.MILLISECONDS,
+  }),
+]);
+```
+
+Rules that commonly affect application code:
+
+- `and`, `or`, `nor`, `ids`, `aggregateIds`, `isIn`, `notIn`, and
+  `containsAll` require one non-empty readonly array.
+- `eq` and `ne` accept JSON scalars, `null`, or an array of JSON scalars.
+- Comparison and collection values cannot be `null` or non-finite numbers.
+- `elementMatch` predicates use element-relative fields and cannot contain
+  root metadata, deletion, or search filters.
+- Snapshot state fields are normally addressed through `state.*`; metadata
+  fields such as `aggregateId` and `snapshotTime` live at the root.
+- Relative-time builders accept `zoneId`, `datePattern`, and `timeUnit`.
+  The client validates offset-zone syntax, date-pattern shape, and `timeUnit`;
+  the server performs final validation of named IANA zones.
+
+## Aggregation
+
+`AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS>` separates root filter fields
+from fields visible inside an element expansion.
+
+| Property | Required | Meaning |
+| --- | --- | --- |
+| `filter` | No | Root-level `FilterExpression` |
+| `elements` | No | Ordered parent-to-child array expansion chain |
+| `groupBy` | No | Terms, numeric histogram, or date histogram groups |
+| `metrics` | Yes | Non-empty tuple of count, numeric, or any-value metrics |
+| `sort` | No | Sorts result rows, usually by an alias |
+| `limit` | No | Maximum aggregation rows |
+
+### Flat aggregation
+
+```ts
+import {
+  type AggregationQuery,
+  aggregation,
+  desc,
+  filter,
+} from '@ahoo-wang/fetcher-wow';
+
+type CartAggregationFields = 'state.status' | 'ownerId';
+type CartSummary = {
+  status: string;
+  carts: number;
+  sampleOwner: string;
+};
+
+const summaryQuery: AggregationQuery<
+  CartFields,
+  CartAggregationFields
+> = {
+  filter: filter.deletion(DeletionState.ACTIVE),
+  groupBy: [aggregation.terms('state.status', 'status')],
+  metrics: [
+    aggregation.count('carts'),
+    aggregation.any('ownerId', 'sampleOwner'),
+  ],
+  sort: [desc('carts')],
+  limit: 20,
+};
+
+const summary = await snapshots.aggregate<CartSummary>(summaryQuery);
+```
+
+### Nested element aggregation
+
+The first element path is relative to the snapshot root. Each later element
+path, its predicate, group field, and metric field is relative to the current
+innermost element.
+
+```ts
+type LineFields = 'sku' | 'quantity' | 'price';
+type RevenueRow = { sku: string; lines: number; revenue: number };
+
+const revenueQuery: AggregationQuery<CartFields, LineFields> = {
+  filter: filter.eq('state.status', 'ACTIVE'),
+  elements: [
+    aggregation.element('state.orders', filter.eq('status', 'PAID')),
+    aggregation.element('lines', filter.gt('quantity', 0)),
+  ],
+  groupBy: [aggregation.terms('sku', 'sku')],
+  metrics: [
+    aggregation.count('lines'),
+    aggregation.sum(
+      aggregation.multiply(
+        aggregation.field('price'),
+        aggregation.field('quantity'),
+      ),
+      'revenue',
+    ),
+  ],
+  sort: [desc('revenue')],
+  limit: 20,
+};
+
+const revenue = await snapshots.aggregate<RevenueRow>(revenueQuery);
+```
+
+### Aggregation builders
+
+| Builder | Output |
+| --- | --- |
+| `element(path, predicate?)` | One element-expansion step |
+| `terms(field, alias)` | Exact-value group |
+| `histogram(field, { interval, alias })` | Numeric buckets; interval must be greater than zero |
+| `dateHistogram(field, { unit, alias, timeZone? })` | Calendar buckets; default time zone is `UTC` |
+| `field`, `constant` | Expression leaves |
+| `add`, `subtract`, `multiply`, `divide` | Binary numeric expressions |
+| `count(alias)` | Row count |
+| `any(field, alias)` | Any representative field value |
+| `sum`, `avg`, `min`, `max` | Numeric expression metrics |
+
+Aliases must be one non-empty field segment and cannot start with the reserved
+`__wow` prefix. Constants must be finite numbers.
+
+To stream large result sets, replace `aggregate` with `aggregateStream` and
+iterate `event.data`:
+
+```ts
+const controller = new AbortController();
+const rows = await snapshots.aggregateStream<RevenueRow>(
+  revenueQuery,
+  undefined,
+  controller,
+);
+
+for await (const event of rows) {
+  console.log(event.data);
+}
+```
+
+## Domain-event queries
+
+`EventStreamQueryClient<E, FIELDS>` uses the same filter, projection, sort,
+pagination, attributes, and cancellation conventions as snapshot queries.
+
+| Method | Endpoint | Return |
+| --- | --- | --- |
+| `list(query)` | `event/list` | `DomainEventStream<E>[]` |
+| `listStream(query)` | `event/list` | SSE of `DomainEventStream<E>` |
+| `paged(query)` | `event/paged` | `PagedList<DomainEventStream<E>>` |
+| `count(filter)` | `event/count` | `number` |
+
+A `DomainEventStream` contains aggregate, owner, space, command, request,
+version, timestamp, header, and event-body data. Event metadata field constants
+are available through `DomainEventStreamMetadataFields`.
+
+```ts
+import { pagedQuery, pagination } from '@ahoo-wang/fetcher-wow';
+
+const eventPage = await events.paged(
+  pagedQuery({
+    filter: filter.aggregateId('cart-1'),
+    pagination: pagination({ index: 1, size: 20 }),
+    sort: [desc('version')],
+  }),
+);
+```
+
+There is no `single` event-stream method; event streams are collection
+resources.
+
+## Historical state loading
+
+| Client | Method | Endpoint below `basePath` |
+| --- | --- | --- |
+| `LoadStateAggregateClient` | `load(id)` | `{id}/state` |
+| `LoadStateAggregateClient` | `loadVersioned(id, version)` | `{id}/state/{version}` |
+| `LoadStateAggregateClient` | `loadTimeBased(id, createTime)` | `{id}/state/time/{createTime}` |
+| `LoadOwnerStateAggregateClient` | `load()` | `state` |
+| `LoadOwnerStateAggregateClient` | `loadVersioned(version)` | `state/{version}` |
+| `LoadOwnerStateAggregateClient` | `loadTimeBased(createTime)` | `state/time/{createTime}` |
+
+`createTime` is a numeric timestamp expected by the Wow endpoint. All methods
+accept attributes followed by an optional `AbortController`.
+
+## Return shapes
+
+| Type | Key fields |
+| --- | --- |
+| `MaterializedSnapshot<S>` | `state`, aggregate identity, tenant/owner/space, version, event and snapshot times, operators, tags, deletion state |
+| `PagedList<T>` | `total`, `list` |
+| `DomainEventStream<E>` | aggregate identity, owner/space, command/request IDs, `version`, `header`, `body`, `createTime` |
+| `CommandResult` | wait stage, aggregate version, error information, command result, signal metadata |
+
+Use `SnapshotMetadataFields` and `DomainEventStreamMetadataFields` when a UI or
+query builder needs stable metadata field names.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| URL still contains `{ownerId}` or `{tenantId}` | Bind the value in `apiMetadata.urlParams.path` or `request.urlParams.path` |
+| `listQuery({ filter })` returns more rows than expected | Filter-based list queries default to `limit: 0`; set an explicit limit |
+| State filter matches nothing | Snapshot state fields normally require the `state.` prefix |
+| `elementMatch` throws before sending | Keep root metadata, deletion, and search filters outside the element predicate |
+| Logical or collection builder throws | Pass one non-empty array, for example `filter.and([a, b])` |
+| Command returned but the operation failed | Test `ErrorCodes.isError(result.errorCode)` and inspect `bindingErrors` |
+| SSE method cannot be consumed | Install the event-stream peer dependency and iterate the returned stream with `for await` |
+| UI request must cancel stale work | Pass an `AbortController` as the third query argument, then call `abort()` |
+
+## Source references
+
+- [`packages/wow/src/index.ts:14`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/index.ts#L14)
+- [`packages/wow/src/query/snapshot/snapshotQueryClient.ts:121`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/snapshot/snapshotQueryClient.ts#L121)
+- [`packages/wow/src/query/filter.ts:582`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts#L582)
+- [`packages/wow/src/query/aggregation.ts:210`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
+- [`skills/fetcher-wow-cqrs/references/api.md:1`](https://github.com/Ahoo-Wang/fetcher/blob/main/skills/fetcher-wow-cqrs/references/api.md#L1)
+- [Fetcher Wow skill](../skills/react-and-integrations.md#fetcher-wow-cqrs)

--- a/wiki/zh/reference/wow.md
+++ b/wiki/zh/reference/wow.md
@@ -1,13 +1,16 @@
 ---
 title: Wow 参考
-description: 发送 Wow 命令，并构建类型化快照、事件、过滤、分页与聚合查询。
+description: Wow 命令、类型化快照与事件查询、过滤、游标、聚合和状态加载的完整参考。
 pageClass: reference-page
 ---
 
 # `@ahoo-wang/fetcher-wow`
 
-Wow 集成把 Wow 命令和查询 HTTP 契约映射为类型化 Fetcher 客户端。它只适用于暴露
-Wow 端点的服务端。
+`@ahoo-wang/fetcher-wow` 把 Wow 的命令和查询 HTTP 契约映射为类型化 Fetcher
+客户端。生成的 Wow 客户端和直接调用 Wow 端点的应用都以这个底层包为基础。
+
+需要完整上手流程时阅读 [Wow CQRS 实战](../recipes/wow-cqrs.md)；需要查找准确的
+Client、方法、查询结构、默认值或返回类型时使用本页。
 
 ## 安装
 
@@ -16,108 +19,551 @@ pnpm add @ahoo-wang/fetcher @ahoo-wang/fetcher-decorator \
   @ahoo-wang/fetcher-eventstream @ahoo-wang/fetcher-wow
 ```
 
-## 命令
+前三个包是 Peer Dependency。流式方法使用 EventStream 包解码 JSON Server-Sent
+Events。
+
+## 选择 Client
+
+| 目标 | Client | 主要方法 |
+| --- | --- | --- |
+| 发送命令 | `CommandClient<C>` | `send`、`sendAndWaitStream` |
+| 查询物化快照 | `SnapshotQueryClient<S, FIELDS>` | `single`、`list`、`paged`、`count`、`aggregate` |
+| 只返回 State，不带快照元数据 | `SnapshotQueryClient<S, FIELDS>` | `singleState`、`listState`、`pagedState` |
+| 查询领域事件流 | `EventStreamQueryClient<E, FIELDS>` | `list`、`listStream`、`paged`、`count` |
+| 按 Aggregate ID 重建状态 | `LoadStateAggregateClient<S>` | `load`、`loadVersioned`、`loadTimeBased` |
+| 重建 Owner-scoped Aggregate | `LoadOwnerStateAggregateClient<S>` | `load`、`loadVersioned`、`loadTimeBased` |
+| 创建一组关联查询 Client | `QueryClientFactory<S, FIELDS, E>` | `createSnapshotQueryClient` 等 Factory 方法 |
+
+## 共享配置
+
+所有 Client 都接收 `@ahoo-wang/fetcher-decorator` 的 `ApiMetadata`。关键字段如下：
+
+| 字段 | 用途 |
+| --- | --- |
+| `fetcher` | `Fetcher` 实例或已注册的 Fetcher 名称 |
+| `basePath` | 添加在 Client Endpoint 之前的基础路径 |
+| `urlParams.path` | `{tenantId}`、`{ownerId}` 等路径占位符的值 |
+| `headers` | 每个 Client 请求继承的 Header |
+| `timeout` | 默认超时毫秒数 |
+| `attributes` | 与 Fetcher Interceptor 共享的值 |
 
 ```ts
-import { Fetcher, HttpMethod } from '@ahoo-wang/fetcher';
+import { Fetcher } from '@ahoo-wang/fetcher';
+import {
+  QueryClientFactory,
+  ResourceAttributionPathSpec,
+} from '@ahoo-wang/fetcher-wow';
+
+interface CartItem {
+  productId: string;
+  quantity: number;
+  price: number;
+}
+
+interface CartOrder {
+  status: 'PAID' | 'CANCELLED';
+  lines: CartItem[];
+}
+
+interface CartState {
+  status: 'ACTIVE' | 'CHECKED_OUT';
+  items: CartItem[];
+  orders: CartOrder[];
+}
+
+type CartFields =
+  | 'aggregateId'
+  | 'ownerId'
+  | 'snapshotTime'
+  | 'state.status'
+  | 'state.items'
+  | 'state.orders';
+
+interface CartItemAdded {
+  productId: string;
+  quantity: number;
+}
+
+const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
+
+const factory = new QueryClientFactory<
+  CartState,
+  CartFields,
+  CartItemAdded
+>({
+  fetcher,
+  contextAlias: 'sales',
+  resourceAttribution: ResourceAttributionPathSpec.OWNER,
+  aggregateName: 'cart',
+  urlParams: { path: { ownerId: 'u-42' } },
+});
+
+const snapshots = factory.createSnapshotQueryClient();
+const events = factory.createEventStreamQueryClient();
+const stateLoader = factory.createLoadStateAggregateClient();
+const ownerStateLoader = factory.createOwnerLoadStateAggregateClient();
+```
+
+Factory 按 `contextAlias/resourceAttribution/aggregateName` 的顺序拼接路径。所以上例在
+追加具体方法的 Endpoint 前使用 `sales/owner/{ownerId}/cart`。
+
+`ResourceAttributionPathSpec` 提供 `NONE`、`TENANT`、`OWNER` 和
+`TENANT_OWNER`。每个占位符都必须通过共享 Metadata 或 Command Request 的
+`urlParams.path` 绑定；缺少值时无法构造有效请求 URL。
+
+## 命令
+
+使用与查询 Client 相同的路由元数据创建 Command Client：
+
+```ts
+import { HttpMethod } from '@ahoo-wang/fetcher';
 import {
   CommandClient,
   CommandHeaders,
   CommandStage,
+  ErrorCodes,
 } from '@ahoo-wang/fetcher-wow';
 
-const fetcher = new Fetcher({ baseURL: 'https://api.example.com' });
-const commands = new CommandClient<{ productId: string }>({
+interface AddCartItem {
+  productId: string;
+  quantity: number;
+}
+
+const commands = new CommandClient<AddCartItem>({
   fetcher,
-  basePath: 'owner/{ownerId}/cart',
+  basePath: 'sales/owner/{ownerId}/cart',
   urlParams: { path: { ownerId: 'u-42' } },
 });
 
 const result = await commands.send({
-  path: 'add_item',
+  path: 'add_cart_item',
   method: HttpMethod.POST,
-  headers: { [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT },
-  body: { productId: 'book-1' },
+  headers: {
+    [CommandHeaders.WAIT_STAGE]: CommandStage.SNAPSHOT,
+    [CommandHeaders.REQUEST_ID]: crypto.randomUUID(),
+  },
+  body: { productId: 'book-1', quantity: 2 },
 });
+
+if (ErrorCodes.isError(result.errorCode)) {
+  throw new Error(`${result.errorCode}: ${result.errorMsg}`);
+}
 ```
 
-`CommandClient.send(request, attributes?)` 等待 `CommandResult`。
-`sendAndWaitStream()` 接收相同请求并返回命令结果 SSE 事件。端点应写入 `request.path`。
+Endpoint 写在 `request.path`；`send()` 不再单独接收 Endpoint 参数。
 
-## 查询与过滤
+### Command 方法
 
-`SnapshotQueryClient` 查询物化快照；`EventStreamQueryClient` 流式读取领域事件；
-`QueryClientFactory` 从共享 bounded-context 和聚合元数据创建快照、事件与状态客户端。
+| 方法 | 返回值 | 使用场景 |
+| --- | --- | --- |
+| `send(request, attributes?)` | `Promise<CommandResult>` | 一个等待结果就足够 |
+| `sendAndWaitStream(request, attributes?)` | `Promise<CommandResultEventStream>` | 需要通过 SSE 接收每个等待信号 |
 
 ```ts
-import { filter, listQuery } from '@ahoo-wang/fetcher-wow';
-
-const query = listQuery({
-  filter: filter.and([
-    filter.ownerId('u-42'),
-    filter.eq('state.status', 'ACTIVE'),
-  ]),
-  limit: 50,
+const stream = await commands.sendAndWaitStream({
+  path: 'add_cart_item',
+  method: HttpMethod.POST,
+  headers: { [CommandHeaders.WAIT_STAGE]: CommandStage.PROJECTED },
+  body: { productId: 'book-1', quantity: 2 },
 });
+
+for await (const event of stream) {
+  console.log(event.data.stage, event.data.aggregateVersion);
+}
 ```
 
-`filter` 是主要 `FilterExpression` 构建器。集合和逻辑操作符接收一个非空 readonly
-数组，并在请求前校验。旧 `Condition` 构建器仍适用于显式要求 `Condition` 的组件 API。
+`CommandResult` 包含 `stage`、`aggregateId`、`aggregateVersion`、
+`commandId`、`requestId`、`errorCode`、`errorMsg`、可选 `bindingErrors`、
+`result` 和 `signalTime`，以及 Bounded Context 与 Function 元数据。
 
-## 查询形状
+### Command Stage
 
-| 构建器                                            | 结果                         |
-| ------------------------------------------------- | ---------------------------- |
-| `singleQuery()`                                   | 一个匹配文档                 |
-| `listQuery()`                                     | 有界列表                     |
-| `pagedQuery()`                                    | 带分页信息的 `PagedList<T>`  |
-| `cursorQuery()`                                   | 稳定游标遍历                 |
-| `pagination()`、`projection()`、`asc()`、`desc()` | 可复用查询部分               |
-| `aggregation`                                     | 分组、表达式、指标与嵌套元素 |
+| Stage | 等待到 |
+| --- | --- |
+| `SENT` | 命令已经发布 |
+| `PROCESSED` | Aggregate 完成命令处理 |
+| `SNAPSHOT` | 物化快照已经生成 |
+| `PROJECTED` | Projection 处理完成 |
+| `EVENT_HANDLED` | Event Handler 处理完成 |
+| `SAGA_HANDLED` | Saga Handler 处理完成 |
 
-包还导出元数据、建模、消息、ABAC、命令结果、快照和领域事件类型，供生成客户端和应用
-契约使用。
+### Command Header
 
-## Client 导航
+| 用途 | 常量 |
+| --- | --- |
+| 归属 | `TENANT_ID`、`OWNER_ID`、`SPACE_ID` |
+| Aggregate | `AGGREGATE_ID`、`AGGREGATE_VERSION`、`COMMAND_AGGREGATE_CONTEXT`、`COMMAND_AGGREGATE_NAME` |
+| 等待 | `WAIT_STAGE`、`WAIT_TIME_OUT`、`WAIT_CONTEXT`、`WAIT_PROCESSOR`、`WAIT_FUNCTION` |
+| 等待链尾部 | `WAIT_TAIL_STAGE`、`WAIT_TAIL_CONTEXT`、`WAIT_TAIL_PROCESSOR`、`WAIT_TAIL_FUNCTION` |
+| 关联与路由 | `REQUEST_ID`、`LOCAL_FIRST`、`COMMAND_TYPE` |
 
-| Client                              | 主要任务                                                        |
-| ----------------------------------- | --------------------------------------------------------------- |
-| `CommandClient<C>`                  | 发送命令，或等待命令结果 SSE Stage                              |
-| `SnapshotQueryClient<S, FIELDS>`    | Single、List、Paged、Count、Cursor、Stream 与 Aggregation Query |
-| `EventStreamQueryClient<E, FIELDS>` | 查询和流式读取领域事件                                          |
-| `LoadStateAggregateClient<S>`       | 按 Aggregate ID 加载聚合状态                                    |
-| `LoadOwnerStateAggregateClient<S>`  | 按 Owner-scoped Route 加载状态                                  |
-| `QueryClientFactory`                | 根据共享 `ApiMetadata` 构建相关 Client                          |
+命令需要支持取消时，把 `AbortController` 放入 `request.abortController`。
 
-所有构造函数都消费 `ApiMetadata` 形状的配置。`{ownerId}` 等路由参数放入
-`urlParams.path`；未解析 Placeholder 属于请求构造错误，不是服务端 Query。
+## Snapshot Query
 
-## FilterExpression 家族
+Snapshot 方法都向 Client `basePath` 下的以下路径发送 POST 请求。
 
-| 家族   | 代表 Builder                                                  |
-| ------ | ------------------------------------------------------------- |
-| 比较   | `eq`、`ne`、`gt`、`gte`、`lt`、`lte`、`between`               |
-| 字符串 | `contains`、`startsWith`、`endsWith`，可传 `StringComparison` |
-| 集合   | `isIn`、`notIn`、`containsAll`、`elementMatch`                |
-| 存在性 | `isEmpty`、Null/Exists 检查、`search`、相对时间 Builder       |
-| 逻辑   | `and`、`or`、`nor`，都会校验 Operand 形状                     |
+| 方法 | Endpoint | 返回值 |
+| --- | --- | --- |
+| `single<T>(query)` | `snapshot/single` | `T`；默认为 `MaterializedSnapshot<S>` |
+| `singleState<T>(query)` | `snapshot/single/state` | `T`；默认为 `S` |
+| `list<T>(query)` | `snapshot/list` | `T[]`；默认为完整 Snapshot |
+| `listState<T>(query)` | `snapshot/list/state` | `T[]`；默认为 `S[]` |
+| `listStream<T>(query)` | `snapshot/list` | `T` Snapshot SSE |
+| `listStateStream<T>(query)` | `snapshot/list/state` | `T` State SSE |
+| `paged<T>(query)` | `snapshot/paged` | `PagedList<T>`；默认为完整 Snapshot |
+| `pagedState<T>(query)` | `snapshot/paged/state` | `PagedList<T>`；默认为 `S` |
+| `count(filter)` | `snapshot/count` | `number` |
+| `aggregate<Row>(query)` | `snapshot/aggregation` | `Row[]` |
+| `aggregateStream<Row>(query)` | `snapshot/aggregation` | `Row` SSE |
 
-数组优先 Builder 接收一个 Readonly Tuple 或 Array，让嵌套表达式可组合，并在网络请求
-前完成校验。
+所有网络查询方法都把共享 Interceptor Attributes 作为第二个参数，把
+`AbortController` 作为第三个参数。
 
-## Aggregation 契约
+```ts
+import {
+  desc,
+  filter,
+  listQuery,
+  projection,
+  singleQuery,
+} from '@ahoo-wang/fetcher-wow';
 
-Aggregation Query 包含可选的有序 `elements`、可选 `filter`、`groupBy`、一个或多个
-`metrics`、可选 Sort 和 Limit。`TERMS`、`HISTOGRAM`、`DATE_HISTOGRAM` 负责分组；
-`COUNT` 与 `NUMERIC` 产生指标。
+type CartListItem = Pick<CartState, 'status' | 'items'>;
 
-处理嵌套数组时，第一个 Element Path 相对 Snapshot Root。后续 Element Path、Filter、
-Group Field 和 Metric Field 都相对当前最内层 Element。示例必须明确展示作用域变化。
+const activeStates = await snapshots.listState<CartListItem>(
+  listQuery<CartFields>({
+    filter: filter.and([
+      filter.ownerId('u-42'),
+      filter.eq('state.status', 'ACTIVE'),
+    ]),
+    projection: projection({ include: ['state.status', 'state.items'] }),
+    sort: [desc('snapshotTime')],
+    limit: 50,
+  }),
+);
 
-## 源码与 Agent 参考
+const oneSnapshot = await snapshots.single(
+  singleQuery<CartFields>({
+    filter: filter.aggregateId('cart-1'),
+  }),
+);
+```
 
-- 公共导出：[`packages/wow/src/index.ts`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/index.ts)
-- Agent 精确 API：[`skills/fetcher-wow-cqrs/references/api.md`](https://github.com/Ahoo-Wang/fetcher/blob/main/skills/fetcher-wow-cqrs/references/api.md)
-- Skill：[`$fetcher-wow-cqrs`](../skills/react-and-integrations.md#fetcher-wow-cqrs)
+需要 Version、Owner、时间戳、Tag、删除状态等元数据时使用 `single`/`list`；应用契约
+只需要 State 值时使用 `*State` 变体。Projection 不会自动推断方法返回类型；选定字段
+形成部分对象时，应显式传入 `T`。
 
-参阅[构建 Wow CQRS 客户端](../recipes/wow-cqrs.md)，了解流式查询和嵌套聚合。
+### ID Helper
+
+| 方法 | 行为 |
+| --- | --- |
+| `getById(id)` | 返回一个完整 Snapshot |
+| `getStateById(id)` | 返回一个 State |
+| `getByIds(ids)` | 返回完整 Snapshot；空数组直接短路 |
+| `getStateByIds(ids)` | 返回 State；空数组直接短路 |
+
+这些 Helper 匹配 Wow Aggregate ID，是 `single`、`list`、
+`filter.aggregateId` 和 `filter.aggregateIds` 的便捷封装。
+
+## Query Builder 与默认值
+
+| Builder | 结构 | 默认值 |
+| --- | --- | --- |
+| `singleQuery()` | filter/condition、projection、sort | 无参数的旧式调用使用 Match All |
+| `listQuery()` | filter/condition、projection、sort、limit | Filter 形式使用 `limit: 0`（无限制）；旧 Condition 形式使用 `10` |
+| `pagedQuery()` | filter/condition、projection、sort、pagination | 第 `1` 页，每页 `10` 条 |
+| `pagination()` | `{ index, size }` | 第 `1` 页，每页 `10` 条 |
+| `projection()` | `{ include?, exclude? }` | 不限制投影字段 |
+| `asc(field)`、`desc(field)` | `{ field, direction }` | 方向显式指定 |
+
+优先使用 `filter` 属性。`condition` 属性和独立 `Condition` Builder 是已弃用的兼容
+API。
+
+### Cursor 遍历
+
+`cursorQuery()` 把 List Query 转换为排他的单字段 Cursor Query。升序遍历增加 `gt`，
+降序遍历增加 `lt`，并把查询排序替换为 Cursor Field。
+
+```ts
+import {
+  CURSOR_ID_START,
+  SortDirection,
+  cursorQuery,
+  filter,
+  listQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const page = await snapshots.list(
+  cursorQuery<CartFields>({
+    field: 'aggregateId',
+    cursorId: CURSOR_ID_START,
+    direction: SortDirection.DESC,
+    query: listQuery({
+      filter: filter.eq('state.status', 'ACTIVE'),
+      limit: 100,
+    }),
+  }),
+);
+
+const nextCursor = page.at(-1)?.aggregateId;
+```
+
+下一页把最后一条记录的 Cursor Field 作为 `cursorId`。应选择稳定且唯一的字段；该
+Helper 会有意生成唯一的 Cursor Sort。`CURSOR_ID_START`（`~`）是默认降序方向的起始
+哨兵；升序遍历需要传入一个排序在所有真实 ID 之前的领域专用哨兵。
+
+## `FilterExpression`
+
+`filter` 是主 Builder。它生成可序列化的 Discriminated Union，并在发出请求前校验
+非法字段、空 Operand、空集合值、支持的枚举和相对时间选项结构。
+
+| 家族 | Builder |
+| --- | --- |
+| 匹配 | `matchAll`、`matchNone` |
+| 元数据 | `id`、`ids`、`aggregateId`、`aggregateIds`、`tenantId`、`ownerId`、`spaceId` |
+| 逻辑 | `and`、`or`、`nor` |
+| 相等/比较 | `eq`、`ne`、`gt`、`gte`、`lt`、`lte`、`between` |
+| 字符串 | `contains`、`startsWith`、`endsWith` |
+| 集合 | `isIn`、`notIn`、`containsAll` |
+| 存在性 | `isEmpty`、`isNull`、`isNotNull`、`exists`、`notExists` |
+| 生命周期 | `deletion`，接收 `DeletionState.ACTIVE`、`DELETED` 或 `ALL` |
+| 嵌套数组 | `elementMatch` |
+| 搜索 | `search`，可指定 Field 和 `SearchMode` |
+| 相对时间 | `today`、`beforeToday`、`tomorrow`、周/月/年 Helper、`recentDays`、`earlierDays` |
+
+```ts
+import {
+  DeletionState,
+  SearchMode,
+  StringComparison,
+  TimeUnit,
+  filter,
+} from '@ahoo-wang/fetcher-wow';
+
+const cartFilter = filter.and<CartFields>([
+  filter.deletion(DeletionState.ACTIVE),
+  filter.contains(
+    'state.status',
+    'active',
+    StringComparison.CASE_INSENSITIVE,
+  ),
+  filter.elementMatch('state.items',
+    filter.and([
+      filter.eq('productId', 'book-1'),
+      filter.gt('quantity', 0),
+    ]),
+  ),
+  filter.search('book', {
+    fields: ['state.status'],
+    mode: SearchMode.TERMS,
+  }),
+  filter.recentDays('snapshotTime', 30, {
+    zoneId: 'Asia/Shanghai',
+    timeUnit: TimeUnit.MILLISECONDS,
+  }),
+]);
+```
+
+应用代码经常遇到的规则：
+
+- `and`、`or`、`nor`、`ids`、`aggregateIds`、`isIn`、`notIn` 和
+  `containsAll` 接收一个非空 Readonly Array。
+- `eq` 和 `ne` 接收 JSON Scalar、`null` 或 JSON Scalar Array。
+- 比较和集合值不能是 `null` 或非有限数字。
+- `elementMatch` Predicate 使用 Element-relative Field，不能包含根级元数据、删除或
+  Search Filter。
+- Snapshot State Field 通常使用 `state.*`；`aggregateId`、`snapshotTime` 等元数据位于
+  Root。
+- 相对时间 Builder 接收 `zoneId`、`datePattern` 和 `timeUnit`。客户端校验 Offset Zone
+  语法、Date Pattern 结构和 `timeUnit`；命名 IANA Zone 由服务端最终校验。
+
+## Aggregation
+
+`AggregationQuery<ROOT_FIELDS, AGGREGATION_FIELDS>` 区分 Root Filter Field 和
+Element 展开后可见的 Field。
+
+| 属性 | 必填 | 含义 |
+| --- | --- | --- |
+| `filter` | 否 | Root-level `FilterExpression` |
+| `elements` | 否 | 按 Parent → Child 排列的数组展开链 |
+| `groupBy` | 否 | Terms、数值 Histogram 或 Date Histogram Group |
+| `metrics` | 是 | Count、Numeric 或 Any-value Metric 的非空 Tuple |
+| `sort` | 否 | 对结果 Row 排序，通常使用 Alias |
+| `limit` | 否 | 最大 Aggregation Row 数 |
+
+### 扁平聚合
+
+```ts
+import {
+  type AggregationQuery,
+  aggregation,
+  desc,
+  filter,
+} from '@ahoo-wang/fetcher-wow';
+
+type CartAggregationFields = 'state.status' | 'ownerId';
+type CartSummary = {
+  status: string;
+  carts: number;
+  sampleOwner: string;
+};
+
+const summaryQuery: AggregationQuery<
+  CartFields,
+  CartAggregationFields
+> = {
+  filter: filter.deletion(DeletionState.ACTIVE),
+  groupBy: [aggregation.terms('state.status', 'status')],
+  metrics: [
+    aggregation.count('carts'),
+    aggregation.any('ownerId', 'sampleOwner'),
+  ],
+  sort: [desc('carts')],
+  limit: 20,
+};
+
+const summary = await snapshots.aggregate<CartSummary>(summaryQuery);
+```
+
+### 嵌套 Element 聚合
+
+第一个 Element Path 相对 Snapshot Root。之后每个 Element Path、Predicate、Group
+Field 和 Metric Field 都相对当前最内层 Element。
+
+```ts
+type LineFields = 'sku' | 'quantity' | 'price';
+type RevenueRow = { sku: string; lines: number; revenue: number };
+
+const revenueQuery: AggregationQuery<CartFields, LineFields> = {
+  filter: filter.eq('state.status', 'ACTIVE'),
+  elements: [
+    aggregation.element('state.orders', filter.eq('status', 'PAID')),
+    aggregation.element('lines', filter.gt('quantity', 0)),
+  ],
+  groupBy: [aggregation.terms('sku', 'sku')],
+  metrics: [
+    aggregation.count('lines'),
+    aggregation.sum(
+      aggregation.multiply(
+        aggregation.field('price'),
+        aggregation.field('quantity'),
+      ),
+      'revenue',
+    ),
+  ],
+  sort: [desc('revenue')],
+  limit: 20,
+};
+
+const revenue = await snapshots.aggregate<RevenueRow>(revenueQuery);
+```
+
+### Aggregation Builder
+
+| Builder | 产物 |
+| --- | --- |
+| `element(path, predicate?)` | 一个 Element 展开步骤 |
+| `terms(field, alias)` | 精确值 Group |
+| `histogram(field, { interval, alias })` | 数值 Bucket；Interval 必须大于零 |
+| `dateHistogram(field, { unit, alias, timeZone? })` | 日历 Bucket；默认时区为 `UTC` |
+| `field`、`constant` | Expression Leaf |
+| `add`、`subtract`、`multiply`、`divide` | Binary Numeric Expression |
+| `count(alias)` | Row Count |
+| `any(field, alias)` | 任意一个代表性 Field Value |
+| `sum`、`avg`、`min`、`max` | Numeric Expression Metric |
+
+Alias 必须是非空单段 Field，且不能以保留前缀 `__wow` 开头。Constant 必须是有限数字。
+
+大结果集可以把 `aggregate` 替换为 `aggregateStream`，并迭代 `event.data`：
+
+```ts
+const controller = new AbortController();
+const rows = await snapshots.aggregateStream<RevenueRow>(
+  revenueQuery,
+  undefined,
+  controller,
+);
+
+for await (const event of rows) {
+  console.log(event.data);
+}
+```
+
+## Domain Event Query
+
+`EventStreamQueryClient<E, FIELDS>` 与 Snapshot Query 使用相同的 Filter、Projection、
+Sort、Pagination、Attributes 和取消约定。
+
+| 方法 | Endpoint | 返回值 |
+| --- | --- | --- |
+| `list(query)` | `event/list` | `DomainEventStream<E>[]` |
+| `listStream(query)` | `event/list` | `DomainEventStream<E>` SSE |
+| `paged(query)` | `event/paged` | `PagedList<DomainEventStream<E>>` |
+| `count(filter)` | `event/count` | `number` |
+
+`DomainEventStream` 包含 Aggregate、Owner、Space、Command、Request、Version、
+Timestamp、Header 和 Event Body 数据。可通过 `DomainEventStreamMetadataFields` 使用
+稳定的事件元数据 Field 常量。
+
+```ts
+import { pagedQuery, pagination } from '@ahoo-wang/fetcher-wow';
+
+const eventPage = await events.paged(
+  pagedQuery({
+    filter: filter.aggregateId('cart-1'),
+    pagination: pagination({ index: 1, size: 20 }),
+    sort: [desc('version')],
+  }),
+);
+```
+
+Event Stream 是集合资源，因此没有 `single` 方法。
+
+## 历史状态加载
+
+| Client | 方法 | `basePath` 下的 Endpoint |
+| --- | --- | --- |
+| `LoadStateAggregateClient` | `load(id)` | `{id}/state` |
+| `LoadStateAggregateClient` | `loadVersioned(id, version)` | `{id}/state/{version}` |
+| `LoadStateAggregateClient` | `loadTimeBased(id, createTime)` | `{id}/state/time/{createTime}` |
+| `LoadOwnerStateAggregateClient` | `load()` | `state` |
+| `LoadOwnerStateAggregateClient` | `loadVersioned(version)` | `state/{version}` |
+| `LoadOwnerStateAggregateClient` | `loadTimeBased(createTime)` | `state/time/{createTime}` |
+
+`createTime` 是 Wow Endpoint 所需的数值时间戳。所有方法都先接收 Attributes，然后接收
+可选 `AbortController`。
+
+## 返回结构
+
+| 类型 | 关键字段 |
+| --- | --- |
+| `MaterializedSnapshot<S>` | `state`、Aggregate 标识、Tenant/Owner/Space、Version、Event/Snapshot Time、Operator、Tag、删除状态 |
+| `PagedList<T>` | `total`、`list` |
+| `DomainEventStream<E>` | Aggregate 标识、Owner/Space、Command/Request ID、`version`、`header`、`body`、`createTime` |
+| `CommandResult` | Wait Stage、Aggregate Version、错误信息、命令结果、Signal 元数据 |
+
+UI 或 Query Builder 需要稳定元数据字段名时，使用 `SnapshotMetadataFields` 和
+`DomainEventStreamMetadataFields`。
+
+## 故障定位
+
+| 现象 | 检查项 |
+| --- | --- |
+| URL 仍包含 `{ownerId}` 或 `{tenantId}` | 在 `apiMetadata.urlParams.path` 或 `request.urlParams.path` 中绑定值 |
+| `listQuery({ filter })` 返回数量超出预期 | Filter 形式默认 `limit: 0`；显式设置 Limit |
+| State Filter 没有匹配结果 | Snapshot State Field 通常需要 `state.` 前缀 |
+| `elementMatch` 在发送前抛错 | Root Metadata、Deletion、Search Filter 应放在 Element Predicate 外部 |
+| Logical 或 Collection Builder 抛错 | 传入一个非空数组，例如 `filter.and([a, b])` |
+| Command 已返回但操作失败 | 检查 `ErrorCodes.isError(result.errorCode)` 和 `bindingErrors` |
+| 无法消费 SSE 方法 | 安装 EventStream Peer Dependency，并用 `for await` 迭代返回的 Stream |
+| UI 请求需要取消旧任务 | 把 `AbortController` 作为第三个 Query 参数，然后调用 `abort()` |
+
+## 源码参考
+
+- [`packages/wow/src/index.ts:14`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/index.ts#L14)
+- [`packages/wow/src/query/snapshot/snapshotQueryClient.ts:121`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/snapshot/snapshotQueryClient.ts#L121)
+- [`packages/wow/src/query/filter.ts:582`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/filter.ts#L582)
+- [`packages/wow/src/query/aggregation.ts:210`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
+- [`skills/fetcher-wow-cqrs/references/api.md:1`](https://github.com/Ahoo-Wang/fetcher/blob/main/skills/fetcher-wow-cqrs/references/api.md#L1)
+- [Fetcher Wow Skill](../skills/react-and-integrations.md#fetcher-wow-cqrs)


### PR DESCRIPTION
## Description

Rewrites the English and Chinese Wow reference pages as a method-level developer reference.

- Adds client, endpoint, return-type, command-stage, and header matrices.
- Documents query defaults, projection typing, cursor semantics, FilterExpression validation, flat and nested aggregation, domain events, historical state, and troubleshooting.
- Keeps FilterExpression as the primary API and Condition as compatibility-only.
- Regenerates llms.txt and llms-full.txt from the current wiki sources.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] pnpm test:unit — 3254 passed, 1 skipped
- [x] pnpm --dir wiki build — 76 pages, 0 missing
- [x] TypeScript compile check for copy-paste examples
- [x] Independent read-only review — no remaining findings
- [x] git diff --check

## Checklist

- [x] My changes are limited to the bilingual Wow reference and generated LLM artifacts
- [x] English and Chinese pages state the same API facts
- [x] Claims were verified against packages/wow public source
- [x] New and existing unit tests pass locally with my changes