### PR TITLE
chore(release): bump version to 3.18.1

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-integration-test",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "private": true,
   "description": "Integration Test Fetcher",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcher",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "A modern HTTP client library based on fetch API",
   "private": true,
   "type": "module",

--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-cosec",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "Enterprise-grade CoSec authentication integration for the Fetcher HTTP client with comprehensive security features including automatic token management, device tracking, and request attribution.",
   "keywords": [
     "fetch",

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-decorator",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "TypeScript decorators for clean, declarative API service definitions with Fetcher HTTP client. Enables automatic parameter binding, method mapping, and type-safe API interactions.",
   "keywords": [
     "fetch",

--- a/packages/eventbus/package.json
+++ b/packages/eventbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventbus",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "A TypeScript event bus library with serial, parallel, and broadcast implementations",
   "keywords": [
     "eventbus",

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventstream",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "Server-Sent Events (SSE) support for Fetcher HTTP client with native LLM streaming API support. Enables real-time data streaming and token-by-token LLM response handling.",
   "keywords": [
     "fetch",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "Fetcher is not just another HTTP client—it's a complete ecosystem designed for modern web development with native LLM\nstreaming API support. Built on the native Fetch API, Fetcher provides an Axios-like experience with powerful features\nwhile maintaining an incredibly small footprint.",
   "keywords": [
     "fetch",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-generator",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "A powerful TypeScript code generation tool that automatically generates type-safe API client code based on OpenAPI specifications. It is designed for general use cases and is also deeply optimized for the [Wow](https://github.com/Ahoo-Wang/Wow) Domain-Driven Design framework, providing native support for the CQRS architectural pattern.",
   "keywords": [
     "fetch",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-openai",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "Type-safe OpenAI API client for Fetcher ecosystem. Provides seamless integration with OpenAI's Chat Completions API, supporting both streaming and non-streaming responses with full TypeScript support.",
   "keywords": [
     "openai",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-openapi",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "OpenAPI Specification TypeScript types for Fetcher - A modern, ultra-lightweight HTTP client for browsers and Node.js. Provides complete TypeScript support with type inference for OpenAPI 3.x schemas.",
   "keywords": [
     "fetch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-react",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "React integration for Fetcher HTTP client. Provides React Hooks and components for seamless data fetching with automatic re-rendering and loading states.",
   "keywords": [
     "fetch",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-storage",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "A lightweight, cross-environment storage library with key-based storage and automatic environment detection. Provides consistent API for browser localStorage and in-memory storage with change notifications.",
   "keywords": [
     "storage",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-viewer",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "A comprehensive React component library for API documentation viewing and data filtering, built on top of Ant Design and the Fetcher ecosystem. Provides reusable UI components for building rich data-driven applications with advanced filtering capabilities and remote data selection.",
   "keywords": [
     "react",

--- a/packages/wow/package.json
+++ b/packages/wow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-wow",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "Support for Wow(https://github.com/Ahoo-Wang/Wow) in Fetcher",
   "keywords": [
     "fetch",


### PR DESCRIPTION
## Description

- Bump the root, all public packages, and the integration-test workspace from 3.18.0 to 3.18.1 in lockstep.
- Prepare the release containing the required QueryApi aggregation methods from #1375.

## Scope

Version fields only. No source, dependency, or lockfile changes.

## How Has This Been Tested?

- [x] pnpm build
- [x] pnpm test:unit
- [x] git diff --check

## Checklist

- [x] All workspace package versions are 3.18.1
- [x] New and existing unit tests pass locally
- [x] The branch is based on the latest main