### PR TITLE
feat: turn Storybook into a scenario lab

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { addons } from 'storybook/manager-api';
+import { create } from 'storybook/theming';
+
+addons.setConfig({
+  theme: create({
+    base: 'dark',
+    brandTitle: 'Fetcher Scenario Lab',
+    brandUrl: './?path=/docs/overview--docs',
+    brandTarget: '_self',
+    colorPrimary: '#6d5dfc',
+    colorSecondary: '#0958d9',
+    appBg: '#111318',
+    appBorderColor: '#303641',
+    appBorderRadius: 8,
+    barBg: '#171a20',
+    barTextColor: '#b7c0cc',
+    barSelectedColor: '#fff',
+    barHoverColor: '#fff',
+    inputBg: '#20242b',
+    inputBorder: '#353b45',
+    inputTextColor: '#f5f7fa',
+    inputBorderRadius: 8,
+  }),
+});

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -10,7 +10,7 @@
   color: #17233b;
 }
 
-.story-overview__hero {
+.story-overview-hero {
   padding: 36px;
   border: 1px solid #d6e4ff;
   border-radius: 20px;
@@ -18,7 +18,7 @@
   box-shadow: 0 18px 44px rgb(16 48 112 / 11%);
 }
 
-.story-overview__eyebrow {
+.story-overview-eyebrow {
   margin: 0 0 8px;
   color: #0958d9;
   font-size: 12px;
@@ -27,7 +27,7 @@
   text-transform: uppercase;
 }
 
-.story-overview__hero h1 {
+.story-overview-hero h1 {
   max-width: 720px;
   margin: 0;
   color: #17233b;
@@ -36,7 +36,7 @@
   letter-spacing: -0.04em;
 }
 
-.story-overview__hero > p:not(.story-overview__eyebrow) {
+.story-overview-hero > p:not(.story-overview-eyebrow) {
   max-width: 700px;
   margin: 18px 0 0;
   color: #3b4b66;
@@ -44,14 +44,14 @@
   line-height: 1.65;
 }
 
-.story-overview__facts {
+.story-overview-facts {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 20px;
 }
 
-.story-overview__facts span {
+.story-overview-facts span {
   min-height: 30px;
   padding: 6px 11px;
   border: 1px solid #adc6ff;
@@ -72,13 +72,13 @@
   font-size: 24px;
 }
 
-.story-overview__grid {
+.story-overview-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
 }
 
-.story-overview__grid a {
+.story-overview-grid a {
   display: flex;
   min-height: 156px;
   box-sizing: border-box;
@@ -96,18 +96,18 @@
     transform 160ms ease;
 }
 
-.story-overview__grid a:hover {
+.story-overview-grid a:hover {
   border-color: #69a1ff;
   box-shadow: 0 12px 26px rgb(16 48 112 / 13%);
   transform: translateY(-2px);
 }
 
-.story-overview__grid a:focus-visible {
+.story-overview-grid a:focus-visible {
   outline: 3px solid #0958d9;
   outline-offset: 2px;
 }
 
-.story-overview__grid a > span {
+.story-overview-grid a > span {
   color: #0958d9;
   font-size: 11px;
   font-weight: 700;
@@ -115,19 +115,19 @@
   text-transform: uppercase;
 }
 
-.story-overview__grid strong {
+.story-overview-grid strong {
   margin-top: 14px;
   font-size: 18px;
 }
 
-.story-overview__grid p {
+.story-overview-grid p {
   margin: 8px 0 0;
   color: #526079;
   font-size: 13px;
   line-height: 1.5;
 }
 
-.story-overview__flow {
+.story-overview-flow {
   display: grid;
   margin: 0;
   padding: 0;
@@ -136,7 +136,7 @@
   list-style-position: inside;
 }
 
-.story-overview__flow li {
+.story-overview-flow li {
   padding: 16px;
   border-left: 3px solid #0958d9;
   border-radius: 0 10px 10px 0;
@@ -145,11 +145,11 @@
   font-weight: 700;
 }
 
-.story-overview__flow strong {
+.story-overview-flow strong {
   margin-left: 4px;
 }
 
-.story-overview__flow span {
+.story-overview-flow span {
   display: block;
   margin: 8px 0 0 20px;
   color: #526079;
@@ -158,7 +158,7 @@
   line-height: 1.5;
 }
 
-.story-overview__footer {
+.story-overview-footer {
   display: grid;
   align-items: center;
   margin-top: 28px;
@@ -166,7 +166,7 @@
   gap: 16px;
 }
 
-.story-overview__footer a {
+.story-overview-footer a {
   min-height: 36px;
   color: #003a8c;
   font-weight: 600;
@@ -185,20 +185,20 @@
   color: #17233b;
 }
 
-.story-scene__header h2 {
+.story-scene-header h2 {
   margin: 4px 0 8px;
   color: #17233b;
   font-size: clamp(24px, 3vw, 34px);
   line-height: 1.15;
 }
 
-.story-scene__domain,
-.story-scene__summary,
-.story-scene__fixture {
+.story-scene-domain,
+.story-scene-summary,
+.story-scene-fixture {
   margin: 0;
 }
 
-.story-scene__domain {
+.story-scene-domain {
   color: #0958d9;
   font-size: 12px;
   font-weight: 700;
@@ -206,14 +206,14 @@
   text-transform: uppercase;
 }
 
-.story-scene__summary {
+.story-scene-summary {
   max-width: 720px;
   color: #3b4b66;
   font-size: 15px;
   line-height: 1.6;
 }
 
-.story-scene__fixture {
+.story-scene-fixture {
   display: inline-flex;
   min-height: 28px;
   align-items: center;
@@ -227,7 +227,7 @@
   font-weight: 600;
 }
 
-.story-scene__contract {
+.story-scene-contract {
   display: grid;
   margin: 20px 0 0;
   padding: 0;
@@ -236,7 +236,7 @@
   list-style-position: inside;
 }
 
-.story-scene__contract li {
+.story-scene-contract li {
   min-height: 104px;
   padding: 14px;
   border: 1px solid #dbe6f8;
@@ -246,11 +246,11 @@
   font-weight: 700;
 }
 
-.story-scene__contract strong {
+.story-scene-contract strong {
   margin-left: 4px;
 }
 
-.story-scene__contract span {
+.story-scene-contract span {
   display: block;
   margin-top: 8px;
   color: #3b4b66;
@@ -259,7 +259,7 @@
   line-height: 1.5;
 }
 
-.story-scene__stage {
+.story-scene-stage {
   margin-top: 12px;
   padding: 20px;
   border: 1px solid #dbe6f8;
@@ -267,7 +267,7 @@
   background: #fff;
 }
 
-.story-scene__stage .story-stack {
+.story-scene-stage .story-stack {
   width: 100%;
 }
 
@@ -351,18 +351,18 @@
   white-space: pre-wrap;
 }
 
-@media (max-width: 720px) {
+@media (width <= 720px) {
   .story-overview {
     padding: 24px 16px 40px;
   }
 
-  .story-overview__hero {
+  .story-overview-hero {
     padding: 24px;
   }
 
-  .story-overview__grid,
-  .story-overview__flow,
-  .story-overview__footer {
+  .story-overview-grid,
+  .story-overview-flow,
+  .story-overview-footer {
     grid-template-columns: 1fr;
   }
 
@@ -370,15 +370,15 @@
     padding: 16px;
   }
 
-  .story-scene__contract {
+  .story-scene-contract {
     grid-template-columns: 1fr;
   }
 
-  .story-scene__contract li {
+  .story-scene-contract li {
     min-height: 0;
   }
 
-  .story-scene__stage {
+  .story-scene-stage {
     padding: 16px;
   }
 }

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -2,6 +2,275 @@
   max-width: 1120px !important;
 }
 
+.story-overview {
+  width: min(1120px, 100%);
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 48px 32px 64px;
+  color: #17233b;
+}
+
+.story-overview__hero {
+  padding: 36px;
+  border: 1px solid #d6e4ff;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #edf4ff 0%, #fff 68%);
+  box-shadow: 0 18px 44px rgb(16 48 112 / 11%);
+}
+
+.story-overview__eyebrow {
+  margin: 0 0 8px;
+  color: #0958d9;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.story-overview__hero h1 {
+  max-width: 720px;
+  margin: 0;
+  color: #17233b;
+  font-size: clamp(36px, 6vw, 64px);
+  line-height: 1.02;
+  letter-spacing: -0.04em;
+}
+
+.story-overview__hero > p:not(.story-overview__eyebrow) {
+  max-width: 700px;
+  margin: 18px 0 0;
+  color: #3b4b66;
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.story-overview__facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.story-overview__facts span {
+  min-height: 30px;
+  padding: 6px 11px;
+  border: 1px solid #adc6ff;
+  border-radius: 999px;
+  background: #fff;
+  color: #003a8c;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.story-overview section {
+  margin-top: 40px;
+}
+
+.story-overview section h2 {
+  margin: 0 0 16px;
+  color: #17233b;
+  font-size: 24px;
+}
+
+.story-overview__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.story-overview__grid a {
+  display: flex;
+  min-height: 156px;
+  box-sizing: border-box;
+  flex-direction: column;
+  padding: 20px;
+  border: 1px solid #dbe6f8;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 6px 18px rgb(16 48 112 / 7%);
+  color: #17233b;
+  text-decoration: none;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.story-overview__grid a:hover {
+  border-color: #69a1ff;
+  box-shadow: 0 12px 26px rgb(16 48 112 / 13%);
+  transform: translateY(-2px);
+}
+
+.story-overview__grid a:focus-visible {
+  outline: 3px solid #0958d9;
+  outline-offset: 2px;
+}
+
+.story-overview__grid a > span {
+  color: #0958d9;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.story-overview__grid strong {
+  margin-top: 14px;
+  font-size: 18px;
+}
+
+.story-overview__grid p {
+  margin: 8px 0 0;
+  color: #526079;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.story-overview__flow {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  list-style-position: inside;
+}
+
+.story-overview__flow li {
+  padding: 16px;
+  border-left: 3px solid #0958d9;
+  border-radius: 0 10px 10px 0;
+  background: #f4f7fc;
+  color: #0958d9;
+  font-weight: 700;
+}
+
+.story-overview__flow strong {
+  margin-left: 4px;
+}
+
+.story-overview__flow span {
+  display: block;
+  margin: 8px 0 0 20px;
+  color: #526079;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.story-overview__footer {
+  display: grid;
+  align-items: center;
+  margin-top: 28px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+}
+
+.story-overview__footer a {
+  min-height: 36px;
+  color: #003a8c;
+  font-weight: 600;
+  line-height: 36px;
+}
+
+.story-scene {
+  width: min(1040px, 100%);
+  box-sizing: border-box;
+  margin: 0 auto;
+  padding: 24px;
+  border: 1px solid #d6e4ff;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #f3f7ff 0%, #fff 72%);
+  box-shadow: 0 12px 30px rgb(16 48 112 / 10%);
+  color: #17233b;
+}
+
+.story-scene__header h2 {
+  margin: 4px 0 8px;
+  color: #17233b;
+  font-size: clamp(24px, 3vw, 34px);
+  line-height: 1.15;
+}
+
+.story-scene__domain,
+.story-scene__summary,
+.story-scene__fixture {
+  margin: 0;
+}
+
+.story-scene__domain {
+  color: #0958d9;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.story-scene__summary {
+  max-width: 720px;
+  color: #3b4b66;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.story-scene__fixture {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  margin-top: 14px;
+  padding: 0 10px;
+  border: 1px solid #adc6ff;
+  border-radius: 999px;
+  background: #eaf2ff;
+  color: #003a8c;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.story-scene__contract {
+  display: grid;
+  margin: 20px 0 0;
+  padding: 0;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  list-style-position: inside;
+}
+
+.story-scene__contract li {
+  min-height: 104px;
+  padding: 14px;
+  border: 1px solid #dbe6f8;
+  border-radius: 12px;
+  background: rgb(255 255 255 / 82%);
+  color: #0958d9;
+  font-weight: 700;
+}
+
+.story-scene__contract strong {
+  margin-left: 4px;
+}
+
+.story-scene__contract span {
+  display: block;
+  margin-top: 8px;
+  color: #3b4b66;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.story-scene__stage {
+  margin-top: 12px;
+  padding: 20px;
+  border: 1px solid #dbe6f8;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.story-scene__stage .story-stack {
+  width: 100%;
+}
+
 .story-stack {
   display: flex;
   width: min(960px, 100%);
@@ -11,6 +280,52 @@
 
 .story-stack > * {
   margin: 0;
+}
+
+.story-scene .story-stack button:not(.ant-btn) {
+  align-self: flex-start;
+  width: fit-content;
+  min-height: 36px;
+  padding: 0 16px;
+  border: 1px solid #0958d9;
+  border-radius: 8px;
+  background: #0958d9;
+  box-shadow: 0 2px 6px rgb(5 47 122 / 18%);
+  color: #fff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  line-height: 1;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.story-scene .story-stack button:not(.ant-btn):hover:not(:disabled) {
+  border-color: #003eb3;
+  background: #003eb3;
+  box-shadow: 0 4px 10px rgb(5 47 122 / 24%);
+  transform: translateY(-1px);
+}
+
+.story-scene .story-stack button:not(.ant-btn):active:not(:disabled) {
+  box-shadow: 0 1px 3px rgb(5 47 122 / 18%);
+  transform: translateY(0);
+}
+
+.story-scene .story-stack button:not(.ant-btn):focus-visible {
+  outline: 3px solid #0958d9;
+  outline-offset: 2px;
+}
+
+.story-scene .story-stack button:not(.ant-btn):disabled {
+  border-color: #d9d9d9;
+  background: #f5f5f5;
+  box-shadow: none;
+  color: #8c8c8c;
+  cursor: not-allowed;
 }
 
 .story-stack a {
@@ -34,6 +349,38 @@
   background: #fafafa;
   font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
   white-space: pre-wrap;
+}
+
+@media (max-width: 720px) {
+  .story-overview {
+    padding: 24px 16px 40px;
+  }
+
+  .story-overview__hero {
+    padding: 24px;
+  }
+
+  .story-overview__grid,
+  .story-overview__flow,
+  .story-overview__footer {
+    grid-template-columns: 1fr;
+  }
+
+  .story-scene {
+    padding: 16px;
+  }
+
+  .story-scene__contract {
+    grid-template-columns: 1fr;
+  }
+
+  .story-scene__contract li {
+    min-height: 0;
+  }
+
+  .story-scene__stage {
+    padding: 16px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,26 +2,141 @@ import type { Preview } from '@storybook/react-vite';
 import { App, ConfigProvider } from 'antd';
 import './preview.css';
 
+interface SceneDefinition {
+  domain: string;
+  summary: string;
+  fixture: string;
+  setup: string;
+  observe: string;
+}
+
+const sceneDefinitions: Record<string, SceneDefinition> = {
+  'HTTP & Streaming/Event Bus': {
+    domain: 'Event delivery',
+    summary:
+      'Compare handler order, completion, and cleanup across typed buses.',
+    fixture: 'In-memory bus · deterministic handlers',
+    setup: 'Named handlers are registered before each isolated run.',
+    observe:
+      'The result exposes delivery order, completion timing, or cleanup.',
+  },
+  'HTTP & Streaming/Event Stream': {
+    domain: 'Streaming',
+    summary: 'Read deterministic SSE frames as browser consumers receive them.',
+    fixture: 'Local ReadableStream · fixed SSE chunks',
+    setup: 'A Response is assembled from known event-stream chunks.',
+    observe:
+      'Parsed events, termination, malformed JSON, or cancellation is visible.',
+  },
+  'HTTP & Streaming/Fetcher': {
+    domain: 'HTTP exchange',
+    summary:
+      'Trace a request through URL resolution, transport, and extraction.',
+    fixture: 'Mock Service Worker · api.example.test',
+    setup:
+      'A Fetcher and deterministic HTTP fixture are created for this path.',
+    observe:
+      'The result names the URL, payload, timeout, or wrapped HTTP error.',
+  },
+  'HTTP & Streaming/OpenAI': {
+    domain: 'Protocol streaming',
+    summary: 'Reconstruct an OpenAI-compatible completion from local chunks.',
+    fixture: 'Local SSE · no credentials',
+    setup: 'Credential-free chat completion chunks form the response.',
+    observe:
+      'Token assembly, [DONE], malformed data, or cancellation is visible.',
+  },
+  'HTTP & Streaming/Storage': {
+    domain: 'State persistence',
+    summary: 'Exercise serialization, listeners, and lifecycle in isolation.',
+    fixture: 'In-memory storage · disposable listeners',
+    setup: 'A fresh key and serializer are created for the selected variant.',
+    observe:
+      'The result exposes values, updates, cleanup, or serializer failure.',
+  },
+  'React Hooks/Async State': {
+    domain: 'React async state',
+    summary: 'Observe one promise as it moves through the hook state machine.',
+    fixture: 'Deterministic timers · isolated hook',
+    setup: 'The hook starts idle with controlled completion timing.',
+    observe:
+      'Status and result show success, rejection, retry, or stale suppression.',
+  },
+  'React Hooks/Fetcher': {
+    domain: 'React request state',
+    summary: 'Bind a typed Fetcher request to React execution state.',
+    fixture: 'Mock Service Worker · local users',
+    setup:
+      'A hook receives a deterministic request and local response fixture.',
+    observe:
+      'Loading, result, error, refresh, and cancellation remain inspectable.',
+  },
+  'React Hooks/Wow Queries': {
+    domain: 'CQRS query state',
+    summary:
+      'Exercise typed Wow query shapes through their React hook adapters.',
+    fixture: 'Local Wow responses · typed filters',
+    setup: 'A query hook starts with deterministic aggregate data and filters.',
+    observe: 'Single, list, page, count, and stream state stay visible.',
+  },
+};
+
 const preview: Preview = {
   decorators: [
-    Story => (
-      <App>
-        <ConfigProvider
-          theme={{
-            token: {
-              colorErrorText: '#820014',
-              colorLink: '#003a8c',
-              colorPrimary: '#0958d9',
-              colorSuccessText: '#135200',
-              colorTextQuaternary: '#595959',
-              colorTextSecondary: '#595959',
-            },
-          }}
+    (Story, context) => {
+      const scene = sceneDefinitions[context.title];
+      const story = scene ? (
+        <article
+          aria-labelledby={`story-scene-${context.id}`}
+          className="story-scene"
         >
-          <Story />
-        </ConfigProvider>
-      </App>
-    ),
+          <header className="story-scene__header">
+            <p className="story-scene__domain">{scene.domain}</p>
+            <h2 id={`story-scene-${context.id}`}>{context.name}</h2>
+            <p className="story-scene__summary">{scene.summary}</p>
+            <p className="story-scene__fixture">Fixture · {scene.fixture}</p>
+          </header>
+          <ol aria-label="Scenario contract" className="story-scene__contract">
+            <li>
+              <strong>Setup</strong>
+              <span>{scene.setup}</span>
+            </li>
+            <li>
+              <strong>Action</strong>
+              <span>Run the “{context.name}” scenario.</span>
+            </li>
+            <li>
+              <strong>Observe</strong>
+              <span>{scene.observe}</span>
+            </li>
+          </ol>
+          <div className="story-scene__stage">
+            <Story />
+          </div>
+        </article>
+      ) : (
+        <Story />
+      );
+
+      return (
+        <App>
+          <ConfigProvider
+            theme={{
+              token: {
+                colorErrorText: '#820014',
+                colorLink: '#003a8c',
+                colorPrimary: '#0958d9',
+                colorSuccessText: '#135200',
+                colorTextQuaternary: '#595959',
+                colorTextSecondary: '#595959',
+              },
+            }}
+          >
+            {story}
+          </ConfigProvider>
+        </App>
+      );
+    },
   ],
   parameters: {
     a11y: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -90,13 +90,13 @@ const preview: Preview = {
           aria-labelledby={`story-scene-${context.id}`}
           className="story-scene"
         >
-          <header className="story-scene__header">
-            <p className="story-scene__domain">{scene.domain}</p>
+          <header className="story-scene-header">
+            <p className="story-scene-domain">{scene.domain}</p>
             <h2 id={`story-scene-${context.id}`}>{context.name}</h2>
-            <p className="story-scene__summary">{scene.summary}</p>
-            <p className="story-scene__fixture">Fixture · {scene.fixture}</p>
+            <p className="story-scene-summary">{scene.summary}</p>
+            <p className="story-scene-fixture">Fixture · {scene.fixture}</p>
           </header>
-          <ol aria-label="Scenario contract" className="story-scene__contract">
+          <ol aria-label="Scenario contract" className="story-scene-contract">
             <li>
               <strong>Setup</strong>
               <span>{scene.setup}</span>
@@ -110,7 +110,7 @@ const preview: Preview = {
               <span>{scene.observe}</span>
             </li>
           </ol>
-          <div className="story-scene__stage">
+          <div className="story-scene-stage">
             <Story />
           </div>
         </article>

--- a/docs/superpowers/plans/2026-08-28-storybook-scenario-lab.md
+++ b/docs/superpowers/plans/2026-08-28-storybook-scenario-lab.md
@@ -1,0 +1,223 @@
+# Fetcher Storybook Scenario Lab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Overview, HTTP & Streaming, and React Hooks read as deterministic developer scenarios while leaving every Viewer story unchanged.
+
+**Architecture:** A Storybook preview decorator looks up component-level scenario metadata by the existing story title and wraps only HTTP/React stories in one shared scene frame. Overview becomes a linked scenario catalog, while manager branding reuses the existing Fetcher logo. Existing story IDs and package behavior stay unchanged.
+
+**Tech Stack:** Storybook 10, React 19, TypeScript, CSS, Vitest browser stories.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-storybook-scenario-lab-design.md`
+
+## Global Constraints
+
+- Do not modify any `Viewer/*` story content, frame, component styling, or behavior.
+- Preserve existing story IDs, routes, deterministic fixtures, and public package imports.
+- Use only existing dependencies and the current blue/violet palette.
+- Keep all Storybook tests keyboard-accessible and leave `scenario` fixed by each exported story.
+- Do not commit, push, or create a PR without a later explicit user request.
+
+---
+
+### Task 1: Shared HTTP/React Scenario Frame
+
+**Files:**
+
+- Modify: `.storybook/preview.tsx`
+- Modify: `.storybook/preview.css`
+- Test: `stories/http/EventBus.stories.tsx`
+- Modify: `stories/http/EventStream.stories.tsx`
+- Modify: `stories/http/Fetcher.stories.tsx`
+- Modify: `stories/http/OpenAIStream.stories.tsx`
+- Modify: `stories/http/Storage.stories.tsx`
+- Test: `stories/react/AsyncState.stories.tsx`
+- Modify: `stories/react/FetcherHooks.stories.tsx`
+- Modify: `stories/react/WowQueryHooks.stories.tsx`
+- Test: `stories/viewer/FetcherViewer.stories.tsx`
+
+**Interfaces:**
+
+- Consumes: Storybook decorator `context.title`, `context.name`, and `context.parameters.layout`.
+- Produces: `.story-scene` markup for titles under `HTTP & Streaming/` and `React Hooks/`; Viewer receives the unwrapped `Story`.
+
+- [ ] **Step 1: Add failing scene-structure assertions**
+
+In Event Bus and Async State play helpers, assert that the decorated canvas contains:
+
+```ts
+await expect(canvas.getByText('Setup')).toBeVisible();
+await expect(canvas.getByText('Action')).toBeVisible();
+await expect(canvas.getByText('Observe')).toBeVisible();
+```
+
+In `FetcherViewer` Remote Success, assert the exclusion:
+
+```ts
+expect(canvas.queryByText('Setup')).not.toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run Storybook tests and verify RED**
+
+Run:
+
+```bash
+pnpm test:storybook
+```
+
+Expected: HTTP/React scene labels are missing; existing behavior assertions still run.
+
+- [ ] **Step 3: Add title-keyed scene metadata and decorator markup**
+
+In `.storybook/preview.tsx`, define metadata for the five HTTP and three React titles:
+
+```ts
+interface SceneDefinition {
+  domain: string;
+  summary: string;
+  fixture: string;
+  setup: string;
+  observe: string;
+}
+```
+
+Wrap only matching titles with semantic markup containing the current
+`context.name`, then render `<Story />` inside `.story-scene__stage`. Return the
+plain Story for Overview and Viewer.
+
+- [ ] **Step 4: Hide the internal HTTP/React scenario Controls**
+
+In the five HTTP and three React meta objects, replace the unusable radio
+Control without touching Viewer:
+
+```ts
+argTypes: {
+  scenario: {
+    table: {
+      disable: true;
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Style the lab frame**
+
+Extend `.storybook/preview.css` with:
+
+- a light neutral lab surface and white stage;
+- compact domain label, story heading, fixture badge;
+- a three-column ordered Setup/Action/Observe contract;
+- one-column responsive reflow below 720px;
+- no selectors targeting `.ant-*`, Storybook manager, or Viewer internals.
+
+- [ ] **Step 6: Run Storybook tests and verify GREEN**
+
+Run `pnpm test:storybook` and expect 15 files / 76 tests to pass.
+
+---
+
+### Task 2: Scenario Catalog And Fetcher Branding
+
+**Files:**
+
+- Modify: `stories/Overview.stories.tsx`
+- Create: `.storybook/manager.ts`
+
+**Interfaces:**
+
+- Consumes: the existing story routes and Storybook manager theme API.
+- Produces: six task-entry links and a branded manager shell without changing story IDs.
+
+- [ ] **Step 1: Add failing Overview assertions**
+
+Extend the Overview play function to require the reading model and six links:
+
+```ts
+await expect(canvas.getByText('Setup')).toBeVisible();
+await expect(canvas.getByText('Action')).toBeVisible();
+await expect(canvas.getByText('Observe')).toBeVisible();
+await expect(canvas.getAllByRole('link')).toHaveLength(7);
+```
+
+The seven links are six Storybook task entries plus the existing five-minute guide.
+
+- [ ] **Step 2: Run the Overview story and verify RED**
+
+Run `pnpm test:storybook` and expect the new Overview assertions to fail.
+
+- [ ] **Step 3: Rewrite Overview as a task catalog**
+
+Keep the existing heading, fixture provenance, and guide. Add six real `_top`
+links for:
+
+- request lifecycle → Fetcher docs;
+- event delivery → Event Bus docs;
+- streaming → Event Stream docs;
+- async state → Async State docs;
+- fetch state → React Fetcher docs;
+- CQRS query state → Wow Queries docs.
+
+Add a semantic ordered Setup/Action/Observe explanation. Do not add icons,
+illustrations, or placeholder assets.
+
+- [ ] **Step 4: Brand the manager**
+
+In `.storybook/manager.ts`, configure the manager with
+`storybook/manager-api` and `storybook/theming`:
+
+- brand title: `Fetcher Scenario Lab`;
+- brand URL: Overview docs;
+- existing blue/violet palette and dark manager base.
+
+- [ ] **Step 5: Verify Overview and static build**
+
+Run:
+
+```bash
+pnpm test:storybook
+pnpm build-storybook
+```
+
+Expected: all interactions pass and static output contains the branded manager asset.
+
+---
+
+### Task 3: Visual QA And Repository Gates
+
+**Files:**
+
+- Verify only: Overview, Event Bus, Async State, FetcherViewer.
+
+**Interfaces:**
+
+- Consumes: completed scenario frame, catalog, and manager theme.
+- Produces: same-viewport visual proof and a clean uncommitted branch for review.
+
+- [ ] **Step 1: Capture the four routes at the audit viewport**
+
+Capture Overview, Event Bus, Async State, and FetcherViewer in the in-app
+browser. Confirm:
+
+- Overview reads as a scenario catalog;
+- HTTP and React show the scenario contract before controls/output;
+- FetcherViewer is visually unchanged and has no scenario frame;
+- no content is cropped and narrow reflow remains readable.
+
+- [ ] **Step 2: Run complete repository gates**
+
+```bash
+pnpm build
+pnpm test:unit
+pnpm lint
+pnpm test:storybook
+pnpm build-storybook
+git diff --check
+```
+
+Existing repository warnings may remain; all commands must exit 0.
+
+- [ ] **Step 3: Independent scope review**
+
+Review the uncommitted diff for scene clarity, accessibility, route stability,
+and the Viewer exclusion. Fix every Critical/Important finding, rerun affected
+gates, and leave the changes uncommitted for user review.

--- a/docs/superpowers/plans/2026-08-28-storybook-scenario-lab.md
+++ b/docs/superpowers/plans/2026-08-28-storybook-scenario-lab.md
@@ -82,7 +82,7 @@ interface SceneDefinition {
 ```
 
 Wrap only matching titles with semantic markup containing the current
-`context.name`, then render `<Story />` inside `.story-scene__stage`. Return the
+`context.name`, then render `<Story />` inside `.story-scene-stage`. Return the
 plain Story for Overview and Viewer.
 
 - [ ] **Step 4: Hide the internal HTTP/React scenario Controls**

--- a/docs/superpowers/specs/2026-08-28-storybook-scenario-lab-design.md
+++ b/docs/superpowers/specs/2026-08-28-storybook-scenario-lab-design.md
@@ -1,0 +1,101 @@
+# Fetcher Storybook Scenario Lab Design
+
+## Goal
+
+Turn Storybook from a package demo list into a developer-facing scenario lab.
+Each HTTP and React story must explain the setup, the action, and the contract
+to observe before showing the interactive implementation.
+
+## Evidence
+
+The current Storybook has three structural problems:
+
+- Overview lists package groups but does not provide task-oriented entry points.
+- HTTP and React canvases are mostly an action button followed by raw output;
+  the story name is the only scenario context.
+- The internal `scenario` arg is visible as a Control even though exported
+  stories already select the scenario and the Control has no usable options.
+
+Viewer stories already demonstrate complete UI components and are explicitly
+out of scope for visual or scenario framing changes.
+
+## Scope
+
+### In scope
+
+- Brand the Storybook manager as **Fetcher Scenario Lab** using the current
+  blue/violet palette.
+- Replace Overview with a task-oriented catalog for request, streaming,
+  eventing, React async state, Fetcher hooks, and Wow query scenarios.
+- Add a shared scenario frame to all `HTTP & Streaming/*` and `React Hooks/*`
+  stories.
+- Show the selected story name, domain summary, deterministic fixture, and a
+  three-step `Setup → Action → Observe` contract.
+- Hide the internal `scenario` arg from Controls.
+- Preserve the improved native interaction button states.
+
+### Out of scope
+
+- Any `Viewer/*` story content, component styling, scenario frame, or behavior.
+- Package runtime code or public APIs.
+- Existing story routes and sidebar hierarchy.
+- External services, credentials, nondeterministic data, or new dependencies.
+
+## Experience
+
+### Storybook manager
+
+Use the title `Fetcher Scenario Lab` and the repository brand colors. Do not
+restructure story IDs or routes. Keep the text lockup because the square logo
+does not fit Storybook's narrow brand slot without losing the product name.
+
+### Overview
+
+Overview becomes the entry point for developer tasks rather than a package
+inventory. It contains:
+
+1. A short promise: deterministic, local, credential-free scenario testing.
+2. Six linked scenario cards covering the HTTP and React groups.
+3. A concise explanation of how to read every scenario: Setup, Action,
+   Observe.
+4. The existing fixture provenance and documentation link.
+
+### Scenario frame
+
+The global preview decorator wraps only HTTP and React stories. The frame has:
+
+- domain label and current story name;
+- one-sentence purpose for the package family;
+- deterministic fixture label;
+- Setup, Action, and Observe cells;
+- the actual story in a separate white stage.
+
+Metadata is keyed by the existing Storybook component title. The current
+story name supplies the concrete Action variant, so individual story exports
+do not duplicate explanatory markup.
+
+### Visual language
+
+- Use the existing primary `#0958d9` and violet accent.
+- Use a light blue neutral lab surface, white stage, 12–16px radii, and compact
+  borders instead of decorative imagery.
+- Preserve content-width native buttons and accessible focus treatment.
+- Reflow the three-step contract to one column on narrow canvases.
+
+## Accessibility
+
+- Keep semantic headings and ordered scene steps.
+- Maintain visible keyboard focus at or above 3:1 contrast.
+- Do not encode scenario meaning by color alone.
+- Keep links and controls at least 36px high where the story owns them.
+- Preserve reduced-motion behavior.
+
+## Verification
+
+- Start with failing Storybook assertions for Overview scene links and the
+  HTTP/React frame while confirming Viewer has no frame.
+- Run all Storybook interaction/a11y tests.
+- Build static Storybook.
+- Run repository lint and unit tests.
+- Capture Overview, Event Bus, Async State, and FetcherViewer at the same
+  viewport; compare before/after and confirm Viewer remains unchanged.

--- a/stories/Overview.stories.tsx
+++ b/stories/Overview.stories.tsx
@@ -27,15 +27,15 @@ type Story = StoryObj<typeof meta>;
 export const StartHere: Story = {
   render: () => (
     <main aria-labelledby="storybook-title" className="story-overview">
-      <header className="story-overview__hero">
-        <p className="story-overview__eyebrow">Fetcher Scenario Lab</p>
+      <header className="story-overview-hero">
+        <p className="story-overview-eyebrow">Fetcher Scenario Lab</p>
         <h1 id="storybook-title">Fetcher interactive workflows</h1>
         <p>
           Explore real package behavior with deterministic local data. Every
           scenario names its setup, action, and observable contract before you
           run it.
         </p>
-        <div className="story-overview__facts" aria-label="Lab guarantees">
+        <div className="story-overview-facts" aria-label="Lab guarantees">
           <span>Local fixtures</span>
           <span>No credentials</span>
           <span>Repeatable assertions</span>
@@ -44,7 +44,7 @@ export const StartHere: Story = {
 
       <section aria-labelledby="scenario-catalog-title">
         <h2 id="scenario-catalog-title">Choose a developer scenario</h2>
-        <div className="story-overview__grid">
+        <div className="story-overview-grid">
           <a href="./?path=/docs/http-streaming-fetcher--docs" target="_top">
             <span>HTTP exchange</span>
             <strong>Trace a request</strong>
@@ -87,7 +87,7 @@ export const StartHere: Story = {
 
       <section aria-labelledby="scenario-reading-title">
         <h2 id="scenario-reading-title">Read every scenario the same way</h2>
-        <ol className="story-overview__flow">
+        <ol className="story-overview-flow">
           <li>
             <strong>Setup</strong>
             <span>Know the fixture and starting state.</span>
@@ -103,7 +103,7 @@ export const StartHere: Story = {
         </ol>
       </section>
 
-      <footer className="story-overview__footer">
+      <footer className="story-overview-footer">
         <output className="story-output">
           Fixtures: {fixtureUsers.map(user => user.name).join(', ')} · Users
         </output>

--- a/stories/Overview.stories.tsx
+++ b/stories/Overview.stories.tsx
@@ -14,11 +14,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
 import { fixtureUsers } from './fixtures/http';
-import { fixtureViewerDefinition } from './fixtures/viewer';
 
 const meta = {
   title: 'Overview',
-  parameters: { layout: 'centered' },
+  parameters: { layout: 'fullscreen' },
 } satisfies Meta;
 
 export default meta;
@@ -27,28 +26,91 @@ type Story = StoryObj<typeof meta>;
 
 export const StartHere: Story = {
   render: () => (
-    <main aria-labelledby="storybook-title" className="story-stack">
-      <h1 id="storybook-title">Fetcher interactive workflows</h1>
-      <p>
-        Explore real package behavior with deterministic local data. No story
-        contacts an external service or requires credentials.
-      </p>
-      <ul>
-        <li>HTTP &amp; Streaming</li>
-        <li>React Hooks</li>
-        <li>Viewer</li>
-      </ul>
-      <p>
-        Use Controls to change inputs, Interactions to inspect assertions, and
-        Accessibility to review the rendered result.
-      </p>
-      <output className="story-output">
-        Fixtures: {fixtureUsers.map(user => user.name).join(', ')} ·{' '}
-        {fixtureViewerDefinition.name}
-      </output>
-      <a href="https://fetcher.ahoo.me/start/first-request">
-        Read the five-minute guide
-      </a>
+    <main aria-labelledby="storybook-title" className="story-overview">
+      <header className="story-overview__hero">
+        <p className="story-overview__eyebrow">Fetcher Scenario Lab</p>
+        <h1 id="storybook-title">Fetcher interactive workflows</h1>
+        <p>
+          Explore real package behavior with deterministic local data. Every
+          scenario names its setup, action, and observable contract before you
+          run it.
+        </p>
+        <div className="story-overview__facts" aria-label="Lab guarantees">
+          <span>Local fixtures</span>
+          <span>No credentials</span>
+          <span>Repeatable assertions</span>
+        </div>
+      </header>
+
+      <section aria-labelledby="scenario-catalog-title">
+        <h2 id="scenario-catalog-title">Choose a developer scenario</h2>
+        <div className="story-overview__grid">
+          <a href="./?path=/docs/http-streaming-fetcher--docs" target="_top">
+            <span>HTTP exchange</span>
+            <strong>Trace a request</strong>
+            <p>Follow URL resolution, transport, extraction, and failure.</p>
+          </a>
+          <a href="./?path=/docs/http-streaming-event-bus--docs" target="_top">
+            <span>Event delivery</span>
+            <strong>Compare handler execution</strong>
+            <p>Observe serial order, parallel completion, and cleanup.</p>
+          </a>
+          <a
+            href="./?path=/docs/http-streaming-event-stream--docs"
+            target="_top"
+          >
+            <span>Streaming</span>
+            <strong>Read an SSE response</strong>
+            <p>
+              Inspect parsing, termination, malformed data, and cancellation.
+            </p>
+          </a>
+          <a href="./?path=/docs/react-hooks-async-state--docs" target="_top">
+            <span>React async state</span>
+            <strong>Drive a promise lifecycle</strong>
+            <p>
+              See success, rejection, retry, debounce, and stale suppression.
+            </p>
+          </a>
+          <a href="./?path=/docs/react-hooks-fetcher--docs" target="_top">
+            <span>React request state</span>
+            <strong>Bind Fetcher to a hook</strong>
+            <p>Exercise loading, result, error, refresh, and cancellation.</p>
+          </a>
+          <a href="./?path=/docs/react-hooks-wow-queries--docs" target="_top">
+            <span>CQRS query state</span>
+            <strong>Run typed Wow queries</strong>
+            <p>Compare single, list, page, count, and stream query state.</p>
+          </a>
+        </div>
+      </section>
+
+      <section aria-labelledby="scenario-reading-title">
+        <h2 id="scenario-reading-title">Read every scenario the same way</h2>
+        <ol className="story-overview__flow">
+          <li>
+            <strong>Setup</strong>
+            <span>Know the fixture and starting state.</span>
+          </li>
+          <li>
+            <strong>Action</strong>
+            <span>Run one named behavior variant.</span>
+          </li>
+          <li>
+            <strong>Observe</strong>
+            <span>Compare the visible result with the contract.</span>
+          </li>
+        </ol>
+      </section>
+
+      <footer className="story-overview__footer">
+        <output className="story-output">
+          Fixtures: {fixtureUsers.map(user => user.name).join(', ')} · Users
+        </output>
+        <a href="https://fetcher.ahoo.me/start/first-request">
+          Read the five-minute guide
+        </a>
+      </footer>
     </main>
   ),
   play: async ({ canvasElement }) => {
@@ -56,6 +118,16 @@ export const StartHere: Story = {
     await expect(
       canvas.getByRole('heading', { name: 'Fetcher interactive workflows' }),
     ).toBeVisible();
+    await expect(canvas.getByText('Setup')).toBeVisible();
+    await expect(canvas.getByText('Action')).toBeVisible();
+    await expect(canvas.getByText('Observe')).toBeVisible();
+    const links = canvas.getAllByRole('link');
+    await expect(links).toHaveLength(7);
+    for (const link of links.slice(0, 6)) {
+      await expect(link.getAttribute('href')?.startsWith('./?path=')).toBe(
+        true,
+      );
+    }
     await expect(canvas.getByText('Fixtures: Ada, Lin · Users')).toBeVisible();
   },
 };

--- a/stories/http/EventBus.stories.tsx
+++ b/stories/http/EventBus.stories.tsx
@@ -110,7 +110,7 @@ const meta = {
   title: 'HTTP & Streaming/Event Bus',
   component: EventBusDemo,
   args: { scenario: 'serial' },
-  argTypes: { scenario: { control: 'radio' } },
+  argTypes: { scenario: { table: { disable: true } } },
 } satisfies Meta<typeof EventBusDemo>;
 
 export default meta;
@@ -118,6 +118,9 @@ type Story = StoryObj<typeof meta>;
 
 async function emitAndExpect(canvasElement: HTMLElement, text: string) {
   const canvas = within(canvasElement);
+  await expect(canvas.getByText('Setup')).toBeVisible();
+  await expect(canvas.getByText('Action')).toBeVisible();
+  await expect(canvas.getByText('Observe')).toBeVisible();
   await userEvent.click(canvas.getByRole('button', { name: 'Emit event' }));
   await expect(await canvas.findByText(text)).toBeVisible();
 }

--- a/stories/http/EventStream.stories.tsx
+++ b/stories/http/EventStream.stories.tsx
@@ -123,7 +123,7 @@ const meta = {
   title: 'HTTP & Streaming/Event Stream',
   component: EventStreamDemo,
   args: { scenario: 'tokens' },
-  argTypes: { scenario: { control: 'radio' } },
+  argTypes: { scenario: { table: { disable: true } } },
 } satisfies Meta<typeof EventStreamDemo>;
 
 export default meta;

--- a/stories/http/Fetcher.stories.tsx
+++ b/stories/http/Fetcher.stories.tsx
@@ -107,7 +107,7 @@ const meta = {
   component: RequestDemo,
   beforeEach: installFetchFixture,
   args: { scenario: 'basic' },
-  argTypes: { scenario: { control: 'radio' } },
+  argTypes: { scenario: { table: { disable: true } } },
 } satisfies Meta<typeof RequestDemo>;
 
 export default meta;

--- a/stories/http/OpenAIStream.stories.tsx
+++ b/stories/http/OpenAIStream.stories.tsx
@@ -92,7 +92,7 @@ const meta = {
   component: OpenAIDemo,
   beforeEach: installFetchFixture,
   args: { scenario: 'json' },
-  argTypes: { scenario: { control: 'radio' } },
+  argTypes: { scenario: { table: { disable: true } } },
 } satisfies Meta<typeof OpenAIDemo>;
 
 export default meta;

--- a/stories/http/Storage.stories.tsx
+++ b/stories/http/Storage.stories.tsx
@@ -87,7 +87,7 @@ const meta = {
   title: 'HTTP & Streaming/Storage',
   component: StorageDemo,
   args: { scenario: 'read-write' },
-  argTypes: { scenario: { control: 'radio' } },
+  argTypes: { scenario: { table: { disable: true } } },
 } satisfies Meta<typeof StorageDemo>;
 
 export default meta;

--- a/stories/react/AsyncState.stories.tsx
+++ b/stories/react/AsyncState.stories.tsx
@@ -117,7 +117,7 @@ const meta = {
   title: 'React Hooks/Async State',
   component: AsyncStateDemo,
   args: { scenario: 'success' },
-  argTypes: { scenario: { control: 'radio' } },
+  argTypes: { scenario: { table: { disable: true } } },
 } satisfies Meta<typeof AsyncStateDemo>;
 
 export default meta;
@@ -125,7 +125,17 @@ type Story = StoryObj<typeof meta>;
 
 async function runAndExpect(canvasElement: HTMLElement, text: string) {
   const canvas = within(canvasElement);
-  await userEvent.click(canvas.getByRole('button', { name: 'Run operation' }));
+  await expect(canvas.getByText('Setup')).toBeVisible();
+  await expect(canvas.getByText('Action')).toBeVisible();
+  await expect(canvas.getByText('Observe')).toBeVisible();
+  const trigger = canvas.getByRole('button', { name: 'Run operation' });
+  await expect(window.getComputedStyle(trigger).borderRadius).toBe('8px');
+  await userEvent.tab();
+  await expect(trigger).toHaveFocus();
+  await expect(window.getComputedStyle(trigger).outlineColor).toBe(
+    'rgb(9, 88, 217)',
+  );
+  await userEvent.click(trigger);
   await expect(await canvas.findByText(text)).toBeVisible();
 }
 

--- a/stories/react/FetcherHooks.stories.tsx
+++ b/stories/react/FetcherHooks.stories.tsx
@@ -90,7 +90,7 @@ const meta = {
   component: FetcherHookDemo,
   beforeEach: installFetchFixture,
   args: { scenario: 'success' },
-  argTypes: { scenario: { control: 'radio' } },
+  argTypes: { scenario: { table: { disable: true } } },
 } satisfies Meta<typeof FetcherHookDemo>;
 
 export default meta;

--- a/stories/react/WowQueryHooks.stories.tsx
+++ b/stories/react/WowQueryHooks.stories.tsx
@@ -135,7 +135,7 @@ const meta = {
   component: WowQueryDemo,
   beforeEach: installFetchFixture,
   args: { scenario: 'single' },
-  argTypes: { scenario: { control: 'radio' } },
+  argTypes: { scenario: { table: { disable: true } } },
 } satisfies Meta<typeof WowQueryDemo>;
 
 export default meta;

--- a/stories/viewer/FetcherViewer.stories.tsx
+++ b/stories/viewer/FetcherViewer.stories.tsx
@@ -38,7 +38,7 @@ function FetcherViewerDemo({
   showRefMethods,
 }: FetcherViewerDemoProps) {
   const viewerRef = useRef<FetcherViewerRef>(null);
-  const [output, setOutput] = useState('Ready');
+  const [output, setOutput] = useState<string>();
 
   const readState = () => {
     const definition = viewerRef.current?.getViewerDefinition();
@@ -90,7 +90,7 @@ function FetcherViewerDemo({
           }
         />
       </FullscreenProvider>
-      {showRefMethods && (
+      {showRefMethods && output && (
         <output className="story-output" aria-live="polite">
           {output}
         </output>
@@ -137,7 +137,9 @@ type Story = StoryObj<typeof meta>;
 export const RemoteSuccess: Story = {
   args: { scenario: 'success' },
   play: async ({ canvasElement }) => {
-    await expect(await within(canvasElement).findByText('Ada')).toBeVisible();
+    const canvas = within(canvasElement);
+    expect(canvas.queryByText('Setup')).not.toBeInTheDocument();
+    await expect(await canvas.findByText('Ada')).toBeVisible();
   },
 };
 
@@ -191,7 +193,16 @@ export const ImperativeMethods: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByText('Ada')).toBeVisible();
-    await userEvent.click(canvas.getByRole('button', { name: 'Refresh data' }));
+    expect(canvas.queryByText('Ready')).not.toBeInTheDocument();
+    const actions = canvasElement.querySelector('.story-actions');
+    await expect(getComputedStyle(actions!).display).toBe('block');
+    const searchButton = canvas.getByRole('button', { name: /搜索/ });
+    await expect(getComputedStyle(searchButton).backgroundColor).toBe(
+      'rgb(9, 88, 217)',
+    );
+    const refreshButton = canvas.getByRole('button', { name: 'Refresh data' });
+    await expect(getComputedStyle(refreshButton).borderRadius).not.toBe('8px');
+    await userEvent.click(refreshButton);
     await expect(await canvas.findByText('Ada (refreshed)')).toBeVisible();
     await userEvent.click(canvas.getByRole('button', { name: 'Read state' }));
     await expect(

--- a/stories/viewer/Viewer.stories.tsx
+++ b/stories/viewer/Viewer.stories.tsx
@@ -28,7 +28,7 @@ import {
 type Scenario = 'ready' | 'loading' | 'empty' | 'error';
 
 function ViewerDemo({ scenario }: { scenario: Scenario }) {
-  const [output, setOutput] = useState('Ready');
+  const [output, setOutput] = useState<string>();
   const [retrySucceeded, setRetrySucceeded] = useState(false);
 
   if (scenario === 'error' && !retrySucceeded) {
@@ -96,9 +96,11 @@ function ViewerDemo({ scenario }: { scenario: Scenario }) {
           setOutput(`Deleted view: ${view.name}`);
         }}
       />
-      <output className="story-output" aria-live="polite">
-        {output}
-      </output>
+      {output && (
+        <output className="story-output" aria-live="polite">
+          {output}
+        </output>
+      )}
     </div>
   );
 }
@@ -121,6 +123,7 @@ export const CompleteFlow: Story = {
     const page = within(canvasElement.ownerDocument.body);
 
     await expect(await canvas.findByText('Ada')).toBeVisible();
+    expect(canvas.queryByText('Ready')).not.toBeInTheDocument();
     await userEvent.click(canvas.getByText('u-ada'));
     await expect(await canvas.findByText('Opened u-ada: Ada')).toBeVisible();
 


### PR DESCRIPTION
## Description

- Brand Storybook as the Fetcher Scenario Lab and replace the package-list overview with task-oriented scenario entry points.
- Add a shared Setup / Action / Observe frame for HTTP, streaming, and React stories using deterministic local fixtures.
- Improve raw interactive controls while scoping new styles to scenario stories so Viewer keeps its existing presentation.
- Preserve Viewer controls, remove non-informative Ready placeholders, and add regression assertions for the isolation boundary.
- Use deployment-base-safe relative Storybook links.

No new dependencies are required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] pnpm test:unit
- [x] pnpm test:storybook (15 files, 76 tests)
- [x] pnpm build-storybook
- [x] pnpm lint (0 errors; existing repository warnings only)
- [x] Browser QA at desktop and 700px widths, including Viewer style-isolation checks

**Test Configuration**:

- Toolchain: Node.js / pnpm 10 / Storybook 10 / Chromium

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings