### PR TITLE
fix(fetcher): preserve headers, URL queries and cancellation

### DIFF
--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -29,6 +29,7 @@ import type { UrlTemplateStyle } from './urlTemplateResolver';
 import type { ResultExtractorCapable } from './resultExtractor';
 import { ResultExtractors } from './resultExtractor';
 import { mergeRequestOptions } from './mergeRequest';
+import { mergeHeaders } from './requestHeaders';
 import type { ValidateStatus } from './validateStatusInterceptor';
 
 /**
@@ -171,10 +172,7 @@ export class Fetcher
    */
   resolveExchange(request: FetchRequest, options?: RequestOptions) {
     // Merge default headers and request-level headers. defensive copy
-    const mergedHeaders = {
-      ...this.headers,
-      ...request.headers,
-    };
+    const mergedHeaders = mergeHeaders(this.headers, request.headers);
     // Merge request options
     const fetchRequest: FetchRequest = {
       ...request,

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -33,3 +33,5 @@ export * from './urls';
 export * from './urlTemplateResolver';
 export * from './utils';
 export * from './validateStatusInterceptor';
+
+export * from './requestHeaders';

--- a/packages/fetcher/src/mergeRequest.ts
+++ b/packages/fetcher/src/mergeRequest.ts
@@ -14,6 +14,7 @@
 import { type FetchRequestInit } from './fetchRequest';
 import { type UrlParams } from './urlBuilder';
 import { mergeRecords } from './utils';
+import { mergeHeaders } from './requestHeaders';
 import type { RequestOptions } from './fetcher';
 import { DEFAULT_REQUEST_OPTIONS } from './fetcher';
 
@@ -67,12 +68,16 @@ export function mergeRequest(
 ): FetchRequestInit {
   // If first request is empty, return second request
   if (Object.keys(first).length === 0) {
-    return second;
+    return second.headers
+      ? { ...second, headers: mergeHeaders(second.headers) }
+      : second;
   }
 
   // If second request is empty, return first request
   if (Object.keys(second).length === 0) {
-    return first;
+    return first.headers
+      ? { ...first, headers: mergeHeaders(first.headers) }
+      : first;
   }
 
   // Merge nested objects
@@ -81,10 +86,7 @@ export function mergeRequest(
     query: mergeRecords(first.urlParams?.query, second.urlParams?.query),
   };
 
-  const headers = {
-    ...first.headers,
-    ...second.headers,
-  };
+  const headers = mergeHeaders(first.headers, second.headers);
 
   // For primitive values, second takes precedence
   const method = second.method ?? first.method;

--- a/packages/fetcher/src/requestBodyInterceptor.ts
+++ b/packages/fetcher/src/requestBodyInterceptor.ts
@@ -17,6 +17,7 @@ import {
 } from './interceptor';
 import type { FetchExchange } from './fetchExchange';
 import { CONTENT_TYPE_HEADER, ContentTypeValues } from './fetchRequest';
+import { deleteHeader, getHeader, setHeader } from './requestHeaders';
 
 /**
  * The name of the RequestBodyInterceptor.
@@ -160,9 +161,7 @@ export class RequestBodyInterceptor implements RequestInterceptor {
     }
     const headers = exchange.ensureRequestHeaders();
     if (this.isAutoAppendContentType(request.body)) {
-      if (headers[CONTENT_TYPE_HEADER]) {
-        delete headers[CONTENT_TYPE_HEADER];
-      }
+      deleteHeader(headers, CONTENT_TYPE_HEADER);
       return;
     }
     // Check if it's a supported type
@@ -174,8 +173,12 @@ export class RequestBodyInterceptor implements RequestInterceptor {
     // Also ensure Content-Type header is set to application/json
     exchange.request.body = JSON.stringify(request.body);
 
-    if (!headers[CONTENT_TYPE_HEADER]) {
-      headers[CONTENT_TYPE_HEADER] = ContentTypeValues.APPLICATION_JSON;
+    if (!getHeader(headers, CONTENT_TYPE_HEADER)) {
+      setHeader(
+        headers,
+        CONTENT_TYPE_HEADER,
+        ContentTypeValues.APPLICATION_JSON,
+      );
     }
   }
 }

--- a/packages/fetcher/src/requestHeaders.ts
+++ b/packages/fetcher/src/requestHeaders.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RequestHeaders } from './fetchRequest';
+
+/** Reads a header regardless of its spelling. The last matching key wins. */
+export function getHeader(
+  headers: RequestHeaders | undefined,
+  name: string,
+): string | undefined {
+  const lowerName = name.toLowerCase();
+  const key = Object.keys(headers ?? {})
+    .reverse()
+    .find(key => key.toLowerCase() === lowerName);
+  return key === undefined ? undefined : headers?.[key];
+}
+
+/** Removes every spelling of a header from the supplied record. */
+export function deleteHeader(headers: RequestHeaders, name: string): void {
+  const lowerName = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lowerName) {
+      delete headers[key];
+    }
+  }
+}
+
+/** Replaces a header, retaining the supplied spelling; undefined removes it. */
+export function setHeader(
+  headers: RequestHeaders,
+  name: string,
+  value: string | undefined,
+): void {
+  deleteHeader(headers, name);
+  if (value !== undefined) {
+    Object.defineProperty(headers, name, {
+      value,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+}
+
+/** Merges records with case-insensitive replacement by the last layer. */
+export function mergeHeaders(
+  ...headers: (RequestHeaders | undefined)[]
+): RequestHeaders {
+  const merged: RequestHeaders = {};
+  for (const record of headers) {
+    for (const [name, value] of Object.entries(record ?? {})) {
+      setHeader(merged, name, value);
+    }
+  }
+  return merged;
+}

--- a/packages/fetcher/src/timeout.ts
+++ b/packages/fetcher/src/timeout.ts
@@ -136,18 +136,11 @@ export async function timeoutFetch(request: FetchRequest): Promise<Response> {
     return await fetch(url, requestInit);
   }
 
-  // Create AbortController for fetch request cancellation.
-  // If the caller supplied an abortController, reuse it — UNLESS it has
-  // already been aborted (e.g. by a prior timeout on the same request during
-  // a retry). Reusing an aborted controller makes the retried fetch reject
-  // immediately instead of performing the request, so a retry after a timeout
-  // could never succeed.
+  // Caller cancellation is authoritative, including an already-aborted signal.
+  // Internal controllers are cleared below so retries can create a fresh one.
   const existingController = request.abortController;
-  const reuseExistingController =
-    existingController && !existingController.signal.aborted;
-  const controller = reuseExistingController
-    ? existingController
-    : new AbortController();
+  const reuseExistingController = existingController !== undefined;
+  const controller = existingController ?? new AbortController();
   request.abortController = controller;
   requestInit.signal = controller.signal;
 
@@ -165,12 +158,6 @@ export async function timeoutFetch(request: FetchRequest): Promise<Response> {
       }
       const error = new FetchTimeoutError(request);
       controller.abort(error);
-      // The controller and its signal were written back onto the request
-      // above. Once aborted they are permanently unusable: a retry reusing
-      // this same request object would fail immediately. Clear them so the
-      // next call builds a fresh controller.
-      request.abortController = undefined;
-      delete requestInit.signal;
       reject(error);
     }, timeout);
   });

--- a/packages/fetcher/src/urlBuilder.ts
+++ b/packages/fetcher/src/urlBuilder.ts
@@ -126,7 +126,19 @@ export class UrlBuilder implements BaseURLCapable {
     if (query) {
       const queryString = new URLSearchParams(query).toString();
       if (queryString) {
-        finalUrl += '?' + queryString;
+        const fragmentIndex = finalUrl.indexOf('#');
+        const fragment = fragmentIndex < 0 ? '' : finalUrl.slice(fragmentIndex);
+        const beforeFragment =
+          fragmentIndex < 0 ? finalUrl : finalUrl.slice(0, fragmentIndex);
+        const queryIndex = beforeFragment.indexOf('?');
+        const separator =
+          queryIndex >= 0
+            ? queryIndex === beforeFragment.length - 1 ||
+              beforeFragment.endsWith('&')
+              ? ''
+              : '&'
+            : '?';
+        finalUrl = beforeFragment + separator + queryString + fragment;
       }
     }
     return finalUrl;

--- a/packages/fetcher/test/requestRegression.test.ts
+++ b/packages/fetcher/test/requestRegression.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse, delay } from 'msw';
+import { Fetcher, ResultExtractors, mergeRequest, timeoutFetch } from '../src';
+
+const server = setupServer(
+  http.all('https://review.test/*', async ({ request }) =>
+    HttpResponse.json({
+      url: request.url,
+      headers: Object.fromEntries(request.headers),
+      body: await request.text(),
+    }),
+  ),
+);
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterAll(() => server.close());
+const options = { resultExtractor: ResultExtractors.Json };
+
+describe('request regressions', () => {
+  it('overrides headers regardless of case across default and request layers', async () => {
+    const fetcher = new Fetcher({
+      baseURL: 'https://review.test',
+      headers: {
+        Authorization: 'Bearer old',
+        'Content-Type': 'application/json',
+      },
+    });
+    const response = await fetcher.post<any>(
+      '/headers',
+      {
+        headers: { authorization: 'Bearer new', 'content-type': 'text/plain' },
+        body: 'hello',
+      },
+      options,
+    );
+    expect(response.headers.authorization).toBe('Bearer new');
+    expect(response.headers['content-type']).toBe('text/plain');
+  });
+
+  it('merges request headers with case-insensitive replacement', () => {
+    const result = mergeRequest(
+      { headers: { Authorization: 'old' } },
+      { headers: { authorization: 'new' } },
+    );
+    expect(
+      new Headers(result.headers as Record<string, string>).get(
+        'authorization',
+      ),
+    ).toBe('new');
+  });
+
+  it('preserves a lowercase JSON content type and removes it for FormData', async () => {
+    const fetcher = new Fetcher({
+      baseURL: 'https://review.test',
+      headers: { 'content-type': 'application/problem+json' },
+    });
+    const json = await fetcher.post<any>(
+      '/headers',
+      { body: { value: 1 } },
+      options,
+    );
+    expect(json.headers['content-type']).toBe('application/problem+json');
+    const form = new FormData();
+    form.set('value', '1');
+    const multipart = await fetcher.post<any>(
+      '/headers',
+      { body: form },
+      options,
+    );
+    expect(multipart.headers['content-type']).toMatch(
+      /^multipart\/form-data; boundary=/,
+    );
+  });
+
+  it.each([
+    ['/users?active=true', 'https://review.test/users?active=true&page=2'],
+    [
+      '/users?active=true#details',
+      'https://review.test/users?active=true&page=2#details',
+    ],
+    ['/users#details', 'https://review.test/users?page=2#details'],
+  ])('adds query parameters before fragments: %s', async (url, expected) => {
+    const fetcher = new Fetcher({ baseURL: 'https://review.test' });
+    const response = await fetcher.get<any>(
+      url,
+      { urlParams: { query: { page: 2 } } },
+      options,
+    );
+    expect(response.url).toBe(expected);
+  });
+
+  it('honors a caller-aborted controller even when timeout is enabled', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('user cancelled'));
+    const fetcher = new Fetcher({
+      baseURL: 'https://review.test',
+      timeout: 1000,
+    });
+    await expect(
+      fetcher.post('/cancelled', {
+        body: { value: 1 },
+        abortController: controller,
+      }),
+    ).rejects.toThrow('user cancelled');
+  });
+});
+
+it.each([true, false])(
+  'normalizes duplicate casing even when one request is empty: %s',
+  first => {
+    const request = { headers: { Authorization: 'old', authorization: 'new' } };
+    const merged = first
+      ? mergeRequest(request, {})
+      : mergeRequest({}, request);
+    expect(
+      new Headers(merged.headers as Record<string, string>).get(
+        'authorization',
+      ),
+    ).toBe('new');
+  },
+);
+
+it('retains the caller controller after timeout instead of reviving it on retry', async () => {
+  server.use(
+    http.get('https://review.test/slow', async () => {
+      await delay(50);
+      return HttpResponse.text('late');
+    }),
+  );
+  const abortController = new AbortController();
+  const request = {
+    url: 'https://review.test/slow',
+    timeout: 5,
+    abortController,
+  };
+  await expect(timeoutFetch(request)).rejects.toThrow('timeout');
+  expect(request.abortController).toBe(abortController);
+  expect(abortController.signal.aborted).toBe(true);
+  await expect(timeoutFetch(request)).rejects.toBe(
+    abortController.signal.reason,
+  );
+});

--- a/packages/fetcher/test/urlBuilder.test.ts
+++ b/packages/fetcher/test/urlBuilder.test.ts
@@ -49,6 +49,34 @@ describe('UrlBuilder', () => {
       expect(url).toBe('https://api.example.com/users?filter=active&page=1');
     });
 
+    it.each([
+      ['/search?pattern=?', 'https://api.example.com/search?pattern=?&page=2'],
+      [
+        '/search?pattern=?#details',
+        'https://api.example.com/search?pattern=?&page=2#details',
+      ],
+      ['/search??#details', 'https://api.example.com/search??&page=2#details'],
+      [
+        '/search?pattern=why?now',
+        'https://api.example.com/search?pattern=why?now&page=2',
+      ],
+      ['/search?', 'https://api.example.com/search?page=2'],
+      ['/search?#details', 'https://api.example.com/search?page=2#details'],
+      [
+        '/search?pattern=ok&#details',
+        'https://api.example.com/search?pattern=ok&page=2#details',
+      ],
+      ['/search#details?', 'https://api.example.com/search?page=2#details?'],
+    ])(
+      'preserves the existing query when appending parameters: %s',
+      (input, expected) => {
+        const urlBuilder = new UrlBuilder('https://api.example.com');
+        const url = urlBuilder.build(input, { query: { page: 2 } });
+        expect(url).toBe(expected);
+        expect(new URL(url).searchParams.get('page')).toBe('2');
+      },
+    );
+
     it('should build URL with path parameters and query parameters', () => {
       const urlBuilder = new UrlBuilder('https://api.example.com');
       const url = urlBuilder.build('/users/{id}', {

--- a/skills/fetcher-integration/references/api.md
+++ b/skills/fetcher-integration/references/api.md
@@ -496,7 +496,11 @@ abortController.abort(); // cancels the in-flight request
 ### Other Utilities
 
 - `getFetcher(fetcher?: string | Fetcher, defaultFetcher?)` -- resolve a registered fetcher by name or pass an instance through (used by decorator services)
-- `mergeRequest(first, second)` -- merge two request configs (headers, nested `urlParams.path`/`query`)
+- `mergeRequest(first, second)` -- merge two request configs (case-insensitive headers, nested `urlParams.path`/`query`)
+- `mergeHeaders(...headers: (RequestHeaders | undefined)[]): RequestHeaders` -- case-insensitive replacement; the last layer and its spelling win, without mutating inputs
+- `getHeader(headers: RequestHeaders | undefined, name: string): string | undefined` -- case-insensitive lookup (last matching key wins)
+- `setHeader(headers: RequestHeaders, name: string, value: string | undefined): void` -- replaces all spellings, retaining `name`; `undefined` removes the header
+- `deleteHeader(headers: RequestHeaders, name: string): void` -- removes all spellings; use these helpers when interceptors read or modify header records
 - `HttpMethod` -- enum of HTTP methods for the generic `fetcher.request()` / `fetcher.fetch()` calls
 - `combineURLs(base, relative)` / `isAbsoluteURL(url)` -- an already-absolute request URL bypasses `baseURL` entirely
 - `Response.json<T>()` -- the package augments `Response` globally so `response.json<User>()` type-checks


### PR DESCRIPTION
## Description

Merge header names case-insensitively, preserve existing query strings and fragments, and keep an already-aborted request cancelled. Export shared header helpers for downstream interceptors.

Preserve existing query keys and values ending in a question mark when appending URL parameters. Only the first question mark can be the empty-query separator; fragments and existing ampersands remain intact. Complete the HTTP regression license header.

This series prepares version 5.0.0 for its public type changes; no release is published by these updates.

## Validation

Local checks passed before this stack update. Each layer was also compared with its verified source delta; current stacked heads receive fresh CI:

- `pnpm build`
- `pnpm test:unit` — 225 files, 3280 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .`
- `git diff --check`

Node.js 24.11.0, pnpm 10.34.5. Existing lint warnings remain; no build configuration or third-party dependencies changed. Regressions were reproduced before behavior changes, and bilingual wiki updates were built.

## Review and CI

Ready for review. Each merge candidate requires a completed GitHub Codex review, no unresolved review threads, and five successful CI workflows for its current head. Old-head results do not satisfy that gate. Codacy quality-rule findings are tracked separately with source evidence.

Native GitHub stack #1418, layer 2 of 16. Keep this PR separate and squash layers in stack order. GitHub rebases the remaining layers after each partial merge; verify their new Codex reviews and CI before continuing.

Split index: #1399.
