### PR TITLE
fix(wow): align V9 query field contract

### DIFF
--- a/packages/wow/src/query/aggregation.ts
+++ b/packages/wow/src/query/aggregation.ts
@@ -15,7 +15,7 @@ import {
   filter,
   type ElementFilterExpression,
   type FilterExpression,
-  type LogicalField,
+  type QueryField,
 } from './filter';
 import type { FieldSort } from './sort';
 
@@ -63,12 +63,12 @@ export enum AggregationFunction {
 }
 
 export interface AggregationElement {
-  path: LogicalField;
+  path: QueryField;
   filter?: ElementFilterExpression;
 }
 
 interface AggregationGroupBase<FIELDS extends string = string> {
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
   alias: string;
 }
 
@@ -100,7 +100,7 @@ export type AggregationGroup<FIELDS extends string = string> =
 
 export interface FieldAggregationExpression<FIELDS extends string = string> {
   type: AggregationExpressionType.FIELD;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
 }
 
 export interface ConstantAggregationExpression {
@@ -134,7 +134,7 @@ export interface NumericAggregationMetric<FIELDS extends string = string> {
 
 export interface AnyAggregationMetric<FIELDS extends string = string> {
   type: AggregationMetricType.ANY;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
   alias: string;
 }
 

--- a/packages/wow/src/query/filter.ts
+++ b/packages/wow/src/query/filter.ts
@@ -13,9 +13,11 @@
 
 import { DeletionState } from './condition';
 
-export type LogicalField<FIELDS extends string = string> = FIELDS;
+export type QueryField<FIELDS extends string = string> = FIELDS;
+/** @deprecated Use QueryField instead. */
+export type LogicalField<FIELDS extends string = string> = QueryField<FIELDS>;
 export type FilterLiteral = null | string | number | boolean;
-export type EqualityFilterValue = FilterLiteral | FilterLiteral[];
+export type EqualityFilterValue = FilterLiteral;
 export type ComparableFilterLiteral = Exclude<FilterLiteral, null>;
 
 export enum FilterOperator {
@@ -93,7 +95,7 @@ export enum TimeUnit {
 
 const LOCAL_TIME_PATTERN =
   /^([01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9](?:\.[0-9]{1,9})?)?$/;
-const LOGICAL_FIELD_PATTERN =
+const QUERY_FIELD_PATTERN =
   /^@?[A-Za-z_][A-Za-z0-9_-]*(\.(?:@?[A-Za-z_][A-Za-z0-9_-]*|[0-9]+))*$/;
 const OFFSET_ZONE_PATTERN =
   /^(?:UTC|GMT|UT)?[+-](\d{1,2}|\d{4}|\d{6}|\d{2}:\d{2}|\d{2}:\d{2}:\d{2})$/;
@@ -139,9 +141,9 @@ const DATE_PATTERN_COUNTS: Readonly<
   g: 19,
 };
 
-function logicalField<FIELDS extends string>(field: FIELDS): FIELDS {
-  if (typeof field !== 'string' || !LOGICAL_FIELD_PATTERN.test(field)) {
-    throw new TypeError(`Logical field is invalid: [${String(field)}].`);
+function queryField<FIELDS extends string>(field: FIELDS): FIELDS {
+  if (typeof field !== 'string' || !QUERY_FIELD_PATTERN.test(field)) {
+    throw new TypeError(`Query field is invalid: [${String(field)}].`);
   }
   return field;
 }
@@ -160,14 +162,6 @@ function filterLiteral<T extends FilterLiteral>(
     throw new TypeError('Filter value must be a JSON scalar.');
   }
   return value;
-}
-
-function equalityFilterValue(value: EqualityFilterValue): EqualityFilterValue {
-  if (Array.isArray(value)) {
-    value.forEach(item => filterLiteral(item, true));
-    return value;
-  }
-  return filterLiteral(value, true);
 }
 
 function requiredString(name: string, value: string): string {
@@ -370,7 +364,7 @@ export type ElementLogicalFilter<FIELDS extends string = string> = {
 
 export type EqualityFilter<FIELDS extends string = string> = {
   op: FilterOperator.EQ | FilterOperator.NE;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
   value: EqualityFilterValue;
 };
 
@@ -380,7 +374,7 @@ export type ComparisonFilter<FIELDS extends string = string> = {
     | FilterOperator.GTE
     | FilterOperator.LT
     | FilterOperator.LTE;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
   value: ComparableFilterLiteral;
 };
 
@@ -389,20 +383,20 @@ export type StringFilter<FIELDS extends string = string> = {
     | FilterOperator.CONTAINS
     | FilterOperator.STARTS_WITH
     | FilterOperator.ENDS_WITH;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
   value: string;
   stringComparison?: StringComparison;
 };
 
 export type CollectionFilter<FIELDS extends string = string> = {
   op: FilterOperator.IN | FilterOperator.NOT_IN | FilterOperator.CONTAINS_ALL;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
   values: ComparableFilterLiteral[];
 };
 
 export type BetweenFilter<FIELDS extends string = string> = {
   op: FilterOperator.BETWEEN;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
   lowerBound: ComparableFilterLiteral;
   upperBound: ComparableFilterLiteral;
 };
@@ -416,7 +410,7 @@ export type FieldPresenceFilter<FIELDS extends string = string> = {
     | FilterOperator.IS_NOT_NULL
     | FilterOperator.EXISTS
     | FilterOperator.NOT_EXISTS;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
 };
 
 export type DeletionFilter = {
@@ -429,19 +423,19 @@ export type ElementMatchFilter<
   ELEMENT_FIELDS extends string = string,
 > = {
   op: FilterOperator.ELEMENT_MATCH;
-  field: LogicalField<FIELDS>;
+  field: QueryField<FIELDS>;
   predicate: ElementFilterExpression<ELEMENT_FIELDS>;
 };
 
 export type SearchFilter<FIELDS extends string = string> = {
   op: FilterOperator.SEARCH;
   query: string;
-  fields?: LogicalField<FIELDS>[];
+  fields?: QueryField<FIELDS>[];
   mode?: SearchMode;
 };
 
 export interface SearchFilterOptions<FIELDS extends string = string> {
-  fields?: readonly LogicalField<FIELDS>[];
+  fields?: readonly QueryField<FIELDS>[];
   mode?: SearchMode;
 }
 
@@ -466,20 +460,20 @@ export type CalendarFilter<FIELDS extends string = string> =
       | FilterOperator.LAST_YEAR
       | FilterOperator.THIS_YEAR
       | FilterOperator.NEXT_YEAR;
-    field: LogicalField<FIELDS>;
+    field: QueryField<FIELDS>;
   };
 
 export type BeforeTodayFilter<FIELDS extends string = string> =
   RelativeTimeFilterOptions & {
     op: FilterOperator.BEFORE_TODAY;
-    field: LogicalField<FIELDS>;
+    field: QueryField<FIELDS>;
     time: string;
   };
 
 export type DaysFilter<FIELDS extends string = string> =
   RelativeTimeFilterOptions & {
     op: FilterOperator.RECENT_DAYS | FilterOperator.EARLIER_DAYS;
-    field: LogicalField<FIELDS>;
+    field: QueryField<FIELDS>;
     days: number;
   };
 
@@ -636,8 +630,8 @@ export const filter = {
   ): EqualityFilter<FIELDS> {
     return {
       op: FilterOperator.EQ,
-      field: logicalField(field),
-      value: equalityFilterValue(value),
+      field: queryField(field),
+      value: filterLiteral(value, true),
     };
   },
   ne<FIELDS extends string>(
@@ -646,8 +640,8 @@ export const filter = {
   ): EqualityFilter<FIELDS> {
     return {
       op: FilterOperator.NE,
-      field: logicalField(field),
-      value: equalityFilterValue(value),
+      field: queryField(field),
+      value: filterLiteral(value, true),
     };
   },
   gt<FIELDS extends string>(
@@ -656,7 +650,7 @@ export const filter = {
   ): ComparisonFilter<FIELDS> {
     return {
       op: FilterOperator.GT,
-      field: logicalField(field),
+      field: queryField(field),
       value: filterLiteral(value, false),
     };
   },
@@ -666,7 +660,7 @@ export const filter = {
   ): ComparisonFilter<FIELDS> {
     return {
       op: FilterOperator.GTE,
-      field: logicalField(field),
+      field: queryField(field),
       value: filterLiteral(value, false),
     };
   },
@@ -676,7 +670,7 @@ export const filter = {
   ): ComparisonFilter<FIELDS> {
     return {
       op: FilterOperator.LT,
-      field: logicalField(field),
+      field: queryField(field),
       value: filterLiteral(value, false),
     };
   },
@@ -686,7 +680,7 @@ export const filter = {
   ): ComparisonFilter<FIELDS> {
     return {
       op: FilterOperator.LTE,
-      field: logicalField(field),
+      field: queryField(field),
       value: filterLiteral(value, false),
     };
   },
@@ -698,7 +692,7 @@ export const filter = {
     validateStringComparison(stringComparison);
     return {
       op: FilterOperator.CONTAINS,
-      field: logicalField(field),
+      field: queryField(field),
       value: requiredString('CONTAINS value', value),
       stringComparison,
     };
@@ -711,7 +705,7 @@ export const filter = {
     validateStringComparison(stringComparison);
     return {
       op: FilterOperator.STARTS_WITH,
-      field: logicalField(field),
+      field: queryField(field),
       value: requiredString('STARTS_WITH value', value),
       stringComparison,
     };
@@ -724,7 +718,7 @@ export const filter = {
     validateStringComparison(stringComparison);
     return {
       op: FilterOperator.ENDS_WITH,
-      field: logicalField(field),
+      field: queryField(field),
       value: requiredString('ENDS_WITH value', value),
       stringComparison,
     };
@@ -737,7 +731,7 @@ export const filter = {
     values.forEach(value => filterLiteral(value, false));
     return {
       op: FilterOperator.IN,
-      field: logicalField(field),
+      field: queryField(field),
       values: [...values],
     };
   },
@@ -749,7 +743,7 @@ export const filter = {
     values.forEach(value => filterLiteral(value, false));
     return {
       op: FilterOperator.NOT_IN,
-      field: logicalField(field),
+      field: queryField(field),
       values: [...values],
     };
   },
@@ -761,7 +755,7 @@ export const filter = {
     values.forEach(value => filterLiteral(value, false));
     return {
       op: FilterOperator.CONTAINS_ALL,
-      field: logicalField(field),
+      field: queryField(field),
       values: [...values],
     };
   },
@@ -772,38 +766,38 @@ export const filter = {
   ): BetweenFilter<FIELDS> {
     return {
       op: FilterOperator.BETWEEN,
-      field: logicalField(field),
+      field: queryField(field),
       lowerBound: filterLiteral(lowerBound, false),
       upperBound: filterLiteral(upperBound, false),
     };
   },
   isEmpty<FIELDS extends string>(field: FIELDS): FieldPresenceFilter<FIELDS> {
-    return { op: FilterOperator.IS_EMPTY, field: logicalField(field) };
+    return { op: FilterOperator.IS_EMPTY, field: queryField(field) };
   },
   isEmptyString<FIELDS extends string>(
     field: FIELDS,
   ): FieldPresenceFilter<FIELDS> {
-    return { op: FilterOperator.IS_EMPTY_STRING, field: logicalField(field) };
+    return { op: FilterOperator.IS_EMPTY_STRING, field: queryField(field) };
   },
   isNotEmptyString<FIELDS extends string>(
     field: FIELDS,
   ): FieldPresenceFilter<FIELDS> {
     return {
       op: FilterOperator.IS_NOT_EMPTY_STRING,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   isNull<FIELDS extends string>(field: FIELDS): FieldPresenceFilter<FIELDS> {
-    return { op: FilterOperator.IS_NULL, field: logicalField(field) };
+    return { op: FilterOperator.IS_NULL, field: queryField(field) };
   },
   isNotNull<FIELDS extends string>(field: FIELDS): FieldPresenceFilter<FIELDS> {
-    return { op: FilterOperator.IS_NOT_NULL, field: logicalField(field) };
+    return { op: FilterOperator.IS_NOT_NULL, field: queryField(field) };
   },
   exists<FIELDS extends string>(field: FIELDS): FieldPresenceFilter<FIELDS> {
-    return { op: FilterOperator.EXISTS, field: logicalField(field) };
+    return { op: FilterOperator.EXISTS, field: queryField(field) };
   },
   notExists<FIELDS extends string>(field: FIELDS): FieldPresenceFilter<FIELDS> {
-    return { op: FilterOperator.NOT_EXISTS, field: logicalField(field) };
+    return { op: FilterOperator.NOT_EXISTS, field: queryField(field) };
   },
   deletion(state: DeletionState): DeletionFilter {
     if (
@@ -822,7 +816,7 @@ export const filter = {
     validateElementPredicate(predicate);
     return {
       op: FilterOperator.ELEMENT_MATCH,
-      field: logicalField(field),
+      field: queryField(field),
       predicate,
     };
   },
@@ -849,7 +843,7 @@ export const filter = {
       op: FilterOperator.SEARCH,
       query,
       mode,
-      fields: fields.map(logicalField),
+      fields: fields.map(queryField),
     };
   },
   today<FIELDS extends string>(
@@ -859,7 +853,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.TODAY,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   beforeToday<FIELDS extends string>(
@@ -873,7 +867,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.BEFORE_TODAY,
-      field: logicalField(field),
+      field: queryField(field),
       time,
     };
   },
@@ -884,7 +878,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.TOMORROW,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   thisWeek<FIELDS extends string>(
@@ -894,7 +888,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.THIS_WEEK,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   nextWeek<FIELDS extends string>(
@@ -904,7 +898,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.NEXT_WEEK,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   lastWeek<FIELDS extends string>(
@@ -914,7 +908,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.LAST_WEEK,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   thisMonth<FIELDS extends string>(
@@ -924,7 +918,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.THIS_MONTH,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   lastMonth<FIELDS extends string>(
@@ -934,7 +928,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.LAST_MONTH,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   yesterday<FIELDS extends string>(
@@ -944,7 +938,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.YESTERDAY,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   nextMonth<FIELDS extends string>(
@@ -954,7 +948,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.NEXT_MONTH,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   lastYear<FIELDS extends string>(
@@ -964,7 +958,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.LAST_YEAR,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   thisYear<FIELDS extends string>(
@@ -974,7 +968,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.THIS_YEAR,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   nextYear<FIELDS extends string>(
@@ -984,7 +978,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.NEXT_YEAR,
-      field: logicalField(field),
+      field: queryField(field),
     };
   },
   recentDays<FIELDS extends string>(
@@ -996,7 +990,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.RECENT_DAYS,
-      field: logicalField(field),
+      field: queryField(field),
       days,
     };
   },
@@ -1009,7 +1003,7 @@ export const filter = {
     return {
       ...validateRelativeTimeOptions(options),
       op: FilterOperator.EARLIER_DAYS,
-      field: logicalField(field),
+      field: queryField(field),
       days,
     };
   },

--- a/packages/wow/test/query/filter.test.ts
+++ b/packages/wow/test/query/filter.test.ts
@@ -20,10 +20,31 @@ import {
   TimeUnit,
   type ElementFilterExpression,
   type MetadataFilter,
+  type QueryField,
 } from '../../src';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 describe('filter', () => {
+  it('exposes QueryField as the field-path type', () => {
+    expectTypeOf<QueryField<'state.status'>>().toEqualTypeOf<'state.status'>();
+  });
+
+  it('types equality filters with scalar values only', () => {
+    const assertCanonicalEqualityValues = () => {
+      // @ts-expect-error Canonical Wow equality filters do not accept arrays.
+      filter.eq('status', ['PAID']);
+      // @ts-expect-error Canonical Wow equality filters do not accept arrays.
+      filter.ne('status', ['PAID']);
+    };
+    expectTypeOf(assertCanonicalEqualityValues).toBeFunction();
+  });
+
+  it('uses QueryField terminology in validation errors', () => {
+    expect(() => filter.eq('bad field', 'value')).toThrow(
+      'Query field is invalid: [bad field].',
+    );
+  });
+
   it('builds the Wow FilterExpression wire shape', () => {
     expect(
       filter.and([
@@ -230,22 +251,31 @@ describe('filter', () => {
     expect(create).toThrow(message);
   });
 
-  it('supports Kotlin equality values and logical fields', () => {
-    expect(filter.eq('@metadata.tags', ['wow', null, 1, true])).toEqual({
+  it('supports scalar equality values and query fields', () => {
+    expect(filter.eq('@metadata.tags', 'wow')).toEqual({
       op: FilterOperator.EQ,
       field: '@metadata.tags',
-      value: ['wow', null, 1, true],
+      value: 'wow',
     });
     expect(filter.eq('state.@metadata.tags', 'wow')).toEqual({
       op: FilterOperator.EQ,
       field: 'state.@metadata.tags',
       value: 'wow',
     });
-    expect(filter.ne('state.status', ['CANCELLED', null])).toEqual({
+    expect(filter.ne('state.status', 'CANCELLED')).toEqual({
       op: FilterOperator.NE,
       field: 'state.status',
-      value: ['CANCELLED', null],
+      value: 'CANCELLED',
     });
+  });
+
+  it('rejects array equality values unsupported by canonical Wow REST', () => {
+    expect(() => Reflect.apply(filter.eq, null, ['status', ['PAID']])).toThrow(
+      'Filter value must be a JSON scalar.',
+    );
+    expect(() => Reflect.apply(filter.ne, null, ['status', ['PAID']])).toThrow(
+      'Filter value must be a JSON scalar.',
+    );
   });
 
   it.each<{
@@ -709,9 +739,9 @@ describe('filter', () => {
       'non-string aggregate IDs value',
       () => Reflect.apply(filter.aggregateIds, null, [['order-1', 2]]),
     ],
-    ['invalid logical field', () => filter.eq('bad field', 'value')],
+    ['invalid query field', () => filter.eq('bad field', 'value')],
     [
-      'non-string logical field',
+      'non-string query field',
       () => Reflect.apply(filter.eq, null, [1, 'value']),
     ],
     [

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -154,6 +154,7 @@ import {
   type PagedQuery,
   type SingleQuery,
   type FilterExpression,
+  type QueryField,
   type ElementFilterExpression,
   type MetadataFilter,
   type EqualityFilterValue,
@@ -634,8 +635,8 @@ await snapshotClient.list({ filter: expression, limit: 10 });
 const query = listQuery({ filter: expression });
 ```
 
-`listQuery({ filter })` defaults `limit` to `0` (unlimited), matching Wow
-8.11. Legacy `listQuery({ condition })` keeps the previous default page size.
+`listQuery({ filter })` defaults `limit` to `0` (unlimited), matching current
+Wow V9. Legacy `listQuery({ condition })` keeps the previous default page size.
 
 Available builders:
 
@@ -661,8 +662,8 @@ filter.notIn('state.status', ['CANCELLED']);
 filter.containsAll('state.tags', ['wow', 'cqrs']);
 ```
 
-`eq` and `ne` accept a JSON scalar or an array of JSON scalars. Logical field
-segments may start with `@`.
+`eq` and `ne` accept a JSON scalar or `null`; use `isIn`/`notIn` for multiple
+values. Query field segments may start with `@`.
 
 `isEmptyString` matches exactly `""`. `isNotEmptyString` requires the field to
 exist, be non-null, and differ from `""`. Whitespace-only strings are not empty.

--- a/wiki/reference/wow.md
+++ b/wiki/reference/wow.md
@@ -378,7 +378,8 @@ Rules that commonly affect application code:
 
 - `and`, `or`, `nor`, `ids`, `aggregateIds`, `isIn`, `notIn`, and
   `containsAll` require one non-empty readonly array.
-- `eq` and `ne` accept JSON scalars, `null`, or an array of JSON scalars.
+- `eq` and `ne` accept a JSON scalar or `null`; use `isIn`/`notIn` for multiple
+  values.
 - Comparison and collection values cannot be `null` or non-finite numbers.
 - `isEmptyString` matches exactly `""`; `isNotEmptyString` requires the field
   to exist, be non-null, and differ from `""`. Whitespace-only strings are not

--- a/wiki/zh/reference/wow.md
+++ b/wiki/zh/reference/wow.md
@@ -368,7 +368,7 @@ const cartFilter = filter.and<CartFields>([
 
 - `and`、`or`、`nor`、`ids`、`aggregateIds`、`isIn`、`notIn` 和
   `containsAll` 接收一个非空 Readonly Array。
-- `eq` 和 `ne` 接收 JSON Scalar、`null` 或 JSON Scalar Array。
+- `eq` 和 `ne` 接收 JSON Scalar 或 `null`；多值匹配请使用 `isIn`/`notIn`。
 - 比较和集合值不能是 `null` 或非有限数字。
 - `isEmptyString` 只匹配 `""`；`isNotEmptyString` 要求 Field 存在、非
   `null` 且不等于 `""`。仅含空白的字符串不视为空字符串。


### PR DESCRIPTION
## Summary

Align the Fetcher Wow query API with Wow v9.0.8.

## Changes

- Rename the canonical field-path type to QueryField across filters and aggregations.
- Restrict eq and ne to JSON scalar values or null, matching canonical Wow REST.
- Keep deprecated LogicalField and Condition/Operator compatibility APIs.
- Update focused tests, the Wow skill API reference, and the English and Chinese Wiki pages.

## Testing

Passed:

- pnpm --filter @ahoo-wang/fetcher-wow test — 353 tests
- pnpm --filter @ahoo-wang/fetcher-wow build
- pnpm test:unit
- TypeScript type check and ESLint

The full pnpm test command also runs the integration workspace. Those tests require the Wow example server on localhost:8080 and were blocked by ECONNREFUSED because the service was not running.

## Type of change

- [x] Bug fix
- [x] Documentation update

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added for the changed behavior
- [x] Package and unit tests pass locally
- [x] Documentation updated

