### PR TITLE
fix(eventstream): preserve SSE framing and retry error semantics

### DIFF
--- a/packages/eventstream/src/responses.ts
+++ b/packages/eventstream/src/responses.ts
@@ -136,7 +136,10 @@ if (typeof Response !== 'undefined') {
         if (!contentType) {
           return false;
         }
-        return contentType.includes(ContentTypeValues.TEXT_EVENT_STREAM);
+        return (
+          contentType.split(';', 1)[0].trim().toLowerCase() ===
+          ContentTypeValues.TEXT_EVENT_STREAM
+        );
       },
       configurable: true,
     });

--- a/packages/eventstream/src/serverSentEventTransformStream.ts
+++ b/packages/eventstream/src/serverSentEventTransformStream.ts
@@ -114,7 +114,7 @@ export class ServerSentEventTransformer extends SafeTransformer<
     const currentEvent = this.currentEventState;
 
     // Skip empty lines (event separator)
-    if (chunk.trim() === '') {
+    if (chunk === '') {
       if (currentEvent.data.length > 0) {
         this.enqueue(controller, {
           event: currentEvent.event || DEFAULT_EVENT_TYPE,
@@ -122,10 +122,9 @@ export class ServerSentEventTransformer extends SafeTransformer<
           id: currentEvent.id || '',
           retry: currentEvent.retry,
         } as ServerSentEvent);
-
-        currentEvent.event = DEFAULT_EVENT_TYPE;
-        currentEvent.data = [];
       }
+      currentEvent.event = DEFAULT_EVENT_TYPE;
+      currentEvent.data = [];
       return;
     }
 
@@ -140,16 +139,15 @@ export class ServerSentEventTransformer extends SafeTransformer<
     let value: string;
 
     if (colonIndex === -1) {
-      field = chunk.toLowerCase();
+      field = chunk;
       value = '';
     } else {
-      field = chunk.substring(0, colonIndex).toLowerCase();
+      field = chunk.substring(0, colonIndex);
       value = chunk.substring(colonIndex + 1);
       if (value.startsWith(' ')) {
         value = value.substring(1);
       }
     }
-
 
     processFieldInternal(field, value, currentEvent);
   }

--- a/packages/eventstream/src/streamController.ts
+++ b/packages/eventstream/src/streamController.ts
@@ -22,8 +22,7 @@
  * @template T - The type of chunks the controller handles
  */
 export type StreamController<T> =
