### PR TITLE
feat(wow): add empty string filters

### DIFF
--- a/packages/wow/src/query/filter.ts
+++ b/packages/wow/src/query/filter.ts
@@ -45,6 +45,8 @@ export enum FilterOperator {
   BETWEEN = 'BETWEEN',
   CONTAINS_ALL = 'CONTAINS_ALL',
   IS_EMPTY = 'IS_EMPTY',
+  IS_EMPTY_STRING = 'IS_EMPTY_STRING',
+  IS_NOT_EMPTY_STRING = 'IS_NOT_EMPTY_STRING',
   IS_NULL = 'IS_NULL',
   IS_NOT_NULL = 'IS_NOT_NULL',
   EXISTS = 'EXISTS',
@@ -408,6 +410,8 @@ export type BetweenFilter<FIELDS extends string = string> = {
 export type FieldPresenceFilter<FIELDS extends string = string> = {
   op:
     | FilterOperator.IS_EMPTY
+    | FilterOperator.IS_EMPTY_STRING
+    | FilterOperator.IS_NOT_EMPTY_STRING
     | FilterOperator.IS_NULL
     | FilterOperator.IS_NOT_NULL
     | FilterOperator.EXISTS
@@ -775,6 +779,19 @@ export const filter = {
   },
   isEmpty<FIELDS extends string>(field: FIELDS): FieldPresenceFilter<FIELDS> {
     return { op: FilterOperator.IS_EMPTY, field: logicalField(field) };
+  },
+  isEmptyString<FIELDS extends string>(
+    field: FIELDS,
+  ): FieldPresenceFilter<FIELDS> {
+    return { op: FilterOperator.IS_EMPTY_STRING, field: logicalField(field) };
+  },
+  isNotEmptyString<FIELDS extends string>(
+    field: FIELDS,
+  ): FieldPresenceFilter<FIELDS> {
+    return {
+      op: FilterOperator.IS_NOT_EMPTY_STRING,
+      field: logicalField(field),
+    };
   },
   isNull<FIELDS extends string>(field: FIELDS): FieldPresenceFilter<FIELDS> {
     return { op: FilterOperator.IS_NULL, field: logicalField(field) };

--- a/packages/wow/test/query/filter.test.ts
+++ b/packages/wow/test/query/filter.test.ts
@@ -70,6 +70,16 @@ describe('filter', () => {
     });
   });
 
+  it('builds operand-free empty string filters', () => {
+    expect([
+      filter.isEmptyString('state.name'),
+      filter.isNotEmptyString('state.name'),
+    ]).toEqual([
+      { op: 'IS_EMPTY_STRING', field: 'state.name' },
+      { op: 'IS_NOT_EMPTY_STRING', field: 'state.name' },
+    ]);
+  });
+
   it('builds search filters with explicit defaults and phrase mode', () => {
     expect(filter.search('wow')).toEqual({
       op: FilterOperator.SEARCH,

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -644,7 +644,7 @@ Available builders:
 - Comparison: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between`
 - String: `contains`, `startsWith`, `endsWith`; pass `StringComparison` as the third argument
 - Collection: `isIn`, `notIn`, `containsAll`
-- Presence: `isEmpty`, `isNull`, `isNotNull`, `exists`, `notExists`
+- Presence: `isEmpty`, `isEmptyString`, `isNotEmptyString`, `isNull`, `isNotNull`, `exists`, `notExists`
 - Scope/search: `deletion`, `elementMatch`, `search(query, options?: SearchFilterOptions)`
 - Relative time: `today`, `beforeToday`, `tomorrow`, `thisWeek`, `nextWeek`, `lastWeek`, `thisMonth`, `lastMonth`, `yesterday`, `nextMonth`, `lastYear`, `thisYear`, `nextYear`, `recentDays`, `earlierDays`
 
@@ -663,6 +663,9 @@ filter.containsAll('state.tags', ['wow', 'cqrs']);
 
 `eq` and `ne` accept a JSON scalar or an array of JSON scalars. Logical field
 segments may start with `@`.
+
+`isEmptyString` matches exactly `""`. `isNotEmptyString` requires the field to
+exist, be non-null, and differ from `""`. Whitespace-only strings are not empty.
 
 Relative-time builders accept JVM `ZoneId` and `DateTimeFormatter` options:
 

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -1,6 +1,6 @@
 # Fetcher Wiki — Full Content
 
-> All documentation pages inlined for LLM consumption. Generated 2026-08-30.
+> All documentation pages inlined for LLM consumption. Generated 2026-08-31.
 
 ## Start
 
@@ -3522,7 +3522,7 @@ supported enums, and relative-time option shapes before a request is sent.
 | Equality/comparison | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between` |
 | String | `contains`, `startsWith`, `endsWith` |
 | Collection | `isIn`, `notIn`, `containsAll` |
-| Presence | `isEmpty`, `isNull`, `isNotNull`, `exists`, `notExists` |
+| Presence | `isEmpty`, `isEmptyString`, `isNotEmptyString`, `isNull`, `isNotNull`, `exists`, `notExists` |
 | Lifecycle | `deletion` with `DeletionState.ACTIVE`, `DELETED`, or `ALL` |
 | Nested arrays | `elementMatch` |
 | Search | `search` with optional fields and `SearchMode` |
@@ -3567,6 +3567,9 @@ Rules that commonly affect application code:
   `containsAll` require one non-empty readonly array.
 - `eq` and `ne` accept JSON scalars, `null`, or an array of JSON scalars.
 - Comparison and collection values cannot be `null` or non-finite numbers.
+- `isEmptyString` matches exactly `""`; `isNotEmptyString` requires the field
+  to exist, be non-null, and differ from `""`. Whitespace-only strings are not
+  empty.
 - `elementMatch` predicates use element-relative fields and cannot contain
   root metadata, deletion, or search filters.
 - Snapshot state fields are normally addressed through `state.*`; metadata
@@ -7753,7 +7756,7 @@ Field。`CursorPage<T>` 包含 `list` 和可空的 `nextCursor`；与 `PagedList
 | 相等/比较 | `eq`、`ne`、`gt`、`gte`、`lt`、`lte`、`between` |
 | 字符串 | `contains`、`startsWith`、`endsWith` |
 | 集合 | `isIn`、`notIn`、`containsAll` |
-| 存在性 | `isEmpty`、`isNull`、`isNotNull`、`exists`、`notExists` |
+| 存在性 | `isEmpty`、`isEmptyString`、`isNotEmptyString`、`isNull`、`isNotNull`、`exists`、`notExists` |
 | 生命周期 | `deletion`，接收 `DeletionState.ACTIVE`、`DELETED` 或 `ALL` |
 | 嵌套数组 | `elementMatch` |
 | 搜索 | `search`，可指定 Field 和 `SearchMode` |
@@ -7798,6 +7801,8 @@ const cartFilter = filter.and<CartFields>([
   `containsAll` 接收一个非空 Readonly Array。
 - `eq` 和 `ne` 接收 JSON Scalar、`null` 或 JSON Scalar Array。
 - 比较和集合值不能是 `null` 或非有限数字。
+- `isEmptyString` 只匹配 `""`；`isNotEmptyString` 要求 Field 存在、非
+  `null` 且不等于 `""`。仅含空白的字符串不视为空字符串。
 - `elementMatch` Predicate 使用 Element-relative Field，不能包含根级元数据、删除或
   Search Filter。
 - Snapshot State Field 通常使用 `state.*`；`aggregateId`、`snapshotTime` 等元数据位于

--- a/wiki/reference/wow.md
+++ b/wiki/reference/wow.md
@@ -335,7 +335,7 @@ supported enums, and relative-time option shapes before a request is sent.
 | Equality/comparison | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `between` |
 | String | `contains`, `startsWith`, `endsWith` |
 | Collection | `isIn`, `notIn`, `containsAll` |
-| Presence | `isEmpty`, `isNull`, `isNotNull`, `exists`, `notExists` |
+| Presence | `isEmpty`, `isEmptyString`, `isNotEmptyString`, `isNull`, `isNotNull`, `exists`, `notExists` |
 | Lifecycle | `deletion` with `DeletionState.ACTIVE`, `DELETED`, or `ALL` |
 | Nested arrays | `elementMatch` |
 | Search | `search` with optional fields and `SearchMode` |
@@ -380,6 +380,9 @@ Rules that commonly affect application code:
   `containsAll` require one non-empty readonly array.
 - `eq` and `ne` accept JSON scalars, `null`, or an array of JSON scalars.
 - Comparison and collection values cannot be `null` or non-finite numbers.
+- `isEmptyString` matches exactly `""`; `isNotEmptyString` requires the field
+  to exist, be non-null, and differ from `""`. Whitespace-only strings are not
+  empty.
 - `elementMatch` predicates use element-relative fields and cannot contain
   root metadata, deletion, or search filters.
 - Snapshot state fields are normally addressed through `state.*`; metadata

--- a/wiki/zh/reference/wow.md
+++ b/wiki/zh/reference/wow.md
@@ -325,7 +325,7 @@ Field。`CursorPage<T>` 包含 `list` 和可空的 `nextCursor`；与 `PagedList
 | 相等/比较 | `eq`、`ne`、`gt`、`gte`、`lt`、`lte`、`between` |
 | 字符串 | `contains`、`startsWith`、`endsWith` |
 | 集合 | `isIn`、`notIn`、`containsAll` |
-| 存在性 | `isEmpty`、`isNull`、`isNotNull`、`exists`、`notExists` |
+| 存在性 | `isEmpty`、`isEmptyString`、`isNotEmptyString`、`isNull`、`isNotNull`、`exists`、`notExists` |
 | 生命周期 | `deletion`，接收 `DeletionState.ACTIVE`、`DELETED` 或 `ALL` |
 | 嵌套数组 | `elementMatch` |
 | 搜索 | `search`，可指定 Field 和 `SearchMode` |
@@ -370,6 +370,8 @@ const cartFilter = filter.and<CartFields>([
   `containsAll` 接收一个非空 Readonly Array。
 - `eq` 和 `ne` 接收 JSON Scalar、`null` 或 JSON Scalar Array。
 - 比较和集合值不能是 `null` 或非有限数字。
+- `isEmptyString` 只匹配 `""`；`isNotEmptyString` 要求 Field 存在、非
+  `null` 且不等于 `""`。仅含空白的字符串不视为空字符串。
 - `elementMatch` Predicate 使用 Element-relative Field，不能包含根级元数据、删除或
   Search Filter。
 - Snapshot State Field 通常使用 `state.*`；`aggregateId`、`snapshotTime` 等元数据位于


### PR DESCRIPTION
## Description

Align the Fetcher Wow FilterExpression API with upstream Wow commit `95311056b`.

- Add `IS_EMPTY_STRING` and `IS_NOT_EMPTY_STRING` operators.
- Add `filter.isEmptyString(field)` and `filter.isNotEmptyString(field)` builders.
- Reuse `FieldPresenceFilter`, including element-relative predicates.
- Synchronize the agent skill reference, English/Chinese Wiki, and generated `llms-full.txt`.
- Keep Query Schema operational metadata and clients outside the Fetcher public surface.

No new dependencies or version changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `pnpm test:unit` — 3256 passed, 1 skipped
- [x] `pnpm --filter @ahoo-wang/fetcher-wow build`
- [x] `pnpm --filter @ahoo-wang/fetcher-wow test:type`
- [x] `pnpm build` in `wiki/`

**Test Configuration**:

- Runtime: Node.js 24.11.0
- Package manager: pnpm 10.34.5
- Platform: macOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings beyond existing tool warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings