### PR TITLE
fix: restore CommonJS entries and align version 5.0.0 dependencies

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-integration-test",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "description": "Integration Test Fetcher",
   "keywords": [

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-integration-test",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "private": true,
   "description": "Integration Test Fetcher",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcher",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "A modern HTTP client library based on fetch API",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetcher",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A modern HTTP client library based on fetch API",
   "private": true,
   "type": "module",

--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-cosec",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Enterprise-grade CoSec authentication integration for the Fetcher HTTP client with comprehensive security features including automatic token management, device tracking, and request attribution.",
   "keywords": [
     "fetch",
@@ -51,9 +51,9 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-eventbus": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-storage": "workspace:^4.0.0"
+    "@ahoo-wang/fetcher": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-eventbus": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-storage": "workspace:^5.0.0"
   },
   "dependencies": {
     "nanoid": "catalog:"

--- a/packages/cosec/package.json
+++ b/packages/cosec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-cosec",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Enterprise-grade CoSec authentication integration for the Fetcher HTTP client with comprehensive security features including automatic token management, device tracking, and request attribution.",
   "keywords": [
     "fetch",

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-decorator",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "TypeScript decorators for clean, declarative API service definitions with Fetcher HTTP client. Enables automatic parameter binding, method mapping, and type-safe API interactions.",
   "keywords": [
     "fetch",
@@ -51,7 +51,7 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0"
+    "@ahoo-wang/fetcher": "workspace:^5.0.0"
   },
   "dependencies": {
     "reflect-metadata": "catalog:"

--- a/packages/decorator/package.json
+++ b/packages/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-decorator",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "TypeScript decorators for clean, declarative API service definitions with Fetcher HTTP client. Enables automatic parameter binding, method mapping, and type-safe API interactions.",
   "keywords": [
     "fetch",
@@ -28,14 +28,14 @@
   "engines": {
     "node": ">=18.20.8"
   },
-  "main": "./dist/index.umd.js",
+  "main": "./dist/index.umd.cjs",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "require": "./dist/index.umd.cjs"
     }
   },
   "files": [

--- a/packages/decorator/vite.config.ts
+++ b/packages/decorator/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     lib: {
       entry: 'src/index.ts',
       name: 'FetcherDecorator',
-      fileName: format => `index.${format}.js`,
+      fileName: format =>
+        format === 'es' ? 'index.es.js' : `index.${format}.cjs`,
     },
     rollupOptions: {
       external: ['@ahoo-wang/fetcher', 'reflect-metadata'],

--- a/packages/eventbus/package.json
+++ b/packages/eventbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventbus",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "A TypeScript event bus library with serial, parallel, and broadcast implementations",
   "keywords": [
     "eventbus",
@@ -49,7 +49,7 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0"
+    "@ahoo-wang/fetcher": "workspace:^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/packages/eventbus/package.json
+++ b/packages/eventbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventbus",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A TypeScript event bus library with serial, parallel, and broadcast implementations",
   "keywords": [
     "eventbus",

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventstream",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Server-Sent Events (SSE) support for Fetcher HTTP client with native LLM streaming API support. Enables real-time data streaming and token-by-token LLM response handling.",
   "keywords": [
     "fetch",
@@ -50,7 +50,7 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0"
+    "@ahoo-wang/fetcher": "workspace:^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/packages/eventstream/package.json
+++ b/packages/eventstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-eventstream",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Server-Sent Events (SSE) support for Fetcher HTTP client with native LLM streaming API support. Enables real-time data streaming and token-by-token LLM response handling.",
   "keywords": [
     "fetch",
@@ -28,14 +28,14 @@
   "engines": {
     "node": ">=18.20.8"
   },
-  "main": "./dist/index.umd.js",
+  "main": "./dist/index.umd.cjs",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "require": "./dist/index.umd.cjs"
     }
   },
   "files": [

--- a/packages/eventstream/vite.config.ts
+++ b/packages/eventstream/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
     lib: {
       entry: 'src/index.ts',
       name: 'FetcherEventStream',
-      fileName: format => `index.${format}.js`,
+      fileName: format =>
+        format === 'es' ? 'index.es.js' : `index.${format}.cjs`,
     },
     rollupOptions: {
       external: ['@ahoo-wang/fetcher'],

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Fetcher is not just another HTTP client—it's a complete ecosystem designed for modern web development with native LLM\nstreaming API support. Built on the native Fetch API, Fetcher provides an Axios-like experience with powerful features\nwhile maintaining an incredibly small footprint.",
   "keywords": [
     "fetch",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Fetcher is not just another HTTP client—it's a complete ecosystem designed for modern web development with native LLM\nstreaming API support. Built on the native Fetch API, Fetcher provides an Axios-like experience with powerful features\nwhile maintaining an incredibly small footprint.",
   "keywords": [
     "fetch",
@@ -31,14 +31,14 @@
   "engines": {
     "node": ">=18.20.8"
   },
-  "main": "./dist/index.umd.js",
+  "main": "./dist/index.umd.cjs",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "require": "./dist/index.umd.cjs"
     }
   },
   "files": [

--- a/packages/fetcher/vite.config.ts
+++ b/packages/fetcher/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
     lib: {
       entry: 'src/index.ts',
       name: 'Fetcher',
-      fileName: format => `index.${format}.js`,
+      fileName: format =>
+        format === 'es' ? 'index.es.js' : `index.${format}.cjs`,
     },
     rollupOptions: {
       external: [],

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-generator",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "A powerful TypeScript code generation tool that automatically generates type-safe API client code based on OpenAPI specifications. It is designed for general use cases and is also deeply optimized for the [Wow](https://github.com/Ahoo-Wang/Wow) Domain-Driven Design framework, providing native support for the CQRS architectural pattern.",
   "keywords": [
     "fetch",
@@ -59,11 +59,11 @@
     "generate": "node dist/cli.js generate -i test/demo.spec.json -o test-output -t tsconfig.json"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-eventstream": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-decorator": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-openapi": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-wow": "workspace:^4.0.0"
+    "@ahoo-wang/fetcher": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-eventstream": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-decorator": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-openapi": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-wow": "workspace:^5.0.0"
   },
   "dependencies": {
     "ts-morph": "catalog:",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-generator",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A powerful TypeScript code generation tool that automatically generates type-safe API client code based on OpenAPI specifications. It is designed for general use cases and is also deeply optimized for the [Wow](https://github.com/Ahoo-Wang/Wow) Domain-Driven Design framework, providing native support for the CQRS architectural pattern.",
   "keywords": [
     "fetch",
@@ -30,8 +30,8 @@
   "engines": {
     "node": ">=18.20.8"
   },
-  "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
     "fetcher-generator": "./dist/cli.js"
@@ -39,8 +39,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/packages/generator/test/packageEntries.test.ts
+++ b/packages/generator/test/packageEntries.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+describe('review regressions', () => {
+  it.each(['commonjs', 'module'] as const)(
+    'loads the published generator dependency chain through %s',
+    mode => {
+      const script = `
+        (async () => {
+          const load = ${mode === 'commonjs' ? 'require' : 'specifier => import(specifier)'};
+          const assertModule = await load('node:assert/strict');
+          const assert = assertModule.default ?? assertModule;
+          const core = await load('@ahoo-wang/fetcher');
+          assert.equal(typeof core.Fetcher, 'function');
+          await load('@ahoo-wang/fetcher-eventstream');
+          const response = new Response('data: ready\\n\\n', {
+            headers: { 'Content-Type': 'text/event-stream' },
+          });
+          const reader = response.requiredEventStream().getReader();
+          assert.equal((await reader.read()).value.data, 'ready');
+          await reader.cancel();
+          const decorator = await load('@ahoo-wang/fetcher-decorator');
+          assert.equal(typeof decorator.api, 'function');
+          const wow = await load('@ahoo-wang/fetcher-wow');
+          assert.equal(wow.getPropertyValue({ nested: { value: 42 } }, ['nested', 'value']), 42);
+          for (const locale of ['en_US', 'zh_CN']) {
+            const loaded = await load('@ahoo-wang/fetcher-wow/query/locale/' + locale);
+            assert.equal(typeof loaded[locale].EQ, 'string');
+          }
+          const generator = await load('@ahoo-wang/fetcher-generator');
+          assert.equal(typeof generator.CodeGenerator, 'function');
+          console.log('exports-ok');
+        })().catch(error => { console.error(error); process.exitCode = 1; });
+      `;
+      expect(
+        execFileSync(process.execPath, [`--input-type=${mode}`, '-e', script], {
+          cwd: fileURLToPath(new URL('..', import.meta.url)),
+          encoding: 'utf8',
+          timeout: 10000,
+        }).trim(),
+      ).toBe('exports-ok');
+    },
+  );
+});

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-openai",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Type-safe OpenAI API client for Fetcher ecosystem. Provides seamless integration with OpenAI's Chat Completions API, supporting both streaming and non-streaming responses with full TypeScript support.",
   "keywords": [
     "openai",

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-openai",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Type-safe OpenAI API client for Fetcher ecosystem. Provides seamless integration with OpenAI's Chat Completions API, supporting both streaming and non-streaming responses with full TypeScript support.",
   "keywords": [
     "openai",
@@ -56,9 +56,9 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-eventstream": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-decorator": "workspace:^4.0.0"
+    "@ahoo-wang/fetcher": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-eventstream": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-decorator": "workspace:^5.0.0"
   },
   "devDependencies": {
     "@ahoo-wang/fetcher-storage": "workspace:^",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-openapi",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "OpenAPI Specification TypeScript types for Fetcher - A modern, ultra-lightweight HTTP client for browsers and Node.js. Provides complete TypeScript support with type inference for OpenAPI 3.x schemas.",
   "keywords": [
     "fetch",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-openapi",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "OpenAPI Specification TypeScript types for Fetcher - A modern, ultra-lightweight HTTP client for browsers and Node.js. Provides complete TypeScript support with type inference for OpenAPI 3.x schemas.",
   "keywords": [
     "fetch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-react",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "React integration for Fetcher HTTP client. Provides React Hooks and components for seamless data fetching with automatic re-rendering and loading states.",
   "keywords": [
     "fetch",
@@ -56,12 +56,12 @@
     "immer": "catalog:"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-eventstream": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-eventbus": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-storage": "workspace:^4.0.0",
+    "@ahoo-wang/fetcher": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-eventstream": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-eventbus": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-storage": "workspace:^5.0.0",
     "@ahoo-wang/fetcher-wow": "workspace:^",
-    "@ahoo-wang/fetcher-cosec": "workspace:^4.0.0",
+    "@ahoo-wang/fetcher-cosec": "workspace:^5.0.0",
     "react": "catalog:",
     "react-dom": "catalog:"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-react",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "React integration for Fetcher HTTP client. Provides React Hooks and components for seamless data fetching with automatic re-rendering and loading states.",
   "keywords": [
     "fetch",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-storage",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "A lightweight, cross-environment storage library with key-based storage and automatic environment detection. Provides consistent API for browser localStorage and in-memory storage with change notifications.",
   "keywords": [
     "storage",
@@ -53,7 +53,7 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher-eventbus": "workspace:^4.0.0"
+    "@ahoo-wang/fetcher-eventbus": "workspace:^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-storage",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A lightweight, cross-environment storage library with key-based storage and automatic environment detection. Provides consistent API for browser localStorage and in-memory storage with change notifications.",
   "keywords": [
     "storage",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-viewer",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A comprehensive React component library for API documentation viewing and data filtering, built on top of Ant Design and the Fetcher ecosystem. Provides reusable UI components for building rich data-driven applications with advanced filtering capabilities and remote data selection.",
   "keywords": [
     "react",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-viewer",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "A comprehensive React component library for API documentation viewing and data filtering, built on top of Ant Design and the Fetcher ecosystem. Provides reusable UI components for building rich data-driven applications with advanced filtering capabilities and remote data selection.",
   "keywords": [
     "react",
@@ -52,14 +52,14 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-decorator": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-eventbus": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-eventstream": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-openapi": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-react": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-storage": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-wow": "workspace:^4.0.0",
+    "@ahoo-wang/fetcher": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-decorator": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-eventbus": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-eventstream": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-openapi": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-react": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-storage": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-wow": "workspace:^5.0.0",
     "@ant-design/icons": "catalog:",
     "antd": "catalog:",
     "dayjs": "catalog:",

--- a/packages/wow/package.json
+++ b/packages/wow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-wow",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Support for Wow(https://github.com/Ahoo-Wang/Wow) in Fetcher",
   "keywords": [
     "fetch",
@@ -27,24 +27,24 @@
   "engines": {
     "node": ">=18.20.8"
   },
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.es.js",
-      "require": "./dist/index.cjs.js"
+      "require": "./dist/index.cjs"
     },
     "./query/locale/zh_CN": {
       "types": "./dist/query/locale/zh_CN.d.ts",
       "import": "./dist/query/locale/zh_CN.es.js",
-      "require": "./dist/query/locale/zh_CN.cjs.js"
+      "require": "./dist/query/locale/zh_CN.cjs"
     },
     "./query/locale/en_US": {
       "types": "./dist/query/locale/en_US.d.ts",
       "import": "./dist/query/locale/en_US.es.js",
-      "require": "./dist/query/locale/en_US.cjs.js"
+      "require": "./dist/query/locale/en_US.cjs"
     }
   },
   "files": [

--- a/packages/wow/package.json
+++ b/packages/wow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahoo-wang/fetcher-wow",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Support for Wow(https://github.com/Ahoo-Wang/Wow) in Fetcher",
   "keywords": [
     "fetch",
@@ -61,9 +61,9 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "peerDependencies": {
-    "@ahoo-wang/fetcher": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-eventstream": "workspace:^4.0.0",
-    "@ahoo-wang/fetcher-decorator": "workspace:^4.0.0"
+    "@ahoo-wang/fetcher": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-eventstream": "workspace:^5.0.0",
+    "@ahoo-wang/fetcher-decorator": "workspace:^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/packages/wow/vite.config.ts
+++ b/packages/wow/vite.config.ts
@@ -25,7 +25,9 @@ export default defineConfig({
       },
       name: 'FetcherWow',
       fileName: (format, entryName) => {
-        return `${entryName}.${format}.js`;
+        return format === 'es'
+          ? `${entryName}.es.js`
+          : `${entryName}.${format}`;
       },
     },
     rollupOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,13 +319,13 @@ importers:
   packages/cosec:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
       '@ahoo-wang/fetcher-eventbus':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventbus
       '@ahoo-wang/fetcher-storage':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../storage
       nanoid:
         specifier: 'catalog:'
@@ -371,7 +371,7 @@ importers:
   packages/decorator:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
       reflect-metadata:
         specifier: 'catalog:'
@@ -420,7 +420,7 @@ importers:
   packages/eventbus:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
     devDependencies:
       '@eslint/js':
@@ -463,7 +463,7 @@ importers:
   packages/eventstream:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
     devDependencies:
       '@eslint/js':
@@ -548,19 +548,19 @@ importers:
   packages/generator:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
       '@ahoo-wang/fetcher-decorator':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../decorator
       '@ahoo-wang/fetcher-eventstream':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventstream
       '@ahoo-wang/fetcher-openapi':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../openapi
       '@ahoo-wang/fetcher-wow':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../wow
       commander:
         specifier: 'catalog:'
@@ -615,13 +615,13 @@ importers:
   packages/openai:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
       '@ahoo-wang/fetcher-decorator':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../decorator
       '@ahoo-wang/fetcher-eventstream':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventstream
     devDependencies:
       '@ahoo-wang/fetcher-eventbus':
@@ -715,19 +715,19 @@ importers:
   packages/react:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
       '@ahoo-wang/fetcher-cosec':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../cosec
       '@ahoo-wang/fetcher-eventbus':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventbus
       '@ahoo-wang/fetcher-eventstream':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventstream
       '@ahoo-wang/fetcher-storage':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../storage
       '@ahoo-wang/fetcher-wow':
         specifier: workspace:^
@@ -815,7 +815,7 @@ importers:
   packages/storage:
     dependencies:
       '@ahoo-wang/fetcher-eventbus':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventbus
     devDependencies:
       '@eslint/js':
@@ -858,28 +858,28 @@ importers:
   packages/viewer:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
       '@ahoo-wang/fetcher-decorator':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../decorator
       '@ahoo-wang/fetcher-eventbus':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventbus
       '@ahoo-wang/fetcher-eventstream':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventstream
       '@ahoo-wang/fetcher-openapi':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../openapi
       '@ahoo-wang/fetcher-react':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../react
       '@ahoo-wang/fetcher-storage':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../storage
       '@ahoo-wang/fetcher-wow':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../wow
       '@ant-design/icons':
         specifier: 'catalog:'
@@ -988,13 +988,13 @@ importers:
   packages/wow:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../fetcher
       '@ahoo-wang/fetcher-decorator':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../decorator
       '@ahoo-wang/fetcher-eventstream':
-        specifier: workspace:^4.0.0
+        specifier: workspace:^5.0.0
         version: link:../eventstream
     devDependencies:
       '@eslint/js':

--- a/skills/fetcher-decorator-service/references/api.md
+++ b/skills/fetcher-decorator-service/references/api.md
@@ -4,6 +4,7 @@
 
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
+- [CommonJS](#commonjs)
 - [Core Concepts](#core-concepts)
   - [1. Service Definition with `@api()`](#1-service-definition-with-api)
   - [2. HTTP Method Decorators](#2-http-method-decorators)
@@ -34,6 +35,23 @@ import 'reflect-metadata';
 ```bash
 pnpm add @ahoo-wang/fetcher-decorator
 ```
+
+## CommonJS
+
+The package supports ESM and CommonJS. `require('@ahoo-wang/fetcher-decorator')`
+uses `dist/index.umd.cjs`; ESM imports use `dist/index.es.js`. Save this example
+as a `.cjs` file and run it with Node:
+
+```javascript
+const { api, EndpointReturnType } = require('@ahoo-wang/fetcher-decorator');
+
+class UserService {}
+api('/users', { returnType: EndpointReturnType.RESULT })(UserService);
+console.log(new UserService() instanceof UserService); // true
+```
+
+`api` and `EndpointReturnType` are runtime exports. Interfaces such as
+`ApiMetadata` remain TypeScript-only and use `import type`.
 
 ## Core Concepts
 

--- a/skills/fetcher-integration/references/api.md
+++ b/skills/fetcher-integration/references/api.md
@@ -35,6 +35,9 @@ The Fetcher HTTP client provides an Axios-like API built on the native Fetch API
 pnpm add @ahoo-wang/fetcher
 ```
 
+The core package supports ESM imports and CommonJS
+`const { Fetcher } = require('@ahoo-wang/fetcher')` through its package entry.
+
 ## 1. Setting Up NamedFetcher
 
 ### Basic Setup

--- a/skills/fetcher-llm-streaming/references/api.md
+++ b/skills/fetcher-llm-streaming/references/api.md
@@ -14,6 +14,7 @@
 - [Result Extractors (for Decorator Pattern)](#result-extractors-for-decorator-pattern)
 - [ReadableStreamAsyncIterable](#readablestreamasynciterable)
 - [Installation](#installation)
+- [CommonJS](#commonjs)
 - [Related Packages](#related-packages)
 
 Implement streaming features for LLM APIs using Fetcher's eventstream package.
@@ -185,6 +186,36 @@ Internal wrapper enabling `for await...of` on ReadableStream. Polyfilled automat
 ```bash
 pnpm add @ahoo-wang/fetcher-eventstream @ahoo-wang/fetcher-openai
 ```
+
+## CommonJS
+
+`@ahoo-wang/fetcher-eventstream` supports ESM and CommonJS. `require()` uses
+`dist/index.umd.cjs`, while ESM imports use `dist/index.es.js`. Requiring the
+package also installs its Response prototype extensions. This `.cjs` example
+uses runtime conversion functions and a local SSE response:
+
+```javascript
+const {
+  toServerSentEventStream,
+  toJsonServerSentEventStream,
+} = require('@ahoo-wang/fetcher-eventstream');
+
+async function main() {
+  const response = new Response('data: {"text":"Hello"}\n\n', {
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+  const events = toJsonServerSentEventStream(toServerSentEventStream(response));
+  for await (const event of events) console.log(event.data.text); // Hello
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});
+```
+
+Stream interfaces such as `ServerSentEvent` are TypeScript-only; they are not
+values to destructure from `require()`.
 
 ## Related Packages
 

--- a/skills/fetcher-openapi-generator/references/api.md
+++ b/skills/fetcher-openapi-generator/references/api.md
@@ -56,6 +56,9 @@ npx fetcher-generator generate -i ./openapi.yaml -o ./src/generated -t ./tsconfi
 
 ## Programmatic API (CodeGenerator)
 
+The published package supports both ESM imports and CommonJS
+`const { CodeGenerator } = require('@ahoo-wang/fetcher-generator')`.
+
 `logger` is a required option (`Logger` interface: `info`/`success`/`error`/`progress`/`progressWithCount`). The package does not export a logger implementation — provide your own:
 
 ```typescript

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -4,6 +4,7 @@
 
 - [Core Concepts](#core-concepts)
 - [Package Imports](#package-imports)
+- [CommonJS](#commonjs)
 - [Constructors (All Use ApiMetadata)](#constructors-all-use-apimetadata)
 - [CommandClient<C>](#commandclientc)
   - [Setup](#setup)
@@ -179,6 +180,26 @@ import {
 ```
 
 ---
+
+## CommonJS
+
+The package supports ESM and CommonJS. `require('@ahoo-wang/fetcher-wow')`
+uses `dist/index.cjs`; ESM imports use `dist/index.es.js`. Save this runtime
+query-builder example as a `.cjs` file and run it with Node:
+
+```javascript
+const { filter, pagedQuery } = require('@ahoo-wang/fetcher-wow');
+
+const query = pagedQuery({
+  filter: filter.eq('state.status', 'PAID'),
+  pagination: { index: 1, size: 10 },
+});
+console.log(query.filter.field); // state.status
+console.log(query.pagination.size); // 10
+```
+
+`filter` and `pagedQuery` are runtime exports. Types such as `FilterExpression`
+and `PagedList` remain TypeScript-only and use `import type`.
 
 ## Constructors (All Use ApiMetadata)
 


### PR DESCRIPTION
## Description

Correct the published CommonJS/ESM entry files across the generator dependency chain and keep the workspace version aligned at 5.0.0. Native Node subprocess tests load the real package exports in both module modes.

The release version is 5.0.0 because component references and nullable active-view results change public types. All explicit internal peer ranges now require the matching 5.x packages.

Targets `main`; this is the common prerequisite for the split groups.

## Type of change

- [x] Bug fix
- [x] Documentation update
- [x] Major version preparation for public type changes

## How Has This Been Tested?

The complete workspace was rebuilt and tested on this exact branch before commit:

- `pnpm build`
- `pnpm test:unit` — 224 files, 3262 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .` — no errors
- `git diff --check`

Node.js 24.11.0, pnpm 10.34.5. The shared lockfile passes frozen validation; third-party dependency resolutions are unchanged. The TypeScript flag is command-line only. Existing lint warnings remain. Source regressions were reproduced before fixing; English/Chinese wiki changes were built where included.

## Review and CI

This PR is ready for review. A fresh GitHub Codex review and the existing CI workflows are requested for the updated head. Codacy quality-rule findings are tracked separately from executable test results; confirmed false positives are documented with source evidence.

Native GitHub stack #1418, layer 1 of 16. Keep this PR separate and squash layers in stack order. GitHub rebases the remaining layers after each partial merge; verify their new Codex reviews and CI before continuing.

Split index: #1399.