-  | ReadableStreamDefaultController<T>
-  | TransformStreamDefaultController<T>;
+  ReadableStreamDefaultController<T> | TransformStreamDefaultController<T>;
 
 /**
  * Executes an action and suppresses TypeError, returning a boolean indicating success.
@@ -33,11 +32,9 @@ export type StreamController<T> =
  * the stream is already closed or errored. This helper catches that TypeError
  * and returns false, while re-throwing any non-TypeError exceptions.
  *
- * Uses both `instanceof TypeError` and `Object.prototype.toString` checks
- * to handle cross-realm TypeErrors (e.g. from iframes or worker threads)
- * where `instanceof` alone would fail. The toString check matches values
- * with the internal TypeError class tag, which covers cross-realm TypeErrors
- * while rejecting plain objects that merely have a `name` property.
+ * Checks the Error brand and a native TypeError constructor in its prototype
+ * chain to support other realms and subclasses without trusting error names.
+ * A custom toStringTag is rejected because it can spoof the Error brand.
  *
  * @param action - The controller operation to attempt
  * @returns true if the action succeeded, false if a TypeError was caught
@@ -48,10 +45,28 @@ function suppressTypeError(action: () => void): boolean {
     return true;
   } catch (error) {
     if (
-      error instanceof TypeError ||
-      Object.prototype.toString.call(error) === '[object TypeError]'
+      typeof error === 'object' &&
+      error !== null &&
+      !(Symbol.toStringTag in error) &&
+      Object.prototype.toString.call(error) === '[object Error]'
     ) {
-      return false;
+      for (
+        let prototype = Object.getPrototypeOf(error);
+        prototype;
+        prototype = Object.getPrototypeOf(prototype)
+      ) {
+        const constructor = Object.getOwnPropertyDescriptor(
+          prototype,
+          'constructor',
+        )?.value;
+        if (
+          typeof constructor === 'function' &&
+          Function.prototype.toString.call(constructor) ===
+            Function.prototype.toString.call(TypeError)
+        ) {
+          return false;
+        }
+      }
     }
     throw error;
   }

--- a/packages/eventstream/src/textLineTransformStream.ts
+++ b/packages/eventstream/src/textLineTransformStream.ts
@@ -16,38 +16,43 @@ import { SafeTransformer } from './safeTransformer';
 /**
  * Transformer that splits text into lines.
  *
- * Accumulates chunks of text and splits them by newline characters ('\n'),
+ * Accumulates chunks of text and splits them by CR, LF, or CRLF,
  * emitting each complete line as a separate chunk. Handles partial lines
  * that span multiple input chunks by maintaining an internal buffer.
  */
 export class TextLineTransformer extends SafeTransformer<string, string> {
   private buffer = '';
 
-  private normalizeLine(line: string): string {
-    return line.endsWith('\r') ? line.slice(0, -1) : line;
-  }
+  private discardLeadingLF = false;
 
   protected onTransform(
     chunk: string,
     controller: TransformStreamDefaultController<string>,
   ): void {
-    this.buffer += chunk;
-    const lines = this.buffer.split('\n');
+    chunk = String(chunk);
+    if (chunk === '') return;
+    if (this.discardLeadingLF && chunk.startsWith('\n')) {
+      chunk = chunk.slice(1);
+    }
+    // A CR ends its line immediately; consume a following LF only once,
+    // even when the pair is separated by chunks.
+    this.discardLeadingLF = chunk.endsWith('\r');
+    const lines = (this.buffer + chunk).split(/\r\n|\r|\n/);
     this.buffer = lines.pop() || '';
 
     for (const line of lines) {
-      this.enqueue(controller, this.normalizeLine(line));
+      this.enqueue(controller, line);
     }
   }
 
   protected onFlush(
     controller: TransformStreamDefaultController<string>,
   ): void {
-    const line = this.normalizeLine(this.buffer);
-    // Only send when normalized buffer is not empty.
-    if (line) {
-      this.enqueue(controller, line);
+    if (this.buffer) {
+      this.enqueue(controller, this.buffer);
     }
+    this.buffer = '';
+    this.discardLeadingLF = false;
   }
 }
 

--- a/packages/eventstream/test/serverSentEventTransformStream.test.ts
+++ b/packages/eventstream/test/serverSentEventTransformStream.test.ts
@@ -662,7 +662,7 @@ describe('serverSentEventTransformStream.ts', () => {
 
       // Mock chunk to throw a non-Error object
       const chunk = {
-        trim: () => {
+        startsWith: () => {
           throw 'Test error string';
         },
       } as any;

--- a/packages/eventstream/test/sseRegression.test.ts
+++ b/packages/eventstream/test/sseRegression.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+import { TextLineTransformer } from '../src';
+
+async function parse(chunks: string[]) {
+  const bytes = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks)
+        controller.enqueue(new TextEncoder().encode(chunk));
+      controller.close();
+    },
+  });
+  const events = [];
+  for await (const event of new Response(bytes, {
+    headers: { 'Content-Type': 'text/event-stream' },
+  }).requiredEventStream())
+    events.push(event);
+  return events;
+}
+
+describe('SSE protocol regressions', () => {
+  it.each([
+    ['data: one\r\rdata: two\r\r'],
+    ['data: one\r', '', '\n\r', '\ndata: two\n\n'],
+    ['data: one\n\ndata: two\r\n\r\n'],
+  ])(
+    'recognizes each legal line ending across chunks: %j',
+    async (...chunks) => {
+      expect((await parse(chunks)).map(event => event.data)).toEqual([
+        'one',
+        'two',
+      ]);
+    },
+  );
+
+  it('emits CR-terminated lines before the connection closes', async () => {
+    const lines: string[] = [];
+    await new TextLineTransformer().transform('data: live\r\r', {
+      enqueue: (line: string) => lines.push(line),
+    } as any);
+    expect(lines).toEqual(['data: live', '']);
+  });
+
+  it('ignores whitespace-only unknown fields inside a JSON event', async () => {
+    const response = new Response('data: {"value":\n \ndata: 1}\n\n', {
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+    const result = [];
+    for await (const event of response.requiredJsonEventStream())
+      result.push(event.data);
+    expect(result).toEqual([{ value: 1 }]);
+  });
+
+  it.each([
+    ['Text/Event-Stream; charset=utf-8', true],
+    ['text/event-stream-extra', false],
+    ['application/json; note=text/event-stream', false],
+  ])('matches the complete media type: %s', (contentType, expected) => {
+    expect(
+      new Response('', { headers: { 'Content-Type': contentType } })
+        .isEventStream,
+    ).toBe(expected);
+  });
+
+  it('resets event type on an empty block while retaining the last event ID', async () => {
+    const events = await parse(['id: keep\nevent: custom\n\ndata: next\n\n']);
+    expect(events).toEqual([
+      { event: 'message', data: 'next', id: 'keep', retry: undefined },
+    ]);
+  });
+
+  it('compares field names literally, including fields without a colon', async () => {
+    const events = await parse([
+      'DATA: ignored\nEVENT: custom\nDATA\n\ndata: valid\n\n',
+    ]);
+    expect(events).toEqual([
+      { event: 'message', data: 'valid', id: '', retry: undefined },
+    ]);
+  });
+});

--- a/packages/eventstream/test/streamController.test.ts
+++ b/packages/eventstream/test/streamController.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { runInNewContext } from 'node:vm';
 import { safeTerminate, safeEnqueue, safeError } from '../src';
 
 describe('safeTerminate', () => {
@@ -38,11 +39,8 @@ describe('safeTerminate', () => {
     expect(() => safeTerminate(controller as any)).toThrow(RangeError);
   });
 
-  it('should return false for cross-realm TypeError (instanceof fails, toString matches)', () => {
-    // Construct an object that instanceof TypeError returns false for,
-    // but Object.prototype.toString returns '[object TypeError]'
-    // This simulates a TypeError from another realm
-    const crossRealmLike = { [Symbol.toStringTag]: 'TypeError', message: 'stream closed' };
+  it('should return false for real cross-realm TypeError', () => {
+    const crossRealmLike = runInNewContext('new TypeError("stream closed")');
     const controller = {
       terminate: vi.fn(() => {
         throw crossRealmLike;
@@ -93,8 +91,8 @@ describe('safeEnqueue', () => {
     expect(() => safeEnqueue(controller as any, 'chunk')).toThrow(RangeError);
   });
 
-  it('should return false for cross-realm TypeError (instanceof fails, toString matches)', () => {
-    const crossRealmLike = { [Symbol.toStringTag]: 'TypeError', message: 'stream closed' };
+  it('should return false for real cross-realm TypeError', () => {
+    const crossRealmLike = runInNewContext('new TypeError("stream closed")');
     const controller = {
       enqueue: vi.fn(() => {
         throw crossRealmLike;
@@ -148,8 +146,8 @@ describe('safeError', () => {
     );
   });
 
-  it('should return false for cross-realm TypeError (instanceof fails, toString matches)', () => {
-    const crossRealmLike = { [Symbol.toStringTag]: 'TypeError', message: 'stream closed' };
+  it('should return false for real cross-realm TypeError', () => {
+    const crossRealmLike = runInNewContext('new TypeError("stream closed")');
     const controller = {
       error: vi.fn(() => {
         throw crossRealmLike;
@@ -173,4 +171,46 @@ describe('safeError', () => {
     }
     expect(caught).toBe(fakeError);
   });
+});
+
+it.each([
+  { name: 'TypeError', [Symbol.toStringTag]: 'TypeError' },
+  { name: 'TypeError', [Symbol.toStringTag]: 'Error' },
+  Object.create(TypeError.prototype),
+  Object.assign(new Error('other'), { name: 'TypeError' }),
+  runInNewContext('new RangeError("other")'),
+  runInNewContext(
+    'class Other extends Error {}; Other.prototype.name = "TypeError"; new Other("other")',
+  ),
+])('does not swallow a forged or unrelated TypeError-like value: %j', value => {
+  let caught: unknown;
+  try {
+    safeEnqueue(
+      {
+        enqueue() {
+          throw value;
+        },
+      } as any,
+      1,
+    );
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBe(value);
+});
+
+it('recognizes a real cross-realm TypeError subclass', () => {
+  const error = runInNewContext(
+    'class Closed extends TypeError {}; new Closed("closed")',
+  );
+  expect(
+    safeEnqueue(
+      {
+        enqueue() {
+          throw error;
+        },
+      } as any,
+      1,
+    ),
+  ).toBe(false);
 });

--- a/packages/eventstream/test/textLineTransformStream.test.ts
+++ b/packages/eventstream/test/textLineTransformStream.test.ts
@@ -113,7 +113,7 @@ describe('textLineTransformStream.ts', () => {
       expect(controller.enqueue).not.toHaveBeenCalled();
     });
 
-    it('should not flush a trailing carriage return as an empty line', async () => {
+    it('should emit a CR separator once without duplicating it on flush', async () => {
       const transformer = new TextLineTransformer();
       const controller = {
         enqueue: vi.fn(),
@@ -121,9 +121,9 @@ describe('textLineTransformStream.ts', () => {
       } as any;
 
       await transformer.transform('\r', controller);
+      expect(controller.enqueue).toHaveBeenCalledExactlyOnceWith('');
       await transformer.flush(controller);
-
-      expect(controller.enqueue).not.toHaveBeenCalled();
+      expect(controller.enqueue).toHaveBeenCalledExactlyOnceWith('');
     });
 
     it('should handle errors in transform', async () => {

--- a/skills/fetcher-llm-streaming/references/api.md
+++ b/skills/fetcher-llm-streaming/references/api.md
@@ -58,6 +58,8 @@ try {
 }
 ```
 
+SSE media types are matched case-insensitively after removing parameters, using the complete type (`text/event-stream`). Field names remain case-sensitive. CR, LF and CRLF delimit lines, including pairs split across chunks; only an empty line ends an event block. Empty blocks reset the event type while retaining the last event ID.
+
 ## SSE Stream Processing Pipeline
 
 The internal pipeline transforms raw bytes into typed events:

--- a/wiki/reference/eventstream.md
+++ b/wiki/reference/eventstream.md
@@ -32,7 +32,10 @@ pnpm add @ahoo-wang/fetcher @ahoo-wang/fetcher-eventstream
 | Build a custom stage | `TextLineTransformStream`, `ServerSentEventTransformStream`, `JsonServerSentEventTransformStream<T>` | The individual `TransformStream` stages. |
 
 Import `@ahoo-wang/fetcher-eventstream` before calling the `Response` prototype
-helpers. `isEventStream` uses `Content-Type.includes('text/event-stream')`.
+helpers. `isEventStream` compares the complete media type before the first `;`
+with `text/event-stream`, ignoring case and surrounding whitespace. Parameters
+such as `charset=utf-8` are accepted; `text/event-stream-extra` and
+`application/json; note=text/event-stream` are not.
 
 ## Consume typed JSON events
 
@@ -69,11 +72,15 @@ unspecified event type to `message`, ignores comment lines, joins repeated
 `data:` fields with `\n`, ignores `id` values containing NUL, and accepts
 `retry` only when it contains ASCII digits. It emits a frame at a blank line or
 when the input stream flushes only if at least one `data:` field was received.
-A metadata-only group does not emit at its blank line, and that blank line does
-not reset its `event`, `id`, or `retry`: those values apply to the following
-data-bearing event. At EOF, metadata-only residue is discarded by flush cleanup
+A metadata-only group does not emit at its blank line. Every blank line resets
+the event type to `message`, while retaining `id` and `retry`. An empty `data:`
+field still emits an event with empty data; after dispatch, its event type also
+resets. At EOF, metadata-only residue is discarded by flush cleanup
 ([`packages/eventstream/src/serverSentEventTransformStream.ts:116`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/eventstream/src/serverSentEventTransformStream.ts#L116),
 [`packages/eventstream/src/serverSentEventTransformStream.ts:157`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/eventstream/src/serverSentEventTransformStream.ts#L157)).
+
+The blank-line reset follows the [WHATWG SSE dispatch steps](https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage),
+which clear the event type even when no data has been received.
 
 ```text
 Response.body (ReadableStream<Uint8Array>)
@@ -93,7 +100,7 @@ the JSON transform only when every non-terminal `data` field is valid JSON.
 | API | Return / failure boundary |
 | --- | --- |
 | `response.contentType` | `string | null` from the `Content-Type` header. |
-| `response.isEventStream` | `true` only when that header includes `text/event-stream`. |
+| `response.isEventStream` | `true` when the media type before `;`, trimmed and compared without case sensitivity, equals `text/event-stream`. |
 | `response.eventStream()` | Raw stream or `null`; it does not throw for a non-SSE content type. |
 | `response.requiredEventStream()` | Raw stream; otherwise `EventStreamConvertError` retaining `response`. |
 | `response.jsonEventStream<T>(detector?)` | JSON stream or `null`. |
@@ -139,7 +146,7 @@ stream creation and the whole consuming loop inside the same error boundary.
 
 | Symptom | Check |
 | --- | --- |
-| `requiredEventStream()` throws immediately | Confirm `Content-Type` includes `text/event-stream` and the `Response` has a body. |
+| `requiredEventStream()` throws immediately | Confirm the media type before Content-Type parameters is `text/event-stream` and the `Response` has a body. |
 | `response.eventStream` is missing | Import `@ahoo-wang/fetcher-eventstream` for its prototype side effect. |
 | JSON processing fails after some events | Identify the malformed `data` payload; use the raw stream for mixed text/JSON protocols or a detector for sentinels. |
 | A `[DONE]` frame becomes a parse error | Pass `event => event.data === '[DONE]'` as the `TerminateDetector`. |

--- a/wiki/zh/reference/eventstream.md
+++ b/wiki/zh/reference/eventstream.md
@@ -30,7 +30,9 @@ pnpm add @ahoo-wang/fetcher @ahoo-wang/fetcher-eventstream
 | 构建自定义阶段 | `TextLineTransformStream`、`ServerSentEventTransformStream`、`JsonServerSentEventTransformStream<T>` | 各个 `TransformStream` 阶段。 |
 
 调用 `Response` 原型辅助 API 前必须导入 `@ahoo-wang/fetcher-eventstream`。
-`isEventStream` 通过 `Content-Type.includes('text/event-stream')` 判断。
+`isEventStream` 取第一个 `;` 前的完整媒体类型，去除两端空白后与 `text/event-stream`
+进行不区分大小写的比较。允许 `charset=utf-8` 等参数；不接受 `text/event-stream-extra`
+或 `application/json; note=text/event-stream`。
 
 ## 消费类型化 JSON 事件
 
@@ -65,10 +67,14 @@ try {
 `ServerSentEvent` 的结构为 `{ event, data, id?, retry? }`。Parser 会把缺失的 Event Type
 设为 `message`，忽略注释行，用 `\n` 合并重复的 `data:` 字段，忽略包含 NUL 的 `id`，仅在
 `retry` 全为 ASCII 数字时接受它。只有至少收到一个 `data:` 字段时，它才会在空行或输入 Stream
-flush 时输出 Frame。仅含 Metadata 的 Group 不会在空行立即输出，且该空行不会重置 `event`、`id`
-或 `retry`；这些值会应用到后续含 `data` 的 Event。EOF 时，只有 Metadata 的残余会由 flush 清理丢弃
+flush 时输出 Frame。仅含 Metadata 的 Group 不会在空行输出。每个空行都会把事件类型重置为
+`message`，同时保留 `id` 和 `retry`。空的 `data:` 字段仍会输出数据为空字符串的事件，
+分发后也会重置事件类型。EOF 时，只有 Metadata 的残余会由 flush 清理丢弃
 （[`packages/eventstream/src/serverSentEventTransformStream.ts:116`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/eventstream/src/serverSentEventTransformStream.ts#L116)、
 [`packages/eventstream/src/serverSentEventTransformStream.ts:157`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/eventstream/src/serverSentEventTransformStream.ts#L157)）。
+
+空行重置遵循 [WHATWG SSE 分发步骤](https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage)：
+即使没有收到数据，也会清空事件类型缓冲区。
 
 ```text
 Response.body (ReadableStream<Uint8Array>)
@@ -87,7 +93,7 @@ Response.body (ReadableStream<Uint8Array>)
 | API | 返回值 / 失败边界 |
 | --- | --- |
 | `response.contentType` | 从 `Content-Type` Header 取得的 `string | null`。 |
-| `response.isEventStream` | 仅当 Header 包含 `text/event-stream` 时为 `true`。 |
+| `response.isEventStream` | 取 `;` 前的媒体类型并去除两端空白，不区分大小写地等于 `text/event-stream` 时为 `true`。 |
 | `response.eventStream()` | Raw Stream 或 `null`；非 SSE Content Type 时不抛错。 |
 | `response.requiredEventStream()` | Raw Stream；否则抛出并保留 `response` 的 `EventStreamConvertError`。 |
 | `response.jsonEventStream<T>(detector?)` | JSON Stream 或 `null`。 |
@@ -130,7 +136,7 @@ for await (const event of events) {
 
 | 现象 | 检查项 |
 | --- | --- |
-| `requiredEventStream()` 立即抛错 | 确认 `Content-Type` 包含 `text/event-stream`，并且 `Response` 有 Body。 |
+| `requiredEventStream()` 立即抛错 | 确认 Content-Type 参数前的媒体类型为 `text/event-stream`，并且 `Response` 有 Body。 |
 | `response.eventStream` 不存在 | 导入 `@ahoo-wang/fetcher-eventstream` 以执行原型 Side Effect。 |
 | 处理若干事件后 JSON 失败 | 定位无效的 `data`；混合文本/JSON 协议使用 Raw Stream，Sentinel 使用 Detector。 |
 | `[DONE]` Frame 变成解析错误 | 传入 `event => event.data === '[DONE]'` 作为 `TerminateDetector`。 |


### PR DESCRIPTION
## Description

Handle CR-only lines, whitespace data, event type resets and case-sensitive SSE fields. Validate the event-stream media type and distinguish actual cross-realm TypeErrors from unrelated named errors before retrying.

Update both language references for exact case-insensitive SSE media-type matching and frame resets. The proposed parser change was checked against the current WHATWG dispatch algorithm and excluded: an empty data buffer also clears the event-type buffer. Complete the regression test license header.

This series prepares version 5.0.0 for its public type changes; no release is published by these updates.

## Validation

Local checks passed before this stack update. Each layer was also compared with its verified source delta; current stacked heads receive fresh CI:

- `pnpm build`
- `pnpm test:unit` — 225 files, 3279 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .`
- `git diff --check`

Node.js 24.11.0, pnpm 10.34.5. Existing lint warnings remain; no build configuration or third-party dependencies changed. Regressions were reproduced before behavior changes, and bilingual wiki updates were built.

## Review and CI

Ready for review. Each merge candidate requires a completed GitHub Codex review, no unresolved review threads, and five successful CI workflows for its current head. Old-head results do not satisfy that gate. Codacy quality-rule findings are tracked separately with source evidence.

Native GitHub stack #1418, layer 6 of 16. Keep this PR separate and squash layers in stack order. GitHub rebases the remaining layers after each partial merge; verify their new Codex reviews and CI before continuing.

Split index: #1399.

Specification evidence: https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage
