### PR TITLE
fix(storage): deserialize cross-context values before notifying listeners

### DIFF
--- a/packages/cosec/src/jwtToken.ts
+++ b/packages/cosec/src/jwtToken.ts
@@ -285,6 +285,25 @@ export class JwtCompositeTokenSerializer
     );
   }
 
+  /** Restores the known object shape emitted by legacy token storage tabs. */
+  deserializeLegacy(value: unknown): JwtCompositeToken {
+    if (typeof value !== 'object' || value === null || !('token' in value)) {
+      throw new TypeError('Invalid legacy composite token');
+    }
+    const token = value.token;
+    if (
+      typeof token !== 'object' ||
+      token === null ||
+      !('accessToken' in token) ||
+      typeof token.accessToken !== 'string' ||
+      !('refreshToken' in token) ||
+      typeof token.refreshToken !== 'string'
+    ) {
+      throw new TypeError('Invalid legacy composite token');
+    }
+    return this.deserialize(this.serialize(value as JwtCompositeToken));
+  }
+
   /**
    * Serializes a JwtCompositeToken to a JSON string.
    *

--- a/packages/cosec/src/tokenStorage.ts
+++ b/packages/cosec/src/tokenStorage.ts
@@ -26,6 +26,21 @@ import {
  */
 export const DEFAULT_COSEC_TOKEN_KEY = 'cosec-token';
 
+const SHARED_TOKEN_SERIALIZERS = Symbol.for(
+  '@ahoo-wang/fetcher-cosec/shared-token-serializers',
+);
+const sharedState = globalThis as typeof globalThis & {
+  [SHARED_TOKEN_SERIALIZERS]?: WeakMap<object, JwtCompositeTokenSerializer>;
+};
+const sharedTokenSerializers =
+  sharedState[SHARED_TOKEN_SERIALIZERS] ??
+  new WeakMap<object, JwtCompositeTokenSerializer>();
+if (!sharedState[SHARED_TOKEN_SERIALIZERS]) {
+  Object.defineProperty(sharedState, SHARED_TOKEN_SERIALIZERS, {
+    value: sharedTokenSerializers,
+  });
+}
+
 /**
  * Options for configuring TokenStorage.
  * Extends KeyStorageOptions excluding 'serializer' and includes EarlyPeriodCapable properties.
@@ -54,7 +69,7 @@ export class TokenStorage
    * @param options - Configuration options for the token storage.
    * @param options.key - The storage key for tokens. Defaults to DEFAULT_COSEC_TOKEN_KEY.
    * @param options.eventBus - Event bus for token change notifications. Defaults to a BroadcastTypedEventBus whose channel name is derived from the storage key.
-   * @param options.earlyPeriod - Early period for token refresh in seconds. Defaults to 0.
+   * @param options.earlyPeriod - Early period for token refresh in seconds. Defaults to 0. Instances sharing an eventBus must use the same period; separate buses on the same channel can use different periods.
    * @param reset - Additional options passed to KeyStorage.
    */
   constructor({
@@ -63,6 +78,15 @@ export class TokenStorage
     earlyPeriod = 0,
     ...reset
   }: TokenStorageOptions = {}) {
+    let serializer = eventBus
+      ? sharedTokenSerializers.get(eventBus)
+      : undefined;
+    if (serializer && serializer.earlyPeriod !== earlyPeriod) {
+      throw new Error(
+        'TokenStorage instances sharing an event bus require the same earlyPeriod; use separate buses for different periods.',
+      );
+    }
+    serializer ??= new JwtCompositeTokenSerializer(earlyPeriod);
     super({
       key,
       // The default bus channel must be derived from the actual key so that
@@ -73,8 +97,9 @@ export class TokenStorage
           delegate: new SerialTypedEventBus(key),
         }),
       ...reset,
-      serializer: new JwtCompositeTokenSerializer(earlyPeriod),
+      serializer,
     });
+    sharedTokenSerializers.set(this.eventBus, serializer);
     this.earlyPeriod = earlyPeriod;
   }
 

--- a/packages/cosec/test/cosecRequestInterceptor.test.ts
+++ b/packages/cosec/test/cosecRequestInterceptor.test.ts
@@ -45,13 +45,13 @@ vi.stubGlobal('window', { localStorage: mockStorage });
 
 vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
   BroadcastTypedEventBus: class BroadcastTypedEventBus {
-    emit = vi.fn();
+    emit = vi.fn().mockResolvedValue(undefined);
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
   },
   SerialTypedEventBus: class SerialTypedEventBus {
-    emit = vi.fn();
+    emit = vi.fn().mockResolvedValue(undefined);
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();

--- a/packages/cosec/test/deviceIdStorage.test.ts
+++ b/packages/cosec/test/deviceIdStorage.test.ts
@@ -44,13 +44,13 @@ const { serialBusChannels } = vi.hoisted(() => ({
 // Mock BroadcastTypedEventBus and SerialTypedEventBus
 vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
   BroadcastTypedEventBus: class BroadcastTypedEventBus {
-    emit = vi.fn();
+    emit = vi.fn().mockResolvedValue(undefined);
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
   },
   SerialTypedEventBus: class SerialTypedEventBus {
-    emit = vi.fn();
+    emit = vi.fn().mockResolvedValue(undefined);
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
@@ -111,7 +111,7 @@ describe('DeviceIdStorage', () => {
     it('should initialize with custom eventBus only', () => {
       // Test partial customization: new DeviceIdStorage({ eventBus: custom })
       const mockEventBus = {
-        emit: vi.fn(),
+        emit: vi.fn().mockResolvedValue(undefined),
         on: vi.fn(),
         off: vi.fn(),
         destroy: vi.fn(),
@@ -124,7 +124,7 @@ describe('DeviceIdStorage', () => {
     it('should initialize with all custom options', () => {
       // Test full customization
       const mockEventBus = {
-        emit: vi.fn(),
+        emit: vi.fn().mockResolvedValue(undefined),
         on: vi.fn(),
         off: vi.fn(),
         destroy: vi.fn(),

--- a/packages/cosec/test/legacyJwtProtocol.test.ts
+++ b/packages/cosec/test/legacyJwtProtocol.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect, it } from 'vitest';
+import {
+  JwtCompositeToken,
+  JwtCompositeTokenSerializer,
+  TokenStorage,
+} from '../src';
+import { InMemoryStorage, type StorageEvent } from '@ahoo-wang/fetcher-storage';
+import {
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+  type CrossTabMessageHandler,
+} from '@ahoo-wang/fetcher-eventbus';
+
+it('restores an old cloned JwtCompositeToken through the storage serializer hook', async () => {
+  const jwt = `e30.${Buffer.from(JSON.stringify({ sub: 'legacy', exp: Math.floor(Date.now() / 1000) + 3600 })).toString('base64url')}.sig`;
+  const original = new JwtCompositeToken({
+    accessToken: jwt,
+    refreshToken: jwt,
+  });
+  let incoming: CrossTabMessageHandler | undefined;
+  const bus = new BroadcastTypedEventBus<StorageEvent<JwtCompositeToken>>({
+    delegate: new SerialTypedEventBus('old-token'),
+    messenger: {
+      postMessage() {},
+      close() {},
+      set onmessage(handler: CrossTabMessageHandler) {
+        incoming = handler;
+      },
+    },
+  });
+  const storage = new TokenStorage({
+    key: 'old-token',
+    storage: new InMemoryStorage(),
+    eventBus: bus,
+    earlyPeriod: 20,
+  });
+  await incoming?.(structuredClone({ newValue: original, oldValue: null }));
+  expect(storage.authenticated).toBe(true);
+  expect(storage.get()).toBeInstanceOf(JwtCompositeToken);
+  expect(storage.get()?.sessionId).toBe(original.sessionId);
+  expect(storage.get()?.earlyPeriod).toBe(20);
+  storage.destroy();
+  bus.destroy();
+});
+
+it.each([
+  null,
+  2,
+  {},
+  { token: {} },
+  { token: { accessToken: 2, refreshToken: 'r' } },
+  { token: { accessToken: 'a', refreshToken: 2 } },
+])('rejects malformed legacy token data: %j', value => {
+  expect(() =>
+    new JwtCompositeTokenSerializer().deserializeLegacy(value),
+  ).toThrow(TypeError);
+});

--- a/packages/cosec/test/spaceIdProvider.test.ts
+++ b/packages/cosec/test/spaceIdProvider.test.ts
@@ -53,13 +53,13 @@ const { serialBusChannels } = vi.hoisted(() => ({
 
 vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
   BroadcastTypedEventBus: class BroadcastTypedEventBus {
-    emit = vi.fn();
+    emit = vi.fn().mockResolvedValue(undefined);
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
   },
   SerialTypedEventBus: class SerialTypedEventBus {
-    emit = vi.fn();
+    emit = vi.fn().mockResolvedValue(undefined);
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
@@ -220,7 +220,7 @@ describe('SpaceIdStorage', () => {
 
     it('should initialize with custom eventBus', () => {
       const mockEventBus = {
-        emit: vi.fn(),
+        emit: vi.fn().mockResolvedValue(undefined),
         on: vi.fn(),
         off: vi.fn(),
         destroy: vi.fn(),
@@ -246,7 +246,7 @@ describe('SpaceIdStorage', () => {
     it('should initialize with all custom options', () => {
       const customKey = 'custom-key';
       const mockEventBus = {
-        emit: vi.fn(),
+        emit: vi.fn().mockResolvedValue(undefined),
         on: vi.fn(),
         off: vi.fn(),
         destroy: vi.fn(),
@@ -413,7 +413,7 @@ describe('SpaceIdStorage', () => {
 
     it('should remove handler from custom eventBus on destroy', () => {
       const mockEventBus = {
-        emit: vi.fn(),
+        emit: vi.fn().mockResolvedValue(undefined),
         on: vi.fn(),
         off: vi.fn().mockReturnValue(true),
         destroy: vi.fn(),
@@ -730,7 +730,7 @@ describe('SpaceIdProvider interface compliance', () => {
 
   it('DefaultSpaceIdProvider instance should satisfy SpaceIdProvider interface', () => {
     const mockEventBus = {
-      emit: vi.fn(),
+      emit: vi.fn().mockResolvedValue(undefined),
       on: vi.fn(),
       off: vi.fn(),
       destroy: vi.fn(),

--- a/packages/cosec/test/tokenStorage.test.ts
+++ b/packages/cosec/test/tokenStorage.test.ts
@@ -45,13 +45,13 @@ const { serialBusChannels } = vi.hoisted(() => ({
 // Mock BroadcastTypedEventBus and SerialTypedEventBus
 vi.mock('@ahoo-wang/fetcher-eventbus', () => ({
   BroadcastTypedEventBus: class BroadcastTypedEventBus {
-    emit = vi.fn();
+    emit = vi.fn().mockResolvedValue(undefined);
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
   },
   SerialTypedEventBus: class SerialTypedEventBus {
-    emit = vi.fn();
+    emit = vi.fn().mockResolvedValue(undefined);
     on = vi.fn();
     off = vi.fn();
     destroy = vi.fn();
@@ -113,7 +113,7 @@ describe('TokenStorage', () => {
   describe('constructor', () => {
     it('should initialize with default options', () => {
       const mockEventBus = {
-        emit: vi.fn(),
+        emit: vi.fn().mockResolvedValue(undefined),
         on: vi.fn(),
         off: vi.fn(),
         destroy: vi.fn(),

--- a/packages/cosec/test/tokenStorageModuleState.test.ts
+++ b/packages/cosec/test/tokenStorageModuleState.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { expect, it, vi } from 'vitest';
+import { InMemoryStorage } from '@ahoo-wang/fetcher-storage';
+import { TokenStorage } from '../src/tokenStorage';
+
+it('reuses the serializer of a default-created bus across CoSec module copies', async () => {
+  vi.resetModules();
+  const other = await import('../src/tokenStorage');
+  const otherJwt = await import('../src/jwtToken');
+  const first = new TokenStorage({
+    key: randomUUID(),
+    earlyPeriod: 30,
+    storage: new InMemoryStorage(),
+  });
+  const serialize = vi.spyOn(
+    otherJwt.JwtCompositeTokenSerializer.prototype,
+    'serialize',
+  );
+  const second = new other.TokenStorage({
+    eventBus: first.eventBus,
+    key: first.eventBus.type,
+    earlyPeriod: 30,
+    storage: new InMemoryStorage(),
+  });
+  const emitted = vi.spyOn(second.eventBus, 'emit');
+  try {
+    second.signIn({ accessToken: 'a', refreshToken: 'b' });
+    await emitted.mock.results[0].value;
+    expect(serialize).not.toHaveBeenCalled();
+    expect(first.get()?.earlyPeriod).toBe(30);
+  } finally {
+    serialize.mockRestore();
+    first.destroy();
+    second.destroy();
+    first.eventBus.destroy();
+  }
+});
+
+it('rejects a different earlyPeriod across CoSec module copies', async () => {
+  vi.resetModules();
+  const other = await import('../src/tokenStorage');
+  const key = randomUUID();
+  const first = new TokenStorage({ key, earlyPeriod: 0 });
+  try {
+    expect(
+      () =>
+        new other.TokenStorage({
+          key,
+          eventBus: first.eventBus,
+          earlyPeriod: 60,
+        }),
+    ).toThrow('same earlyPeriod');
+  } finally {
+    first.destroy();
+    first.eventBus.destroy();
+  }
+});

--- a/packages/cosec/test/tokenStorageSharing.test.ts
+++ b/packages/cosec/test/tokenStorageSharing.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { expect, it } from 'vitest';
+import {
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+} from '@ahoo-wang/fetcher-eventbus';
+import { InMemoryStorage, type StorageEvent } from '@ahoo-wang/fetcher-storage';
+import { TokenStorage } from '../src/tokenStorage';
+import { JwtCompositeToken } from '../src/jwtToken';
+
+it.each([false, true])(
+  'shares a bus with the same earlyPeriod (default bus: %s)',
+  async useDefault => {
+    const bus = new BroadcastTypedEventBus<StorageEvent<JwtCompositeToken>>({
+      delegate: new SerialTypedEventBus(randomUUID()),
+    });
+    const storage = new InMemoryStorage();
+    const first = new TokenStorage({
+      key: 'k',
+      storage,
+      eventBus: useDefault ? undefined : bus,
+      earlyPeriod: 30,
+    });
+    const second = new TokenStorage({
+      key: 'k',
+      storage,
+      eventBus: first.eventBus,
+      earlyPeriod: 30,
+    });
+    try {
+      const token = new JwtCompositeToken(
+        { accessToken: 'a', refreshToken: 'b' },
+        30,
+      );
+      await first.eventBus.emit({ newValue: token, oldValue: null });
+      expect(first.get()).toBe(token);
+      expect(second.get()).toBe(token);
+      expect(second.get()?.earlyPeriod).toBe(30);
+    } finally {
+      first.destroy();
+      second.destroy();
+      first.eventBus.destroy();
+      bus.destroy();
+    }
+  },
+);
+
+it('rejects sharing a bus with another earlyPeriod before registering a handler', () => {
+  const bus = new BroadcastTypedEventBus<StorageEvent<JwtCompositeToken>>({
+    delegate: new SerialTypedEventBus(randomUUID()),
+  });
+  const first = new TokenStorage({ key: 'k', eventBus: bus, earlyPeriod: 0 });
+  try {
+    expect(
+      () => new TokenStorage({ key: 'k', eventBus: bus, earlyPeriod: 60 }),
+    ).toThrow('same earlyPeriod');
+    expect(bus.handlers).toHaveLength(1);
+  } finally {
+    first.destroy();
+    bus.destroy();
+  }
+});
+
+it('keeps independent early periods for separate default buses on the same channel', async () => {
+  const key = randomUUID();
+  const storage = new InMemoryStorage();
+  const first = new TokenStorage({ key, storage, earlyPeriod: 0 });
+  const second = new TokenStorage({ key, storage, earlyPeriod: 60 });
+  try {
+    const changed = new Promise<StorageEvent<JwtCompositeToken>>(resolve =>
+      second.addListener({ name: 'next', once: true, handle: resolve }),
+    );
+    first.signIn({ accessToken: 'a', refreshToken: 'b' });
+    const received = await changed;
+    expect(received.newValue?.earlyPeriod).toBe(60);
+    expect(second.get()?.earlyPeriod).toBe(60);
+    expect(first.get()?.earlyPeriod).toBe(0);
+  } finally {
+    first.destroy();
+    second.destroy();
+    first.eventBus.destroy();
+    second.eventBus.destroy();
+  }
+});

--- a/packages/eventbus/src/broadcastTypedEventBus.ts
+++ b/packages/eventbus/src/broadcastTypedEventBus.ts
@@ -35,6 +35,16 @@ export interface BroadcastTypedEventBusOptions<EVENT> {
    * implementation when provided.
    */
   messenger?: CrossTabMessenger;
+
+  /** Converts only messages crossing the messenger boundary; local events stay unchanged. */
+  messageTransformer?: {
+    serialize(event: EVENT): unknown;
+    deserialize(message: unknown): EVENT;
+    /** Capture this dispatch's wire message before local handlers; defaults to false. */
+    serializeBeforeDispatch?: boolean;
+    /** Retries a failed messenger post once using a replacement wire message. */
+    fallbackSerialize?(message: unknown, error: unknown): unknown;
+  };
 }
 
 /**
@@ -112,6 +122,7 @@ export class BroadcastTypedEventBus<EVENT> implements TypedEventBus<EVENT> {
   public readonly type: EventType;
   private readonly delegate: TypedEventBus<EVENT>;
   private messenger: CrossTabMessenger;
+  public messageTransformer?: BroadcastTypedEventBusOptions<EVENT>['messageTransformer'];
 
   /**
    * Creates a new broadcast event bus with cross-context communication
@@ -122,14 +133,22 @@ export class BroadcastTypedEventBus<EVENT> implements TypedEventBus<EVENT> {
   constructor(options: BroadcastTypedEventBusOptions<EVENT>) {
     this.delegate = options.delegate;
     this.type = this.delegate.type;
+    this.messageTransformer = options.messageTransformer;
     const messenger =
       options.messenger ?? createCrossTabMessenger(`_broadcast_:${this.type}`);
     if (!messenger) {
       throw new Error('Messenger setup failed');
     }
     this.messenger = messenger;
-    this.messenger.onmessage = async (event: EVENT) => {
-      await this.delegate.emit(event);
+    this.messenger.onmessage = async (message: unknown) => {
+      try {
+        const event = this.messageTransformer
+          ? this.messageTransformer.deserialize(message)
+          : (message as EVENT);
+        await this.delegate.emit(event);
+      } catch (error) {
+        console.warn(`Broadcast message error for ${this.type}:`, error);
+      }
     };
   }
 
@@ -160,8 +179,22 @@ export class BroadcastTypedEventBus<EVENT> implements TypedEventBus<EVENT> {
    * @throws Propagates any errors from local event processing
    */
   async emit(event: EVENT): Promise<void> {
+    const transformer = this.messageTransformer;
+    const beforeDispatch = transformer?.serializeBeforeDispatch === true;
+    const preparedMessage =
+      transformer && beforeDispatch ? transformer.serialize(event) : undefined;
     await this.delegate.emit(event);
-    this.messenger.postMessage(event);
+    const message = beforeDispatch
+      ? preparedMessage
+      : transformer
+        ? transformer.serialize(event)
+        : event;
+    try {
+      this.messenger.postMessage(message);
+    } catch (error) {
+      if (!transformer?.fallbackSerialize) throw error;
+      this.messenger.postMessage(transformer.fallbackSerialize(message, error));
+    }
   }
 
   /**

--- a/packages/eventbus/test/broadcastTypedEventBus.inbound.test.ts
+++ b/packages/eventbus/test/broadcastTypedEventBus.inbound.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { expect, it, vi } from 'vitest';
+import {
+  BroadcastChannelMessenger,
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+  StorageMessenger,
+} from '../src';
+
+it.each(['broadcast', 'storage'] as const)(
+  'reports invalid incoming messages and keeps receiving through the real %s messenger',
+  async kind => {
+    const channelName = `inbound-${randomUUID()}`;
+    const createMessenger = () =>
+      kind === 'broadcast'
+        ? new BroadcastChannelMessenger(channelName)
+        : new StorageMessenger({ channelName });
+    const sender = createMessenger();
+    const bus = new BroadcastTypedEventBus<{ count: bigint }>({
+      delegate: new SerialTypedEventBus(channelName),
+      messenger: createMessenger(),
+      messageTransformer: {
+        serialize: event => ({ count: String(event.count) }),
+        deserialize: message => ({
+          count: BigInt((message as { count: string }).count),
+        }),
+      },
+    });
+    const received: { count: bigint }[] = [];
+    bus.on({
+      name: 'direct',
+      handle: event => {
+        received.push(event);
+      },
+    });
+    const warnings: unknown[][] = [];
+    const warn = vi.spyOn(console, 'warn').mockImplementation((...args) => {
+      warnings.push(args);
+    });
+    const send = (message: unknown) => {
+      sender.postMessage(message);
+      if (kind === 'storage') {
+        const key = Array.from({ length: localStorage.length }, (_, index) =>
+          localStorage.key(index),
+        ).find(key => key?.startsWith(`_storage_msg_${channelName}_`))!;
+        // Browser storage events originate in the other document.
+        window.dispatchEvent(
+          new StorageEvent('storage', {
+            key,
+            newValue: localStorage.getItem(key),
+            storageArea: localStorage,
+          }),
+        );
+        localStorage.removeItem(key);
+      }
+    };
+    try {
+      send({ count: 'invalid' });
+      await vi.waitFor(() => expect(warnings).toHaveLength(1));
+      expect(warnings[0][0]).toEqual(expect.stringContaining(channelName));
+      expect(warnings[0][1]).toBeInstanceOf(SyntaxError);
+      expect(received).toEqual([]);
+
+      send({ count: '2' });
+      await vi.waitFor(() => expect(received).toEqual([{ count: 2n }]));
+      expect(warnings).toHaveLength(1);
+    } finally {
+      bus.destroy();
+      sender.close();
+      warn.mockRestore();
+    }
+  },
+);

--- a/packages/eventbus/test/broadcastTypedEventBus.test.ts
+++ b/packages/eventbus/test/broadcastTypedEventBus.test.ts
@@ -151,6 +151,55 @@ describe('BroadcastTypedEventBus', () => {
     expect(mockMessenger.close).toHaveBeenCalled();
   });
 
+  it('transforms wire messages while preserving local events and decoded delivery', async () => {
+    const delegate = new SerialTypedEventBus<{ count: bigint }>('transformed');
+    const events: { count: bigint }[] = [];
+    delegate.on({
+      name: 'existing',
+      handle: event => {
+        events.push(event);
+      },
+    });
+    const bus = new BroadcastTypedEventBus({
+      delegate,
+      messenger: mockMessenger,
+      messageTransformer: {
+        serialize: event => ({ count: String(event.count) }),
+        deserialize: message => ({
+          count: BigInt((message as { count: string }).count),
+        }),
+      },
+    });
+    const value = { count: 2n };
+    await bus.emit(value);
+    expect(events[0]).toBe(value);
+    expect(mockMessenger.postMessage).toHaveBeenCalledWith({ count: '2' });
+    await mockMessenger._onmessage({ count: '3' });
+    expect(events[1]).toEqual({ count: 3n });
+    expect(Object.keys(events[1])).toEqual(['count']);
+  });
+
+  it('retains the starting transformer while local delivery is pending', async () => {
+    let finishLocal!: () => void;
+    const local = new Promise<void>(resolve => {
+      finishLocal = resolve;
+    });
+    delegate.on({ name: 'pending', handle: () => local });
+    const bus = new BroadcastTypedEventBus({
+      delegate,
+      messenger: mockMessenger,
+      messageTransformer: {
+        serialize: event => `encoded:${event}`,
+        deserialize: String,
+      },
+    });
+    const emitted = bus.emit('value');
+    bus.messageTransformer = undefined;
+    finishLocal();
+    await emitted;
+    expect(mockMessenger.postMessage).toHaveBeenCalledWith('encoded:value');
+  });
+
   describe('options constructor', () => {
     it('should use custom messenger from options', () => {
       const customMessenger = {

--- a/packages/eventbus/test/messageFallback.test.ts
+++ b/packages/eventbus/test/messageFallback.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect, it, vi } from 'vitest';
+import {
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+  type CrossTabMessageHandler,
+} from '../src';
+
+it('retries a failed messenger post once with its already serialized message', async () => {
+  const failure = new Error('post failed');
+  const postMessage = vi.fn().mockImplementationOnce(() => {
+    throw failure;
+  });
+  const serialize = vi.fn(() => 'wire');
+  const fallbackSerialize = vi.fn(() => 'fallback');
+  const bus = new BroadcastTypedEventBus({
+    delegate: new SerialTypedEventBus<string>('retry'),
+    messenger: {
+      postMessage,
+      close() {},
+      set onmessage(_: CrossTabMessageHandler) {},
+    },
+    messageTransformer: { serialize, fallbackSerialize, deserialize: String },
+  });
+  await bus.emit('original');
+  expect(serialize).toHaveBeenCalledExactlyOnceWith('original');
+  expect(fallbackSerialize).toHaveBeenCalledExactlyOnceWith('wire', failure);
+  expect(postMessage.mock.calls).toEqual([['wire'], ['fallback']]);
+  bus.destroy();
+});
+
+it('does not treat conversion failures as messenger failures or retry a second failure', async () => {
+  const failure = new Error('failed');
+  const postMessage = vi.fn(() => {
+    throw failure;
+  });
+  const fallbackSerialize = vi.fn(() => 'fallback');
+  const serialize = vi.fn<() => string>(() => {
+    throw failure;
+  });
+  const bus = new BroadcastTypedEventBus({
+    delegate: new SerialTypedEventBus<string>('failure'),
+    messenger: {
+      postMessage,
+      close() {},
+      set onmessage(_: CrossTabMessageHandler) {},
+    },
+    messageTransformer: { serialize, fallbackSerialize, deserialize: String },
+  });
+  await expect(bus.emit('original')).rejects.toBe(failure);
+  expect(fallbackSerialize).not.toHaveBeenCalled();
+  expect(postMessage).not.toHaveBeenCalled();
+  serialize.mockImplementation(() => 'wire');
+  await expect(bus.emit('original')).rejects.toBe(failure);
+  expect(postMessage).toHaveBeenCalledTimes(2);
+  expect(fallbackSerialize).toHaveBeenCalledOnce();
+  bus.destroy();
+});
+
+it.each([true, false])(
+  'keeps nested messages independent with early serialization %s',
+  async beforeDispatch => {
+    const order: string[] = [];
+    const bus = new BroadcastTypedEventBus<{ value: number }>({
+      delegate: new SerialTypedEventBus('nested'),
+      messenger: {
+        postMessage(message: { value: number }) {
+          order.push(`post:${message.value}`);
+        },
+        close() {},
+        set onmessage(_: CrossTabMessageHandler) {},
+      },
+      messageTransformer: {
+        ...(beforeDispatch ? { serializeBeforeDispatch: true } : {}),
+        serialize(event) {
+          order.push(`serialize:${event.value}`);
+          return { value: event.value };
+        },
+        deserialize: message => message as { value: number },
+      },
+    });
+    bus.on({
+      name: 'reenter',
+      once: true,
+      async handle(event) {
+        order.push(`local:${event.value}`);
+        event.value = 2;
+        await bus.emit(event);
+        event.value = 3;
+      },
+    });
+    await bus.emit({ value: 1 });
+    expect(order).toEqual(
+      beforeDispatch
+        ? ['serialize:1', 'local:1', 'serialize:2', 'post:2', 'post:1']
+        : ['local:1', 'serialize:2', 'post:2', 'serialize:3', 'post:3'],
+    );
+    bus.destroy();
+  },
+);

--- a/packages/storage/src/keyStorage.ts
+++ b/packages/storage/src/keyStorage.ts
@@ -13,7 +13,11 @@
 
 import type { Serializer } from './serializer';
 import { jsonSerializer } from './serializer';
-import type { EventHandler, TypedEventBus } from '@ahoo-wang/fetcher-eventbus';
+import type {
+  BroadcastTypedEventBus,
+  EventHandler,
+  TypedEventBus,
+} from '@ahoo-wang/fetcher-eventbus';
 import {
   nameGenerator,
   SerialTypedEventBus,
@@ -23,6 +27,134 @@ import { getStorage } from './env';
 export interface StorageEvent<Deserialized> {
   newValue?: Deserialized | null;
   oldValue?: Deserialized | null;
+}
+
+// Kept on the wire so receivers never need to serialize a cloned class instance.
+const SERIALIZED_STORAGE_EVENT = '__fetcher_storage_snapshot__';
+
+type SerializedStorageEvent = StorageEvent<unknown> & {
+  [SERIALIZED_STORAGE_EVENT]: StorageEvent<string>;
+};
+
+type BroadcastStorageState = {
+  key: string;
+  serializer?: object;
+  defaultSerializer?: boolean;
+  transformer?: object;
+  snapshots?: WeakMap<object, SerializedStorageEvent>;
+};
+const BROADCAST_STORAGE_STATES = Symbol.for(
+  '@ahoo-wang/fetcher-storage/broadcast-storage-states',
+);
+const sharedState = globalThis as typeof globalThis & {
+  [BROADCAST_STORAGE_STATES]?: WeakMap<object, BroadcastStorageState>;
+};
+const broadcastStorageStates =
+  sharedState[BROADCAST_STORAGE_STATES] ??
+  new WeakMap<object, BroadcastStorageState>();
+if (!sharedState[BROADCAST_STORAGE_STATES]) {
+  Object.defineProperty(sharedState, BROADCAST_STORAGE_STATES, {
+    value: broadcastStorageStates,
+  });
+}
+
+function deserializeStorageEvent<T>(
+  message: unknown,
+  serializer: Serializer<string, T>,
+): StorageEvent<T> {
+  const snapshot = (message as SerializedStorageEvent)[
+    SERIALIZED_STORAGE_EVENT
+  ];
+  if (!snapshot && !serializer.deserializeLegacy) {
+    return message as StorageEvent<T>;
+  }
+  const event = snapshot ?? (message as StorageEvent<unknown>);
+  const deserialize = (value: unknown): T =>
+    snapshot
+      ? serializer.deserialize(value as string)
+      : serializer.deserializeLegacy!(value);
+  const decoded: StorageEvent<T> = {};
+  if (Object.prototype.hasOwnProperty.call(event, 'newValue')) {
+    const value = event.newValue;
+    decoded.newValue =
+      value === null
+        ? null
+        : value === undefined
+          ? undefined
+          : deserialize(value);
+  }
+  if (Object.prototype.hasOwnProperty.call(event, 'oldValue')) {
+    try {
+      const value = event.oldValue;
+      decoded.oldValue =
+        value === null
+          ? null
+          : value === undefined
+            ? undefined
+            : deserialize(value);
+    } catch {
+      // An unavailable historical value must not discard a valid current value.
+      decoded.oldValue = undefined;
+    }
+  }
+  return decoded;
+}
+
+function serializeStorageEvent<T>(
+  event: StorageEvent<T>,
+  serializer: Serializer<string, T>,
+  serializedNewValue?: string | null,
+): SerializedStorageEvent {
+  const snapshot: StorageEvent<string> = {};
+  const wireEvent: SerializedStorageEvent = {
+    [SERIALIZED_STORAGE_EVENT]: snapshot,
+  };
+  if (Object.prototype.hasOwnProperty.call(event, 'newValue')) {
+    const value = event.newValue;
+    snapshot.newValue =
+      serializedNewValue !== undefined
+        ? serializedNewValue
+        : value === null
+          ? null
+          : value === undefined
+            ? undefined
+            : serializer.serialize(value);
+    wireEvent.newValue = value;
+  }
+  if (Object.prototype.hasOwnProperty.call(event, 'oldValue')) {
+    const value = event.oldValue;
+    try {
+      snapshot.oldValue =
+        value === null
+          ? null
+          : value === undefined
+            ? undefined
+            : serializer.serialize(value);
+    } catch {
+      // An unavailable historical snapshot must not discard the current value.
+      snapshot.oldValue = undefined;
+    }
+    wireEvent.oldValue = value;
+  }
+  Object.defineProperty(wireEvent, 'toJSON', {
+    value: () => {
+      const jsonEvent: SerializedStorageEvent = {
+        [SERIALIZED_STORAGE_EVENT]: snapshot,
+      };
+      for (const name of ['newValue', 'oldValue'] as const) {
+        try {
+          Object.assign(
+            jsonEvent,
+            JSON.parse(JSON.stringify({ [name]: wireEvent[name] })),
+          );
+        } catch {
+          // JSON-incompatible values still travel in the string snapshot.
+        }
+      }
+      return jsonEvent;
+    },
+  });
+  return wireEvent;
 }
 
 /**
@@ -62,7 +194,10 @@ export interface KeyStorageOptions<Deserialized> {
   storage?: Storage;
 
   /**
-   * Optional event bus for cross-tab communication. Defaults to SerialTypedEventBus
+   * Optional event bus for cross-tab communication. Defaults to SerialTypedEventBus.
+   * A shared bus must represent one storage key. An automatic broadcast codec is
+   * bound to the same serializer instance for the bus lifetime, including after destroy().
+   * Caller-configured or replaced codecs remain the caller's responsibility.
    */
   eventBus?: TypedEventBus<StorageEvent<Deserialized>>;
 
@@ -86,6 +221,7 @@ export class KeyStorage<
   public readonly eventBus: TypedEventBus<StorageEvent<Deserialized>>;
   private readonly defaultValue: Deserialized | null = null;
   private cacheValue: Deserialized | null = null;
+  private readonly serializedEvents?: WeakMap<object, SerializedStorageEvent>;
   private readonly keyStorageHandler: EventHandler<StorageEvent<Deserialized>> =
     {
       name: nameGenerator.generate('KeyStorage'),
@@ -107,6 +243,86 @@ export class KeyStorage<
       new SerialTypedEventBus<StorageEvent<Deserialized>>(
         `KeyStorage:${this.key}`,
       );
+    if ('messageTransformer' in this.eventBus) {
+      const bus = this.eventBus as TypedEventBus<StorageEvent<Deserialized>> &
+        Pick<
+          BroadcastTypedEventBus<StorageEvent<Deserialized>>,
+          'messageTransformer'
+        >;
+      let state = broadcastStorageStates.get(bus);
+      if (!state) {
+        state = { key: this.key };
+        if (!bus.messageTransformer) {
+          const snapshots = new WeakMap<object, SerializedStorageEvent>();
+          const serializer = this.serializer;
+          bus.messageTransformer = {
+            serializeBeforeDispatch: true,
+            serialize: (event: StorageEvent<Deserialized>) => {
+              const snapshot = snapshots.get(event);
+              snapshots.delete(event);
+              return snapshot ?? serializeStorageEvent(event, serializer);
+            },
+            deserialize: (message: unknown) =>
+              deserializeStorageEvent(message, serializer),
+            fallbackSerialize: (message: unknown, error: unknown) => {
+              if (
+                typeof error === 'object' &&
+                error !== null &&
+                'name' in error &&
+                error.name === 'DataCloneError' &&
+                typeof message === 'object' &&
+                message !== null &&
+                SERIALIZED_STORAGE_EVENT in message
+              ) {
+                const snapshot = message[SERIALIZED_STORAGE_EVENT];
+                if (
+                  typeof snapshot === 'object' &&
+                  snapshot !== null &&
+                  (Object.prototype.hasOwnProperty.call(snapshot, 'newValue') ||
+                    Object.prototype.hasOwnProperty.call(
+                      snapshot,
+                      'oldValue',
+                    )) &&
+                  (!('newValue' in snapshot) ||
+                    snapshot.newValue == null ||
+                    typeof snapshot.newValue === 'string') &&
+                  (!('oldValue' in snapshot) ||
+                    snapshot.oldValue == null ||
+                    typeof snapshot.oldValue === 'string')
+                ) {
+                  return { [SERIALIZED_STORAGE_EVENT]: snapshot };
+                }
+              }
+              throw error;
+            },
+          };
+          state.transformer = bus.messageTransformer;
+          state.serializer = serializer;
+          state.defaultSerializer = options.serializer === undefined;
+          state.snapshots = snapshots;
+        }
+        broadcastStorageStates.set(bus, state);
+      }
+      if (state.key !== this.key) {
+        throw new Error(
+          'A shared storage event bus requires the same storage key; create a new bus for another key.',
+        );
+      }
+      if (state.snapshots) {
+        if (options.serializer === undefined && state.defaultSerializer) {
+          this.serializer = state.serializer as Serializer<
+            string,
+            Deserialized
+          >;
+        }
+        if (state.serializer !== this.serializer) {
+          throw new Error(
+            'An automatic storage event bus requires the same serializer instance for its lifetime; create a new bus for another serializer.',
+          );
+        }
+        this.serializedEvents = state.snapshots;
+      }
+    }
     this.defaultValue = options.defaultValue ?? null;
     this.eventBus.on(this.keyStorageHandler);
   }
@@ -185,11 +401,11 @@ export class KeyStorage<
   set(value: Deserialized): void {
     const oldValue = this.get();
     const serialized = this.serializer.serialize(value);
+    const event = this.snapshotEvent({ newValue: value, oldValue }, serialized);
     this.storage.setItem(this.key, serialized);
     this.cacheValue = value;
-    this.eventBus.emit({
-      newValue: value,
-      oldValue: oldValue,
+    this.eventBus.emit(event).catch(error => {
+      console.warn(`Storage event error for ${this.key}:`, error);
     });
   }
 
@@ -207,12 +423,30 @@ export class KeyStorage<
    */
   remove(): void {
     const oldValue = this.get();
+    const event = this.snapshotEvent({ newValue: null, oldValue }, null);
     this.storage.removeItem(this.key);
     this.cacheValue = null;
-    this.eventBus.emit({
-      oldValue: oldValue,
-      newValue: null,
+    this.eventBus.emit(event).catch(error => {
+      console.warn(`Storage event error for ${this.key}:`, error);
     });
+  }
+
+  private snapshotEvent(
+    event: StorageEvent<Deserialized>,
+    serializedNewValue: string | null,
+  ): StorageEvent<Deserialized> {
+    if (
+      !this.serializedEvents ||
+      !('messageTransformer' in this.eventBus) ||
+      this.eventBus.messageTransformer !==
+        broadcastStorageStates.get(this.eventBus)?.transformer
+    )
+      return event;
+    this.serializedEvents.set(
+      event,
+      serializeStorageEvent(event, this.serializer, serializedNewValue),
+    );
+    return event;
   }
 
   /**

--- a/packages/storage/src/serializer.ts
+++ b/packages/storage/src/serializer.ts
@@ -30,6 +30,9 @@ export interface Serializer<Serialized, Deserialized> {
    * @returns The deserialized value
    */
   deserialize(value: Serialized): Deserialized;
+
+  /** Restores a known legacy broadcast value when no serialized snapshot exists. */
+  deserializeLegacy?(value: unknown): Deserialized;
 }
 
 /**

--- a/packages/storage/test/broadcastOwnership.test.ts
+++ b/packages/storage/test/broadcastOwnership.test.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it, vi } from 'vitest';
+import type { CrossTabMessageHandler } from '@ahoo-wang/fetcher-eventbus';
+import {
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+} from '@ahoo-wang/fetcher-eventbus';
+import { InMemoryStorage, KeyStorage, type StorageEvent } from '../src';
+
+class Counter {
+  constructor(public value: number) {}
+  read() {
+    return this.value;
+  }
+}
+const serializer = {
+  serialize: (value: Counter) => String(value.read()),
+  deserialize: (raw: string) => new Counter(Number(raw)),
+};
+function createBus() {
+  const messenger = {
+    onmessage: () => {},
+    postMessage: vi.fn(),
+    close() {},
+  };
+  const bus = new BroadcastTypedEventBus<StorageEvent<Counter>>({
+    delegate: new SerialTypedEventBus('ownership'),
+    messenger,
+  });
+  return { bus, messenger };
+}
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+it('installs a codec for a compatible bus from another evaluated package instance', async () => {
+  vi.resetModules();
+  const other = await import('@ahoo-wang/fetcher-eventbus');
+  const bus = new other.BroadcastTypedEventBus<StorageEvent<Counter>>({
+    delegate: new other.SerialTypedEventBus('other'),
+    messenger: {
+      postMessage() {},
+      set onmessage(_handler: CrossTabMessageHandler) {},
+      close() {},
+    },
+  });
+  expect(bus).not.toBeInstanceOf(BroadcastTypedEventBus);
+  const storage = new KeyStorage({
+    key: 'k',
+    storage: new InMemoryStorage(),
+    eventBus: bus,
+    serializer,
+  });
+  expect(bus.messageTransformer).toBeDefined();
+  storage.destroy();
+  bus.destroy();
+});
+
+it.each([false, true])(
+  'binds a provided bus to one key (caller codec: %s)',
+  callerCodec => {
+    const { bus } = createBus();
+    if (callerCodec)
+      bus.messageTransformer = {
+        serialize: value => value,
+        deserialize: value => value as StorageEvent<Counter>,
+      };
+    const first = new KeyStorage({
+      key: 'a',
+      storage: new InMemoryStorage(),
+      eventBus: bus,
+      serializer,
+    });
+    try {
+      expect(
+        () => new KeyStorage({ key: 'b', eventBus: bus, serializer }),
+      ).toThrow('same storage key');
+      expect(bus.handlers).toHaveLength(1);
+    } finally {
+      first.destroy();
+      bus.destroy();
+    }
+  },
+);
+
+it('rejects a distinct serializer object even while the first owner is active', () => {
+  const { bus } = createBus();
+  const first = new KeyStorage({ key: 'k', eventBus: bus, serializer });
+  try {
+    expect(
+      () =>
+        new KeyStorage({
+          key: 'k',
+          eventBus: bus,
+          serializer: { ...serializer },
+        }),
+    ).toThrow('same serializer instance');
+  } finally {
+    first.destroy();
+    bus.destroy();
+  }
+});
+
+it.each(['clear', 'replace'] as const)(
+  'does not automatically reacquire a caller-%s codec',
+  async change => {
+    const { bus, messenger } = createBus();
+    const backing = new InMemoryStorage();
+    const first = new KeyStorage({
+      key: 'k',
+      storage: backing,
+      eventBus: bus,
+      serializer,
+    });
+    const original = bus.messageTransformer;
+    const replacement =
+      change === 'clear'
+        ? undefined
+        : {
+            serialize: (event: StorageEvent<Counter>) => [
+              'caller',
+              event.newValue?.read(),
+            ],
+            deserialize: (event: unknown) => event as StorageEvent<Counter>,
+          };
+    bus.messageTransformer = replacement;
+    const second = new KeyStorage({
+      key: 'k',
+      storage: backing,
+      eventBus: bus,
+      serializer,
+    });
+    try {
+      expect(bus.messageTransformer).toBe(replacement);
+      bus.messageTransformer = original;
+      first.set(new Counter(1));
+      await flush();
+      second.set(new Counter(2));
+      await flush();
+      expect(
+        messenger.postMessage.mock.calls.map(
+          ([event]) => event.__fetcher_storage_snapshot__.newValue,
+        ),
+      ).toEqual(['1', '2']);
+    } finally {
+      first.destroy();
+      second.destroy();
+      bus.destroy();
+    }
+  },
+);
+
+it('does not take over a cleared caller-preconfigured codec', () => {
+  const { bus } = createBus();
+  bus.messageTransformer = {
+    serialize: value => value,
+    deserialize: value => value as StorageEvent<Counter>,
+  };
+  const first = new KeyStorage({ key: 'k', eventBus: bus, serializer });
+  bus.messageTransformer = undefined;
+  const second = new KeyStorage({ key: 'k', eventBus: bus, serializer });
+  expect(bus.messageTransformer).toBeUndefined();
+  first.destroy();
+  second.destroy();
+  bus.destroy();
+});
+
+it('encodes current fields when a retained event is dispatched again', async () => {
+  const { bus, messenger } = createBus();
+  const storage = new KeyStorage({
+    key: 'k',
+    eventBus: bus,
+    storage: new InMemoryStorage(),
+    serializer,
+  });
+  let retained: StorageEvent<Counter> | undefined;
+  storage.addListener({
+    name: 'retain',
+    handle: event => {
+      retained = event;
+    },
+  });
+  try {
+    storage.set(new Counter(1));
+    await flush();
+    const event = retained!;
+    event.newValue = new Counter(2);
+    await bus.emit(event);
+    expect(messenger.postMessage.mock.calls[0][0]).toHaveProperty(
+      '__fetcher_storage_snapshot__',
+    );
+    expect(
+      messenger.postMessage.mock.calls[1][0].__fetcher_storage_snapshot__
+        .newValue,
+    ).toBe('2');
+    expect(messenger.postMessage.mock.calls[1][0].newValue.read()).toBe(2);
+  } finally {
+    storage.destroy();
+    bus.destroy();
+  }
+});
+
+it('falls back only for DataCloneError with a complete serialized snapshot', () => {
+  const { bus } = createBus();
+  const storage = new KeyStorage({ key: 'k', eventBus: bus, serializer });
+  const fallback = bus.messageTransformer!.fallbackSerialize!;
+  const error = new DOMException('Uncloneable value', 'DataCloneError');
+  const snapshot = { newValue: '2', oldValue: '1' };
+  try {
+    expect(
+      fallback(
+        { newValue: () => 2, __fetcher_storage_snapshot__: snapshot },
+        error,
+      ),
+    ).toEqual({ __fetcher_storage_snapshot__: snapshot });
+    const oldOnly = { newValue: undefined, oldValue: '1' };
+    expect(fallback({ __fetcher_storage_snapshot__: oldOnly }, error)).toEqual({
+      __fetcher_storage_snapshot__: oldOnly,
+    });
+    for (const event of [
+      { newValue: () => 2 },
+      { __fetcher_storage_snapshot__: {} },
+      { __fetcher_storage_snapshot__: { newValue: 2 } },
+    ]) {
+      expect(() => fallback(event, error)).toThrow(error);
+    }
+    const transportFailure = new Error('Transport closed');
+    expect(() =>
+      fallback({ __fetcher_storage_snapshot__: snapshot }, transportFailure),
+    ).toThrow(transportFailure);
+  } finally {
+    storage.destroy();
+    bus.destroy();
+  }
+});

--- a/packages/storage/test/crossTabSerialization.test.ts
+++ b/packages/storage/test/crossTabSerialization.test.ts
@@ -1,0 +1,883 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { expect, it, vi } from 'vitest';
+import type { CrossTabMessageHandler } from '@ahoo-wang/fetcher-eventbus';
+import {
+  BroadcastChannelMessenger,
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+} from '@ahoo-wang/fetcher-eventbus';
+import {
+  InMemoryStorage,
+  KeyStorage,
+  type Serializer,
+  type StorageEvent,
+} from '../src';
+
+class Counter {
+  constructor(private readonly value: number) {}
+  read() {
+    return this.value;
+  }
+}
+const serializer: Serializer<string, Counter> = {
+  serialize(value: Counter) {
+    return String(value.read());
+  },
+  deserialize(value: string) {
+    return new Counter(Number(value));
+  },
+};
+
+function nextEvent(storage: KeyStorage<Counter>) {
+  return new Promise<StorageEvent<Counter>>(resolve => {
+    storage.addListener({ name: randomUUID(), once: true, handle: resolve });
+  });
+}
+
+it('decodes an already posted message for direct subscribers after the last storage owner is destroyed', async () => {
+  const key = randomUUID();
+  const backing = new InMemoryStorage();
+  backing.setItem(key, '1');
+  const senderMessenger = new BroadcastChannelMessenger(key);
+  const create = (messenger = new BroadcastChannelMessenger(key)) => {
+    const bus = new BroadcastTypedEventBus<StorageEvent<bigint>>({
+      delegate: new SerialTypedEventBus(key),
+      messenger,
+    });
+    const storage = new KeyStorage({
+      key,
+      storage: backing,
+      serializer: { serialize: String, deserialize: BigInt },
+      eventBus: bus,
+    });
+    return { storage, bus };
+  };
+  const sender = create(senderMessenger);
+  const receiver = create();
+  const received = new Promise<StorageEvent<bigint>>(resolve => {
+    receiver.bus.on({ name: 'direct', once: true, handle: resolve });
+  });
+  const post = senderMessenger.postMessage.bind(senderMessenger);
+  const posted = vi
+    .spyOn(senderMessenger, 'postMessage')
+    .mockImplementation(message => {
+      post(message);
+      receiver.storage.destroy();
+    });
+  try {
+    sender.storage.set(2n);
+    expect(await received).toEqual({ newValue: 2n, oldValue: 1n });
+  } finally {
+    posted.mockRestore();
+    sender.storage.destroy();
+    receiver.storage.destroy();
+    sender.bus.destroy();
+    receiver.bus.destroy();
+  }
+});
+
+it('shares snapshots and keeps conversion after the final storage owner is destroyed', async () => {
+  const key = randomUUID();
+  const backing = new InMemoryStorage();
+  backing.setItem(key, '1');
+  const bus = new BroadcastTypedEventBus<StorageEvent<Counter>>({
+    delegate: new SerialTypedEventBus(key),
+  });
+  const first = new KeyStorage({
+    key,
+    storage: backing,
+    serializer,
+    eventBus: bus,
+  });
+  const second = new KeyStorage({
+    key,
+    storage: backing,
+    serializer,
+    eventBus: bus,
+  });
+  const receiver = new KeyStorage({
+    key,
+    storage: backing,
+    serializer,
+    eventBus: new BroadcastTypedEventBus<StorageEvent<Counter>>({
+      delegate: new SerialTypedEventBus(key),
+    }),
+  });
+  const transformer = bus.messageTransformer;
+  try {
+    const changed = nextEvent(receiver);
+    second.set(new Counter(2));
+    const event = await changed;
+    expect(event.newValue).toBeInstanceOf(Counter);
+    expect(event.newValue?.read()).toBe(2);
+    first.destroy();
+    first.destroy();
+    expect(bus.messageTransformer).toBeDefined();
+    const removed = nextEvent(receiver);
+    second.remove();
+    const removal = await removed;
+    expect(removal.newValue).toBeNull();
+    expect(removal.oldValue).toBeInstanceOf(Counter);
+    expect(removal.oldValue?.read()).toBe(2);
+    second.destroy();
+    expect(bus.messageTransformer).toBe(transformer);
+  } finally {
+    first.destroy();
+    second.destroy();
+    receiver.destroy();
+    bus.destroy();
+    receiver.eventBus.destroy();
+  }
+});
+
+it('rejects a new serializer on an idle bus without losing pending messages', async () => {
+  const key = randomUUID();
+  const backing = new InMemoryStorage();
+  const bus = new BroadcastTypedEventBus<StorageEvent<Counter>>({
+    delegate: new SerialTypedEventBus(key),
+  });
+  const first = new KeyStorage({
+    key,
+    storage: backing,
+    eventBus: bus,
+    serializer,
+  });
+  const sender = new BroadcastChannelMessenger(`_broadcast_:${key}`);
+  const received = new Promise<StorageEvent<Counter>>(resolve => {
+    bus.on({ name: 'direct', once: true, handle: resolve });
+  });
+  try {
+    sender.postMessage({
+      __fetcher_storage_snapshot__: { newValue: '2', oldValue: '1' },
+    });
+    first.destroy();
+    expect(
+      () =>
+        new KeyStorage({
+          key,
+          storage: backing,
+          eventBus: bus,
+          serializer: {
+            serialize: (value: Counter) => `v2:${value.read()}`,
+            deserialize: (raw: string) => {
+              if (!raw.startsWith('v2:'))
+                throw new Error('Expected v2 counter');
+              return new Counter(Number(raw.slice(3)));
+            },
+          },
+        }),
+    ).toThrow('same serializer instance');
+    const event = await received;
+    expect(event.newValue?.read()).toBe(2);
+    expect(event.oldValue?.read()).toBe(1);
+  } finally {
+    first.destroy();
+    sender.close();
+    bus.destroy();
+  }
+});
+
+it.each(['set', 'remove'] as const)(
+  'finishes an in-flight %s after the storage owner is destroyed',
+  async operation => {
+    const key = randomUUID();
+    const backing = new InMemoryStorage();
+    backing.setItem(key, '1');
+    const create = () =>
+      new KeyStorage({
+        key,
+        storage: backing,
+        serializer,
+        eventBus: new BroadcastTypedEventBus<StorageEvent<Counter>>({
+          delegate: new SerialTypedEventBus(key),
+        }),
+      });
+    const sender = create();
+    const receiver = create();
+    try {
+      const received = nextEvent(receiver);
+      if (operation === 'set') sender.set(new Counter(2));
+      else sender.remove();
+      sender.destroy();
+      const event = await received;
+      expect(event.oldValue).toBeInstanceOf(Counter);
+      expect(event.oldValue?.read()).toBe(1);
+      if (operation === 'set') {
+        expect(event.newValue).toBeInstanceOf(Counter);
+        expect(event.newValue?.read()).toBe(2);
+      } else expect(event.newValue).toBeNull();
+    } finally {
+      sender.destroy();
+      receiver.destroy();
+      sender.eventBus.destroy();
+      receiver.eventBus.destroy();
+    }
+  },
+);
+
+it.each([
+  [null, 7, 9],
+  [undefined, 7, 9],
+  [undefined, null, 9],
+  [null, { count: 7 }, { count: 9 }],
+  [undefined, { count: 7 }, { count: 9 }],
+])(
+  'keeps JSON events readable by new and legacy receivers (missing: %s, default: %j)',
+  async (missing, defaultValue, value) => {
+    const key = randomUUID();
+    const backing = new InMemoryStorage();
+    const getItem = backing.getItem.bind(backing);
+    Object.defineProperty(backing, 'getItem', {
+      value: (name: string) => getItem(name) ?? missing,
+    });
+    const create = () =>
+      new KeyStorage({
+        key,
+        storage: backing,
+        defaultValue,
+        eventBus: new BroadcastTypedEventBus<StorageEvent<unknown>>({
+          delegate: new SerialTypedEventBus(key),
+        }),
+      });
+    const sender = create();
+    const receiver = create();
+    // A legacy receiver has no snapshot transformer and reads the standard fields directly.
+    const legacy = new BroadcastTypedEventBus<StorageEvent<unknown>>({
+      delegate: new SerialTypedEventBus(key),
+    });
+    let legacyCache: unknown = defaultValue;
+    const legacyReceived = new Promise<StorageEvent<unknown>>(resolve => {
+      legacy.on({
+        name: 'legacy-cache',
+        once: true,
+        handle: event => {
+          legacyCache = event.newValue ?? null;
+          resolve(event);
+        },
+      });
+    });
+    const received = new Promise<StorageEvent<unknown>>(resolve => {
+      receiver.addListener({
+        name: 'new-receiver',
+        once: true,
+        handle: resolve,
+      });
+    });
+    try {
+      sender.set(value);
+      const [event, oldProtocolEvent] = await Promise.all([
+        received,
+        legacyReceived,
+      ]);
+      expect(event).toEqual({ newValue: value, oldValue: defaultValue });
+      expect(receiver.get()).toEqual(value);
+      expect(legacyCache).toEqual(value);
+      expect(oldProtocolEvent.newValue).toEqual(value);
+      expect(oldProtocolEvent.oldValue).toEqual(defaultValue);
+    } finally {
+      sender.destroy();
+      receiver.destroy();
+      sender.eventBus.destroy();
+      receiver.eventBus.destroy();
+      legacy.destroy();
+    }
+  },
+);
+
+it('preserves and uses a caller transformer during storage use and after destroy', async () => {
+  const key = randomUUID();
+  const backing = new InMemoryStorage();
+  backing.setItem(key, '1');
+  const serializedEvents: StorageEvent<Counter>[] = [];
+  const transformer = {
+    serialize(event: StorageEvent<Counter>) {
+      serializedEvents.push(event);
+      return JSON.stringify([event.newValue?.read(), event.oldValue?.read()]);
+    },
+    deserialize(message: unknown): StorageEvent<Counter> {
+      const [newValue, oldValue] = JSON.parse(String(message));
+      return {
+        newValue: new Counter(newValue),
+        oldValue: new Counter(oldValue),
+      };
+    },
+  };
+  const create = () => {
+    const bus = new BroadcastTypedEventBus<StorageEvent<Counter>>({
+      delegate: new SerialTypedEventBus(key),
+      messageTransformer: transformer,
+    });
+    const storage = new KeyStorage({
+      key,
+      storage: backing,
+      serializer,
+      eventBus: bus,
+    });
+    return { bus, storage };
+  };
+  const sender = create();
+  const receiver = create();
+  try {
+    const value = new Counter(2);
+    const received = nextEvent(receiver.storage);
+    sender.storage.set(value);
+    const event = await received;
+    expect(serializedEvents).toHaveLength(1);
+    expect(serializedEvents[0].newValue).toBe(value);
+    expect(Object.keys(serializedEvents[0]).sort()).toEqual([
+      'newValue',
+      'oldValue',
+    ]);
+    expect(event.newValue?.read()).toBe(2);
+    expect(event.oldValue?.read()).toBe(1);
+    for (const side of [sender, receiver]) {
+      expect(side.bus.messageTransformer).toBe(transformer);
+      side.storage.destroy();
+      expect(side.bus.messageTransformer).toBe(transformer);
+    }
+  } finally {
+    sender.storage.destroy();
+    receiver.storage.destroy();
+    sender.bus.destroy();
+    receiver.bus.destroy();
+  }
+});
+
+it.each([false, true])(
+  'retains the automatic transformer and preserves a caller replacement on destroy (replaced: %s)',
+  replaced => {
+    const bus = new BroadcastTypedEventBus<StorageEvent<number>>({
+      delegate: new SerialTypedEventBus(randomUUID()),
+    });
+    const storage = new KeyStorage({
+      key: 'owned-transformer',
+      storage: new InMemoryStorage(),
+      eventBus: bus,
+    });
+    const replacement = {
+      serialize: (event: StorageEvent<number>) => JSON.stringify(event),
+      deserialize: (message: unknown): StorageEvent<number> =>
+        JSON.parse(String(message)),
+    };
+    try {
+      const transformer = bus.messageTransformer;
+      expect(transformer).toBeDefined();
+      if (replaced) bus.messageTransformer = replacement;
+      storage.destroy();
+      expect(bus.messageTransformer).toBe(replaced ? replacement : transformer);
+      if (replaced) {
+        const next = new KeyStorage({
+          key: 'owned-transformer',
+          storage: new InMemoryStorage(),
+          eventBus: bus,
+        });
+        try {
+          expect(bus.messageTransformer).toBe(replacement);
+        } finally {
+          next.destroy();
+        }
+      }
+    } finally {
+      storage.destroy();
+      bus.destroy();
+    }
+  },
+);
+
+it.each([false, true])(
+  'keeps subscriptions on the supplied bus before and after construction (broadcast: %s)',
+  async broadcast => {
+    const key = randomUUID();
+    const backing = new InMemoryStorage();
+    backing.setItem(key, '1');
+    const create = () => {
+      const bus = broadcast
+        ? new BroadcastTypedEventBus<StorageEvent<Counter>>({
+            delegate: new SerialTypedEventBus(key),
+          })
+        : new SerialTypedEventBus<StorageEvent<Counter>>(key);
+      const events: StorageEvent<Counter>[] = [];
+      bus.on({
+        name: 'before-construction',
+        order: -5,
+        handle: event => {
+          events.push(event);
+        },
+      });
+      const storage = new KeyStorage({
+        key,
+        storage: backing,
+        serializer,
+        eventBus: bus,
+      });
+      bus.on({
+        name: 'after-construction',
+        handle: event => {
+          events.push(event);
+        },
+      });
+      storage.addListener({
+        name: 'storage-listener',
+        handle: event => {
+          events.push(event);
+        },
+      });
+      return { bus, storage, events };
+    };
+    const sender = create();
+    const receiver = broadcast ? create() : sender;
+    const received = nextEvent(receiver.storage);
+    try {
+      const value = new Counter(2);
+      sender.storage.set(value);
+      await received;
+      expect(sender.events[0].newValue).toBe(value);
+      for (const side of new Set([sender, receiver])) {
+        expect(side.events).toHaveLength(3);
+        for (const event of side.events) {
+          expect(Object.keys(event).sort()).toEqual(['newValue', 'oldValue']);
+          expect({ ...event }).toEqual({
+            newValue: new Counter(2),
+            oldValue: new Counter(1),
+          });
+          expect(JSON.parse(JSON.stringify(event))).toEqual({
+            newValue: { value: 2 },
+            oldValue: { value: 1 },
+          });
+          expect(event.newValue).toBe(side.events[0].newValue);
+        }
+      }
+    } finally {
+      for (const side of new Set([sender, receiver])) {
+        side.storage.destroy();
+        side.bus.destroy();
+      }
+    }
+  },
+);
+
+it('keeps the cached old value when backing storage becomes unreadable', async () => {
+  const key = randomUUID();
+  const backing = new InMemoryStorage();
+  backing.setItem(key, '1');
+  const strictSerializer: Serializer<string, Counter> = {
+    serialize: serializer.serialize,
+    deserialize(raw) {
+      if (!/^\d+$/.test(raw)) throw new Error('Invalid stored counter');
+      return new Counter(Number(raw));
+    },
+  };
+  const create = () =>
+    new KeyStorage({
+      key,
+      storage: backing,
+      serializer: strictSerializer,
+      eventBus: new BroadcastTypedEventBus<StorageEvent<Counter>>({
+        delegate: new SerialTypedEventBus(key),
+      }),
+    });
+  const sender = create();
+  const receiver = create();
+  const events: StorageEvent<Counter>[] = [];
+  receiver.addListener({
+    name: 'valid-new-value',
+    handle: event => {
+      events.push(event);
+    },
+  });
+  try {
+    expect(sender.get()?.read()).toBe(1);
+    expect(receiver.get()?.read()).toBe(1);
+    backing.setItem(key, 'unreadable');
+    const received = nextEvent(receiver);
+    sender.set(new Counter(2));
+    await received;
+    expect(receiver.get()?.read()).toBe(2);
+    expect(events).toHaveLength(1);
+    expect(events[0].newValue?.read()).toBe(2);
+    expect(events[0].oldValue?.read()).toBe(1);
+  } finally {
+    sender.destroy();
+    receiver.destroy();
+    sender.eventBus.destroy();
+    receiver.eventBus.destroy();
+  }
+});
+
+it('reports an invalid new snapshot without changing the cache', async () => {
+  let receive!: (message: unknown) => void;
+  const bus = new BroadcastTypedEventBus<StorageEvent<Counter>>({
+    delegate: new SerialTypedEventBus('invalid-new'),
+    messenger: {
+      postMessage() {},
+      set onmessage(handler: CrossTabMessageHandler) {
+        receive = handler;
+      },
+      close() {},
+    },
+  });
+  const backing = new InMemoryStorage();
+  backing.setItem('invalid-new', '1');
+  const storage = new KeyStorage({
+    key: 'invalid-new',
+    storage: backing,
+    eventBus: bus,
+    serializer: {
+      serialize: serializer.serialize,
+      deserialize(raw: string) {
+        if (!/^\d+$/.test(raw)) throw new Error('Invalid current counter');
+        return new Counter(Number(raw));
+      },
+    },
+  });
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    expect(storage.get()?.read()).toBe(1);
+    await receive({
+      __fetcher_storage_snapshot__: { newValue: 'invalid', oldValue: '1' },
+    });
+    expect(warn).toHaveBeenCalledWith(
+      'Broadcast message error for invalid-new:',
+      new Error('Invalid current counter'),
+    );
+    expect(storage.get()?.read()).toBe(1);
+  } finally {
+    storage.destroy();
+    bus.destroy();
+    warn.mockRestore();
+  }
+});
+
+it('restores custom class semantics in cross-tab caches and both listener values', async () => {
+  const key = randomUUID();
+  const storage = new InMemoryStorage();
+  storage.setItem(key, '1');
+  const createStorage = () =>
+    new KeyStorage<Counter>({
+      key,
+      storage,
+      serializer,
+      eventBus: new BroadcastTypedEventBus({
+        delegate: new SerialTypedEventBus(key),
+      }),
+    });
+  const a = createStorage();
+  const b = createStorage();
+  const localEvents: StorageEvent<Counter>[] = [];
+  a.addListener({
+    name: 'local',
+    handle: event => {
+      localEvents.push(event);
+    },
+  });
+  try {
+    const initial = a.get();
+    const value = new Counter(2);
+    const received = nextEvent(b);
+    a.set(value);
+    const event = await received;
+    expect(
+      [event.newValue, event.oldValue].map(value => value?.constructor),
+    ).toEqual([Counter, Counter]);
+    expect(event.newValue?.read()).toBe(2);
+    expect(event.oldValue?.read()).toBe(1);
+    expect(b.get()).toBe(event.newValue);
+    expect(a.get()).toBe(value);
+    expect(localEvents[0]).toEqual({ newValue: value, oldValue: initial });
+    expect(localEvents[0].newValue).toBe(value);
+    expect(Object.keys(event).sort()).toEqual(['newValue', 'oldValue']);
+
+    const changedBack = nextEvent(a);
+    b.set(new Counter(3));
+    const back = await changedBack;
+    expect(back.oldValue?.read()).toBe(2);
+    expect(back.newValue?.read()).toBe(3);
+    expect(a.get()?.read()).toBe(3);
+
+    const removed = nextEvent(b);
+    a.remove();
+    const removal = await removed;
+    expect(removal.newValue).toBeNull();
+    expect(removal.oldValue?.read()).toBe(3);
+    expect(b.get()).toBeNull();
+  } finally {
+    a.destroy();
+    b.destroy();
+    a.eventBus.destroy();
+    b.eventBus.destroy();
+  }
+});
+
+it('continues accepting ordinary events from a custom local bus', async () => {
+  const bus = new SerialTypedEventBus<StorageEvent<Counter>>('local');
+  const storage = new KeyStorage({
+    key: 'local',
+    storage: new InMemoryStorage(),
+    serializer,
+    eventBus: bus,
+  });
+  const value = new Counter(4);
+  const changed = nextEvent(storage);
+  await bus.emit({ newValue: value, oldValue: null });
+  expect(await changed).toEqual({ newValue: value, oldValue: null });
+  expect(storage.get()).toBe(value);
+  storage.destroy();
+  bus.destroy();
+});
+
+it('preserves class listener names and removal when wrapping event delivery', async () => {
+  const bus = new SerialTypedEventBus<StorageEvent<Counter>>('listener');
+  const storage = new KeyStorage({
+    key: 'listener',
+    storage: new InMemoryStorage(),
+    serializer,
+    eventBus: bus,
+  });
+  class Listener {
+    values: number[] = [];
+    get name() {
+      return 'class-listener';
+    }
+    handle(event: StorageEvent<Counter>) {
+      this.values.push(event.newValue!.read());
+    }
+  }
+  const listener = new Listener();
+  const remove = storage.addListener(listener);
+  await bus.emit({ newValue: new Counter(1) });
+  remove();
+  await bus.emit({ newValue: new Counter(2) });
+  expect(listener.values).toEqual([1]);
+  storage.destroy();
+  bus.destroy();
+});
+
+it.each([
+  ['set', true],
+  ['remove', true],
+  ['set', false],
+  ['remove', false],
+] as const)(
+  'can %s a readable legacy value that cannot be reserialized (stored: %s)',
+  async (operation, stored) => {
+    const underlying = new InMemoryStorage();
+    if (stored) underlying.setItem('legacy', 'legacy:1');
+    const storage = new KeyStorage<string | number>({
+      key: 'legacy',
+      storage: underlying,
+      defaultValue: 'legacy:1',
+      serializer: {
+        serialize(value) {
+          if (typeof value === 'string') throw new Error('legacy is read-only');
+          return String(value);
+        },
+        deserialize(value) {
+          return value.startsWith('legacy:') ? value : Number(value);
+        },
+      },
+    });
+    const received = new Promise<StorageEvent<string | number>>(resolve => {
+      storage.addListener({
+        name: 'legacy-update',
+        once: true,
+        handle: resolve,
+      });
+    });
+    try {
+      expect(storage.get()).toBe('legacy:1');
+      expect(() =>
+        operation === 'set' ? storage.set(2) : storage.remove(),
+      ).not.toThrow();
+      expect(underlying.getItem('legacy')).toBe(
+        operation === 'set' ? '2' : null,
+      );
+      expect(await received).toEqual({
+        oldValue: 'legacy:1',
+        newValue: operation === 'set' ? 2 : null,
+      });
+    } finally {
+      storage.destroy();
+      storage.eventBus.destroy();
+    }
+  },
+);
+
+it.each(['set', 'remove'] as const)(
+  'can %s a cached value when only backing reads fail',
+  async operation => {
+    const underlying = new InMemoryStorage();
+    underlying.setItem('cached', '1');
+    const readStored = underlying.getItem.bind(underlying);
+    const storage = new KeyStorage<Counter>({
+      key: 'cached',
+      storage: underlying,
+      serializer,
+    });
+    const uncached = new KeyStorage<Counter>({
+      key: 'cached',
+      storage: underlying,
+      serializer,
+    });
+    const oldValue = storage.get();
+    underlying.getItem = () => {
+      throw new Error('backing reads unavailable');
+    };
+    const received = nextEvent(storage);
+    const value = new Counter(2);
+    try {
+      expect(storage.get()).toBe(oldValue);
+      expect(() =>
+        operation === 'set' ? storage.set(value) : storage.remove(),
+      ).not.toThrow();
+      expect(readStored('cached')).toBe(operation === 'set' ? '2' : null);
+      const event = await received;
+      expect(event.oldValue).toBe(oldValue);
+      expect(event.newValue).toBe(operation === 'set' ? value : null);
+      expect(() => uncached.get()).toThrow('backing reads unavailable');
+    } finally {
+      storage.destroy();
+      storage.eventBus.destroy();
+      uncached.destroy();
+      uncached.eventBus.destroy();
+    }
+  },
+);
+
+it('gives direct subscribers standard enumerable local and remote events', async () => {
+  const key = randomUUID();
+  const underlying = new InMemoryStorage();
+  underlying.setItem(key, '1');
+  const create = () =>
+    new KeyStorage<Counter>({
+      key,
+      storage: underlying,
+      serializer,
+      eventBus: new BroadcastTypedEventBus({
+        delegate: new SerialTypedEventBus(key),
+      }),
+    });
+  const sender = create();
+  const receiver = create();
+  const direct = new Promise<StorageEvent<Counter>>(resolve => {
+    receiver.eventBus.on({
+      name: 'direct',
+      order: -1,
+      once: true,
+      handle: resolve,
+    });
+  });
+  const local = new Promise<StorageEvent<Counter>>(resolve => {
+    sender.eventBus.on({ name: 'local-direct', once: true, handle: resolve });
+  });
+  try {
+    const value = new Counter(2);
+    sender.set(value);
+    const [event, localEvent] = await Promise.all([direct, local]);
+    expect(event.newValue?.read()).toBe(2);
+    expect(event.oldValue?.read()).toBe(1);
+    expect(localEvent.newValue).toBe(value);
+    for (const observed of [event, localEvent]) {
+      expect(Object.keys(observed).sort()).toEqual(['newValue', 'oldValue']);
+      expect({ ...observed }).toEqual({
+        newValue: new Counter(2),
+        oldValue: new Counter(1),
+      });
+      expect(JSON.parse(JSON.stringify(observed))).toEqual({
+        newValue: { value: 2 },
+        oldValue: { value: 1 },
+      });
+    }
+  } finally {
+    sender.destroy();
+    receiver.destroy();
+    sender.eventBus.destroy();
+    receiver.eventBus.destroy();
+  }
+});
+
+it('transfers the sender default as the old value when storage is empty', async () => {
+  const key = randomUUID();
+  const underlying = new InMemoryStorage();
+  const create = (defaultValue: number) =>
+    new KeyStorage<number>({
+      key,
+      storage: underlying,
+      defaultValue,
+      eventBus: new BroadcastTypedEventBus({
+        delegate: new SerialTypedEventBus(key),
+      }),
+    });
+  const sender = create(7);
+  const receiver = create(99);
+  const received = new Promise<StorageEvent<number>>(resolve => {
+    receiver.addListener({ name: 'default', once: true, handle: resolve });
+  });
+  try {
+    sender.set(9);
+    expect(await received).toEqual({ oldValue: 7, newValue: 9 });
+  } finally {
+    sender.destroy();
+    receiver.destroy();
+    sender.eventBus.destroy();
+    receiver.eventBus.destroy();
+  }
+});
+
+it('preserves class snapshots for both dispatches when a once listener immediately re-emits the event', async () => {
+  const key = randomUUID();
+  const backing = new InMemoryStorage();
+  const create = () =>
+    new KeyStorage({
+      key,
+      storage: backing,
+      serializer,
+      eventBus: new BroadcastTypedEventBus<StorageEvent<Counter>>({
+        delegate: new SerialTypedEventBus(key),
+      }),
+    });
+  const sender = create();
+  const receiver = create();
+  sender.addListener({
+    name: 'forward-once',
+    once: true,
+    handle: event => sender.eventBus.emit(event),
+  });
+  const events: StorageEvent<Counter>[] = [];
+  const received = new Promise<void>(resolve => {
+    receiver.addListener({
+      name: 'receive-both',
+      handle: event => {
+        events.push(event);
+        if (events.length === 2) resolve();
+      },
+    });
+  });
+  try {
+    sender.set(new Counter(2));
+    await received;
+    expect(events).toHaveLength(2);
+    for (const event of events) {
+      expect(event.newValue).toBeInstanceOf(Counter);
+      expect(event.newValue?.read()).toBe(2);
+    }
+    expect(receiver.get()).toBeInstanceOf(Counter);
+  } finally {
+    sender.destroy();
+    receiver.destroy();
+    sender.eventBus.destroy();
+    receiver.eventBus.destroy();
+  }
+});

--- a/packages/storage/test/dispatchConsistency.test.ts
+++ b/packages/storage/test/dispatchConsistency.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+} from '@ahoo-wang/fetcher-eventbus';
+import { InMemoryStorage, KeyStorage, type StorageEvent } from '../src';
+
+const cleanup: (() => void)[] = [];
+afterEach(() => {
+  for (const close of cleanup.splice(0)) close();
+});
+
+function pair() {
+  const channel = `storage-dispatch-${crypto.randomUUID()}`;
+  const backing = new InMemoryStorage();
+  const buses = [0, 1].map(
+    () =>
+      new BroadcastTypedEventBus<StorageEvent<number>>({
+        delegate: new SerialTypedEventBus(channel),
+      }),
+  );
+  const [sender, receiver] = buses.map(
+    eventBus =>
+      new KeyStorage<number>({
+        key: 'count',
+        storage: backing,
+        eventBus,
+      }),
+  );
+  const local: StorageEvent<number>[] = [];
+  const remote: StorageEvent<number>[] = [];
+  sender.addListener({
+    name: 'local-events',
+    handle: event => {
+      local.push(event);
+    },
+  });
+  receiver.addListener({
+    name: 'remote-events',
+    handle: event => {
+      remote.push(event);
+    },
+  });
+  cleanup.push(() => {
+    sender.destroy();
+    receiver.destroy();
+    for (const bus of buses) bus.destroy();
+  });
+  return { sender, receiver, backing, local, remote };
+}
+
+describe('KeyStorage dispatch consistency', () => {
+  it.each(['set', 'remove'] as const)(
+    'handles rejected broadcast conversion from %s',
+    async operation => {
+      const failure = new Error('encoder rejected the storage event');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const backing = new InMemoryStorage();
+      backing.setItem('count', '1');
+      const bus = new BroadcastTypedEventBus<StorageEvent<number>>({
+        delegate: new SerialTypedEventBus(
+          `storage-rejection-${crypto.randomUUID()}`,
+        ),
+        messageTransformer: {
+          serialize: () => {
+            throw failure;
+          },
+          deserialize: message => message as StorageEvent<number>,
+        },
+      });
+      const storage = new KeyStorage<number>({
+        key: 'count',
+        storage: backing,
+        eventBus: bus,
+      });
+      cleanup.push(() => {
+        storage.destroy();
+        bus.destroy();
+      });
+      const local = vi.fn();
+      storage.addListener({ name: 'record-local', handle: local });
+      if (operation === 'set') storage.set(2);
+      else storage.remove();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(local).toHaveBeenCalledOnce();
+      expect(backing.getItem('count')).toBe(operation === 'set' ? '2' : null);
+      expect(warn).toHaveBeenCalledWith(
+        'Storage event error for count:',
+        failure,
+      );
+    },
+  );
+
+  it('uses the current public fields when a retained local event is emitted again', async () => {
+    const { sender, receiver, local, remote } = pair();
+    sender.set(1);
+    await vi.waitFor(() => expect(remote).toHaveLength(1));
+    const retained = local[0];
+    retained.oldValue = 9;
+    retained.newValue = 2;
+    await sender.eventBus.emit(retained);
+    await vi.waitFor(() => expect(remote).toHaveLength(2));
+    expect(local[1]).toEqual({ oldValue: 9, newValue: 2 });
+    expect(remote[1]).toEqual(local[1]);
+    expect(receiver.get()).toBe(2);
+  });
+
+  it.each(['set', 'remove'] as const)(
+    'keeps one oldValue for local and remote %s after backing storage drift',
+    async operation => {
+      const { sender, backing, local, remote } = pair();
+      sender.set(1);
+      await vi.waitFor(() => expect(remote).toHaveLength(1));
+      backing.setItem('count', '2');
+      expect(sender.get()).toBe(1);
+      if (operation === 'set') sender.set(3);
+      else sender.remove();
+      await vi.waitFor(() => expect(remote).toHaveLength(2));
+      expect(local[1].oldValue).toBe(1);
+      expect(remote[1]).toEqual(local[1]);
+    },
+  );
+});

--- a/packages/storage/test/eventPresence.test.ts
+++ b/packages/storage/test/eventPresence.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { randomUUID } from 'node:crypto';
+import { expect, it } from 'vitest';
+import {
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+  type CrossTabMessageHandler,
+} from '@ahoo-wang/fetcher-eventbus';
+import { InMemoryStorage, KeyStorage, type StorageEvent } from '../src';
+
+it.each([
+  { newValue: 1 },
+  { oldValue: 1 },
+  { newValue: undefined },
+  { oldValue: undefined },
+])(
+  'preserves own optional fields through BroadcastChannel: %j',
+  async event => {
+    const channel = randomUUID();
+    const sender = new BroadcastTypedEventBus<StorageEvent<number>>({
+      delegate: new SerialTypedEventBus(channel),
+    });
+    const receiver = new BroadcastTypedEventBus<StorageEvent<number>>({
+      delegate: new SerialTypedEventBus(channel),
+    });
+    const stores = [sender, receiver].map(
+      eventBus =>
+        new KeyStorage({
+          key: channel,
+          storage: new InMemoryStorage(),
+          eventBus,
+        }),
+    );
+    const received = new Promise<StorageEvent<number>>(resolve =>
+      receiver.on({ name: 'remote', once: true, handle: resolve }),
+    );
+    try {
+      await sender.emit(event);
+      expect(await received).toStrictEqual(event);
+    } finally {
+      stores.forEach(storage => storage.destroy());
+      sender.destroy();
+      receiver.destroy();
+    }
+  },
+);
+
+it('keeps native JSON omission while legacy old-value decode failures stay explicit', () => {
+  const bus = new BroadcastTypedEventBus<StorageEvent<number>>({
+    delegate: new SerialTypedEventBus(randomUUID()),
+    messenger: {
+      postMessage() {},
+      close() {},
+      set onmessage(_: CrossTabMessageHandler) {},
+    },
+  });
+  const storage = new KeyStorage({
+    key: 'json',
+    eventBus: bus,
+    storage: new InMemoryStorage(),
+    serializer: {
+      serialize: String,
+      deserialize(raw) {
+        if (raw === 'invalid') throw new Error('invalid old');
+        return Number(raw);
+      },
+    },
+  });
+  const codec = bus.messageTransformer!;
+  try {
+    const event = { newValue: undefined, oldValue: 1 };
+    const wire = JSON.parse(JSON.stringify(codec.serialize(event)));
+    expect(codec.deserialize(wire)).toStrictEqual(
+      JSON.parse(JSON.stringify(event)),
+    );
+    expect(
+      codec.deserialize({
+        __fetcher_storage_snapshot__: { newValue: '2', oldValue: 'invalid' },
+      }),
+    ).toStrictEqual({ newValue: 2, oldValue: undefined });
+  } finally {
+    storage.destroy();
+    bus.destroy();
+  }
+});
+
+it('allows old-only clone fallback and rejects an empty fabricated snapshot', async () => {
+  class Value {
+    method = () => this.value;
+    constructor(readonly value: number) {}
+  }
+  const posts: unknown[] = [];
+  const bus = new BroadcastTypedEventBus<StorageEvent<Value>>({
+    delegate: new SerialTypedEventBus(randomUUID()),
+    messenger: {
+      postMessage(message: unknown) {
+        posts.push(structuredClone(message));
+      },
+      close() {},
+      set onmessage(_: CrossTabMessageHandler) {},
+    },
+  });
+  const storage = new KeyStorage({
+    key: 'fallback',
+    eventBus: bus,
+    storage: new InMemoryStorage(),
+    serializer: {
+      serialize: value => String(value.value),
+      deserialize: raw => new Value(Number(raw)),
+    },
+  });
+  try {
+    await bus.emit({ oldValue: new Value(3) });
+    const received = bus.messageTransformer!.deserialize(posts[0]);
+    expect(Object.keys(received)).toEqual(['oldValue']);
+    expect(received.oldValue?.method()).toBe(3);
+    const error = new DOMException('uncloneable', 'DataCloneError');
+    expect(() =>
+      bus.messageTransformer!.fallbackSerialize!(
+        { __fetcher_storage_snapshot__: {} },
+        error,
+      ),
+    ).toThrow(error);
+  } finally {
+    storage.destroy();
+    bus.destroy();
+  }
+});

--- a/packages/storage/test/legacyProtocol.test.ts
+++ b/packages/storage/test/legacyProtocol.test.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { randomUUID } from 'node:crypto';
+import { expect, it, vi } from 'vitest';
+import {
+  BroadcastChannelMessenger,
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+  type CrossTabMessageHandler,
+} from '@ahoo-wang/fetcher-eventbus';
+import { InMemoryStorage, KeyStorage, type StorageEvent } from '../src';
+
+it.each([
+  ['Date', new Date(0)],
+  ['Map', new Map([['one', 1]])],
+  ['NaN', NaN],
+  ['undefined property', { present: undefined }],
+])(
+  'keeps native clone semantics for a legacy receiver: %s',
+  async (_, value) => {
+    const channel = randomUUID();
+    const receiver = new BroadcastChannelMessenger(channel);
+    const senderBus = new BroadcastTypedEventBus<StorageEvent<unknown>>({
+      delegate: new SerialTypedEventBus(channel),
+      messenger: new BroadcastChannelMessenger(channel),
+    });
+    const storage = new KeyStorage({
+      key: channel,
+      storage: new InMemoryStorage(),
+      eventBus: senderBus,
+      serializer: { serialize: () => 'snapshot', deserialize: () => value },
+    });
+    const received = new Promise<StorageEvent<unknown>>(resolve => {
+      receiver.onmessage = resolve;
+    });
+    try {
+      storage.set(value);
+      const event = await received;
+      expect(event.newValue).toStrictEqual(value);
+    } finally {
+      storage.destroy();
+      senderBus.destroy();
+      receiver.close();
+    }
+  },
+);
+
+it('retries an uncloneable wire value with only its prepared snapshot', async () => {
+  let onmessage: CrossTabMessageHandler | undefined;
+  const postMessage = vi.fn((value: unknown) => structuredClone(value));
+  const bus = new BroadcastTypedEventBus<
+    StorageEvent<{ value: number; method(): number }>
+  >({
+    delegate: new SerialTypedEventBus('uncloneable'),
+    messenger: {
+      postMessage,
+      close() {},
+      set onmessage(handler: CrossTabMessageHandler) {
+        onmessage = handler;
+      },
+    },
+  });
+  const storage = new KeyStorage({
+    key: 'uncloneable',
+    storage: new InMemoryStorage(),
+    eventBus: bus,
+    serializer: {
+      serialize: value => String(value.value),
+      deserialize: value => ({
+        value: Number(value),
+        method: () => Number(value),
+      }),
+    },
+  });
+  const emitted = vi.spyOn(bus, 'emit');
+  const value = {
+    value: 1,
+    method() {
+      return this.value;
+    },
+  };
+  storage.set(value);
+  await expect(emitted.mock.results[0].value).resolves.toBeUndefined();
+  expect(postMessage).toHaveBeenCalledTimes(2);
+  const wire = postMessage.mock.results[1].value;
+  expect(Object.keys(wire)).toEqual(['__fetcher_storage_snapshot__']);
+  await onmessage?.(wire);
+  expect(storage.get()?.method()).toBe(1);
+  storage.destroy();
+  bus.destroy();
+});
+
+it.each(['toJSON', 'getter'] as const)(
+  'does not inspect %s before storage and local notification, and preserves native JSON keys',
+  async kind => {
+    const calls: string[] = [];
+    const localCalls: string[][] = [];
+    const value = { value: 1 };
+    if (kind === 'toJSON') {
+      Object.defineProperty(value, 'toJSON', {
+        value(key: string) {
+          calls.push(key);
+          return { value: this.value, key };
+        },
+      });
+    } else {
+      Object.defineProperty(value, 'observed', {
+        enumerable: true,
+        get() {
+          calls.push('getter');
+          return true;
+        },
+      });
+    }
+    const postMessage = vi.fn((message: unknown) =>
+      JSON.parse(JSON.stringify(message)),
+    );
+    const bus = new BroadcastTypedEventBus<StorageEvent<typeof value>>({
+      delegate: new SerialTypedEventBus('json'),
+      messenger: {
+        postMessage,
+        close() {},
+        set onmessage(_: CrossTabMessageHandler) {},
+      },
+    });
+    const backing = new InMemoryStorage();
+    const storage = new KeyStorage({
+      key: 'json',
+      storage: backing,
+      eventBus: bus,
+      serializer: {
+        serialize: entry => String(entry.value),
+        deserialize: raw => ({ value: Number(raw) }),
+      },
+    });
+    const emitted = vi.spyOn(bus, 'emit');
+    storage.addListener({
+      name: 'local',
+      handle() {
+        expect(backing.getItem('json')).toBe('1');
+        localCalls.push([...calls]);
+      },
+    });
+    storage.set(value);
+    await emitted.mock.results[0].value;
+    expect(localCalls).toEqual([[]]);
+    expect(calls).toEqual([kind === 'toJSON' ? 'newValue' : 'getter']);
+    if (kind === 'toJSON')
+      expect(postMessage.mock.results[0].value.newValue.key).toBe('newValue');
+    storage.destroy();
+    bus.destroy();
+  },
+);
+
+it('only restores legacy values when the serializer explicitly supports them', async () => {
+  const make = (deserializeLegacy?: (value: unknown) => number) => {
+    let incoming: CrossTabMessageHandler | undefined;
+    const bus = new BroadcastTypedEventBus<StorageEvent<number>>({
+      delegate: new SerialTypedEventBus('legacy'),
+      messenger: {
+        postMessage() {},
+        close() {},
+        set onmessage(handler: CrossTabMessageHandler) {
+          incoming = handler;
+        },
+      },
+    });
+    const storage = new KeyStorage({
+      key: 'legacy',
+      storage: new InMemoryStorage(),
+      eventBus: bus,
+      serializer: { serialize: String, deserialize: Number, deserializeLegacy },
+    });
+    return { storage, bus, incoming: incoming! };
+  };
+  const plain = make();
+  const hooked = make(value => {
+    if (typeof value !== 'object' || !value || !('value' in value))
+      throw new TypeError('legacy value');
+    return Number(value.value);
+  });
+  const raw = { value: 2 };
+  await plain.incoming({ newValue: raw });
+  expect(plain.storage.get()).toBe(raw);
+  await hooked.incoming({ newValue: raw, oldValue: 'unsupported' });
+  expect(hooked.storage.get()).toBe(2);
+  const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  await hooked.incoming({ newValue: 'unsupported' });
+  expect(hooked.storage.get()).toBe(2);
+  expect(warning).toHaveBeenCalledOnce();
+  plain.storage.destroy();
+  plain.bus.destroy();
+  hooked.storage.destroy();
+  hooked.bus.destroy();
+});
+
+it.each([
+  'local',
+  'caller transformer',
+  'replaced transformer',
+  'cleared transformer',
+] as const)(
+  'does not serialize optional old snapshots for a %s bus',
+  async kind => {
+    const delegate = new SerialTypedEventBus<StorageEvent<number>>('owned');
+    const bus =
+      kind === 'local'
+        ? delegate
+        : new BroadcastTypedEventBus({
+            delegate,
+            messenger: {
+              postMessage() {},
+              close() {},
+              set onmessage(_: CrossTabMessageHandler) {},
+            },
+            messageTransformer:
+              kind === 'caller transformer'
+                ? {
+                    serialize: event => event,
+                    deserialize: message => message as StorageEvent<number>,
+                  }
+                : undefined,
+          });
+    const serialize = vi.fn(String);
+    const storage = new KeyStorage({
+      key: 'owned',
+      eventBus: bus,
+      storage: new InMemoryStorage(),
+      defaultValue: 1,
+      serializer: { serialize, deserialize: Number },
+    });
+    if (
+      bus instanceof BroadcastTypedEventBus &&
+      kind === 'replaced transformer'
+    ) {
+      bus.messageTransformer = {
+        serialize: event => event,
+        deserialize: message => message as StorageEvent<number>,
+      };
+    } else if (
+      bus instanceof BroadcastTypedEventBus &&
+      kind === 'cleared transformer'
+    ) {
+      bus.messageTransformer = undefined;
+    }
+    storage.set(2);
+    expect(serialize.mock.calls).toEqual([[2]]);
+    storage.remove();
+    expect(serialize.mock.calls).toEqual([[2]]);
+    storage.destroy();
+    bus.destroy();
+  },
+);

--- a/packages/storage/test/moduleState.test.ts
+++ b/packages/storage/test/moduleState.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it, vi } from 'vitest';
+import type { CrossTabMessageHandler } from '@ahoo-wang/fetcher-eventbus';
+import {
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+} from '@ahoo-wang/fetcher-eventbus';
+import {
+  KeyStorage,
+  InMemoryStorage,
+  jsonSerializer,
+  type StorageEvent,
+} from '../src';
+
+function createBus() {
+  return new BroadcastTypedEventBus<StorageEvent<number>>({
+    delegate: new SerialTypedEventBus('modules'),
+    messenger: {
+      postMessage() {},
+      set onmessage(_handler: CrossTabMessageHandler) {},
+      close() {},
+    },
+  });
+}
+async function otherModule() {
+  vi.resetModules();
+  return import('../src');
+}
+const serializer = { serialize: String, deserialize: Number };
+
+it('enforces the key and explicit serializer identity across storage module copies', async () => {
+  const other = await otherModule();
+  const bus = createBus();
+  const first = new KeyStorage({ key: 'k', eventBus: bus, serializer });
+  try {
+    expect(
+      () => new other.KeyStorage({ key: 'other', eventBus: bus, serializer }),
+    ).toThrow('same storage key');
+    expect(
+      () =>
+        new other.KeyStorage({
+          key: 'k',
+          eventBus: bus,
+          serializer: { ...serializer },
+        }),
+    ).toThrow('same serializer instance');
+  } finally {
+    first.destroy();
+    bus.destroy();
+  }
+});
+
+it('uses the same prepared snapshot table across storage module copies', async () => {
+  const other = await otherModule();
+  const bus = createBus();
+  const codec = { serialize: vi.fn(String), deserialize: Number };
+  const first = new KeyStorage({ key: 'k', eventBus: bus, serializer: codec });
+  const second = new other.KeyStorage({
+    key: 'k',
+    eventBus: bus,
+    serializer: codec,
+    storage: new InMemoryStorage(),
+  });
+  const emitted = vi.spyOn(bus, 'emit');
+  try {
+    second.set(2);
+    await emitted.mock.results[0].value;
+    expect(codec.serialize).toHaveBeenCalledTimes(1);
+  } finally {
+    first.destroy();
+    second.destroy();
+    bus.destroy();
+  }
+});
+
+it('reuses only the known default JSON serializer when both copies omit one', async () => {
+  const other = await otherModule();
+  const bus = createBus();
+  const first = new KeyStorage<number>({ key: 'k', eventBus: bus });
+  const localSerialize = vi.spyOn(jsonSerializer, 'serialize');
+  const otherSerialize = vi.spyOn(other.jsonSerializer, 'serialize');
+  const second = new other.KeyStorage<number>({
+    key: 'k',
+    eventBus: bus,
+    storage: new InMemoryStorage(),
+  });
+  const emitted = vi.spyOn(bus, 'emit');
+  try {
+    second.set(2);
+    await emitted.mock.results[0].value;
+    expect(localSerialize).toHaveBeenCalledTimes(1);
+    expect(otherSerialize).not.toHaveBeenCalled();
+  } finally {
+    localSerialize.mockRestore();
+    otherSerialize.mockRestore();
+    first.destroy();
+    second.destroy();
+    bus.destroy();
+  }
+});
+
+it('preserves caller-preconfigured ownership and key restrictions across module copies', async () => {
+  const other = await otherModule();
+  const bus = createBus();
+  bus.messageTransformer = {
+    serialize: event => event,
+    deserialize: event => event as StorageEvent<number>,
+  };
+  const first = new KeyStorage({ key: 'k', eventBus: bus, serializer });
+  bus.messageTransformer = undefined;
+  const second = new other.KeyStorage({ key: 'k', eventBus: bus, serializer });
+  try {
+    expect(bus.messageTransformer).toBeUndefined();
+    expect(
+      () => new other.KeyStorage({ key: 'other', eventBus: bus, serializer }),
+    ).toThrow('same storage key');
+  } finally {
+    first.destroy();
+    second.destroy();
+    bus.destroy();
+  }
+});
+
+it('retains shared automatic state across caller clear and restore in another copy', async () => {
+  const other = await otherModule();
+  const bus = createBus();
+  const codec = { serialize: vi.fn(String), deserialize: Number };
+  const first = new KeyStorage({ key: 'k', eventBus: bus, serializer: codec });
+  const original = bus.messageTransformer;
+  bus.messageTransformer = undefined;
+  const second = new other.KeyStorage({
+    key: 'k',
+    eventBus: bus,
+    serializer: codec,
+    storage: new InMemoryStorage(),
+  });
+  const emitted = vi.spyOn(bus, 'emit');
+  try {
+    expect(bus.messageTransformer).toBeUndefined();
+    bus.messageTransformer = original;
+    second.set(2);
+    await emitted.mock.results[0].value;
+    expect(codec.serialize).toHaveBeenCalledTimes(1);
+  } finally {
+    first.destroy();
+    second.destroy();
+    bus.destroy();
+  }
+});
+
+it('preserves a frozen caller-configured bus without adding ownership properties', async () => {
+  const other = await otherModule();
+  const bus = createBus();
+  bus.messageTransformer = {
+    serialize: event => event,
+    deserialize: event => event as StorageEvent<number>,
+  };
+  Object.freeze(bus);
+  const keys = Reflect.ownKeys(bus);
+  const first = new KeyStorage({ key: 'k', eventBus: bus, serializer });
+  const second = new other.KeyStorage({ key: 'k', eventBus: bus, serializer });
+  try {
+    expect(Reflect.ownKeys(bus)).toEqual(keys);
+    expect(
+      () => new other.KeyStorage({ key: 'other', eventBus: bus, serializer }),
+    ).toThrow('same storage key');
+  } finally {
+    first.destroy();
+    second.destroy();
+    bus.destroy();
+  }
+});

--- a/packages/storage/test/storageFallback.test.ts
+++ b/packages/storage/test/storageFallback.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it, vi } from 'vitest';
+import {
+  BroadcastTypedEventBus,
+  SerialTypedEventBus,
+  StorageMessenger,
+  type TypedEventBus,
+} from '@ahoo-wang/fetcher-eventbus';
+import { KeyStorage, type StorageEvent as KeyStorageEvent } from '../src';
+
+it.each(['active', 'shared', 'destroyed', 'reentrant'] as const)(
+  'transfers BigInt and cyclic values through the real storage fallback (%s owner)',
+  async ownership => {
+    class Value {
+      self = this;
+      constructor(readonly count: bigint) {}
+    }
+    localStorage.clear();
+    localStorage.setItem('data', '1');
+    const serializer = {
+      serialize: (value: Value) => String(value.count),
+      deserialize: (raw: string) => new Value(BigInt(raw)),
+    };
+    const createStorage = (eventBus?: TypedEventBus<KeyStorageEvent<Value>>) =>
+      new KeyStorage<Value>({
+        key: 'data',
+        storage: localStorage,
+        serializer,
+        eventBus:
+          eventBus ??
+          new BroadcastTypedEventBus({
+            delegate: new SerialTypedEventBus<KeyStorageEvent<Value>>('data'),
+            messenger: new StorageMessenger({ channelName: 'fallback' }),
+          }),
+      });
+    const first = createStorage();
+    const sender =
+      ownership === 'shared' ? createStorage(first.eventBus) : first;
+    if (ownership === 'shared') first.destroy();
+    const receiver = createStorage();
+    if (ownership === 'reentrant') {
+      sender.addListener({
+        name: 'forward-once',
+        once: true,
+        handle: event => sender.eventBus.emit(event),
+      });
+    }
+    const emitted = vi.spyOn(sender.eventBus, 'emit');
+    const local: KeyStorageEvent<Value>[] = [];
+    sender.addListener({
+      name: 'local',
+      handle: event => {
+        local.push(event);
+      },
+    });
+    const received = new Promise<KeyStorageEvent<Value>>(resolve => {
+      receiver.addListener({ name: 'remote', once: true, handle: resolve });
+    });
+    const directlyReceived = new Promise<KeyStorageEvent<Value>>(resolve => {
+      receiver.eventBus.on({
+        name: 'remote-direct',
+        order: -1,
+        once: true,
+        handle: resolve,
+      });
+    });
+    try {
+      const value = new Value(2n);
+      sender.set(value);
+      if (ownership === 'destroyed') sender.destroy();
+      await expect(emitted.mock.results[0].value).resolves.toBeUndefined();
+      expect(local[0].newValue).toBe(value);
+      const key = Array.from({ length: localStorage.length }, (_, index) =>
+        localStorage.key(index)!,
+      ).find(key => key !== 'data')!;
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key,
+          storageArea: localStorage,
+          newValue: localStorage.getItem(key),
+        }),
+      );
+      const [event, directEvent] = await Promise.all([
+        received,
+        directlyReceived,
+      ]);
+      expect(event.newValue?.count).toBe(2n);
+      expect(event.oldValue?.count).toBe(1n);
+      expect(event.newValue?.self).toBe(event.newValue);
+      expect(receiver.get()).toBe(event.newValue);
+      expect(Object.keys(directEvent).sort()).toEqual(['newValue', 'oldValue']);
+      expect(directEvent.newValue).toBe(event.newValue);
+      expect(directEvent.oldValue).toBe(event.oldValue);
+    } finally {
+      first.destroy();
+      sender.destroy();
+      receiver.destroy();
+      sender.eventBus.destroy();
+      receiver.eventBus.destroy();
+      localStorage.clear();
+    }
+  },
+);

--- a/skills/fetcher-cosec-auth/references/api.md
+++ b/skills/fetcher-cosec-auth/references/api.md
@@ -192,6 +192,14 @@ authentication or integrity check; the server still validates JWTs.
 
 Token storage with a localStorage backend and cross-tab synchronization.
 
+TokenStorage instances sharing one supplied `eventBus` must use the same storage key and `earlyPeriod`; they reuse one serializer object, including across duplicate package modules in the same JavaScript global. A different `earlyPeriod` on that bus throws, including after an earlier instance is destroyed. For independent expiration policies, use separate buses on the same channel. The default creates one bus per TokenStorage instance with a channel derived from its key, so each receiver keeps its own `earlyPeriod` while synchronizing the same token record.
+
+`JwtCompositeTokenSerializer.deserializeLegacy(value: unknown)` restores the known plain-object shape broadcast
+by older TokenStorage tabs. It requires string `value.token.accessToken` and
+`value.token.refreshToken`, then reuses the normal serializer to restore getters,
+the receiving serializer's `earlyPeriod`, and session identity. Malformed legacy
+shapes throw `TypeError`; this hook is used only when no serialized snapshot exists.
+
 ### Constructor
 
 ```text

--- a/skills/fetcher-eventbus/references/api.md
+++ b/skills/fetcher-eventbus/references/api.md
@@ -159,6 +159,35 @@ await bus.emit('broadcast-message'); // Local + cross-tab
 
 Default messenger channel: `_broadcast_:{type}`. Pass a custom `messenger` option to override.
 
+`BroadcastTypedEventBusOptions<EVENT>` also accepts an optional message conversion:
+
+```typescript
+messageTransformer?: {
+  serialize(event: EVENT): unknown;
+  deserialize(message: unknown): EVENT;
+  serializeBeforeDispatch?: boolean;
+  fallbackSerialize?(message: unknown, error: unknown): unknown;
+};
+```
+
+It can also be assigned to `bus.messageTransformer` after construction. Local
+handlers receive the original event. By default, serialization runs after local
+handlers, before posting to the messenger. With `serializeBeforeDispatch: true`,
+`serialize` runs at the start of each emission and its result belongs to that
+emission, so nested or overlapping emissions cannot overwrite its prepared message.
+The messenger post still occurs after local handlers. An early conversion error
+rejects before local dispatch. Each `emit()` captures its starting transformer and
+this option before awaiting local handlers, so changing or clearing them does not
+change an in-flight message's encoding. Incoming messages are deserialized before any delegate handlers
+run, including handlers registered before the transformer was configured. Without
+a transformer, messages pass through unchanged. Outgoing conversion errors propagate
+from `emit()`. When a messenger post throws, `fallbackSerialize`, if provided,
+receives that already serialized message and error; its replacement is posted once.
+Conversion errors do not invoke the fallback, and fallback errors or a second post
+failure still reject `emit()`. Incoming conversion or delegate errors are reported with `console.warn`
+and the bus type; an undecodable message is not dispatched, and later messages can
+still be received. Messenger callbacks do not leave rejected promises unhandled.
+
 ### Generic EventBus<Events>
 
 Manages multiple named event types with lazy-loaded TypedEventBus instances:

--- a/skills/fetcher-storage/references/api.md
+++ b/skills/fetcher-storage/references/api.md
@@ -45,6 +45,13 @@ interface StorageEvent<Deserialized> {
 }
 ```
 
+Automatic broadcast conversion preserves which standard fields are own properties.
+A missing field stays absent; an explicitly present `undefined` stays present over
+BroadcastChannel. JSON transports, including StorageMessenger, follow JSON's native
+omission of `undefined` object fields. `set()` and `remove()` continue emitting both
+fields. If an existing old-value snapshot cannot be decoded, the received event
+retains an explicit `oldValue: undefined` instead of discarding its valid new value.
+
 ### `StorageListenable<Deserialized>`
 
 ```typescript
@@ -83,7 +90,7 @@ const userStorage = new KeyStorage<{ name: string; age: number }>({
 - `get(): T | null` — Get value (cached, or deserialized from storage). Returns `defaultValue` if key missing.
 - `set(value: T): void` — Store value with caching and emit change event.
 - `remove(): void` — Remove value, clear cache, emit change event.
-- `destroy(): void` — Remove internal event handler to prevent memory leaks. Call when done.
+- `destroy(): void` — Remove the internal event handler and release this storage's share of the default message transformer. The automatic codec stays on the supplied bus so its direct subscribers can decode messages already in transit. Call when done.
 - `addListener(handler: EventHandler<StorageEvent<T>>): RemoveStorageListener`
 
 ### Example: Basic Usage with defaultValue
@@ -121,7 +128,34 @@ storage.destroy(); // prevent memory leaks
 
 ## Cross-tab Synchronization
 
-`KeyStorage` defaults to `SerialTypedEventBus`, so its change notifications stay in the current JavaScript context. Pass a `BroadcastTypedEventBus` to enable browser cross-tab synchronization; its default messenger uses `BroadcastChannel` with a `StorageEvent` fallback.
+`KeyStorage` defaults to `SerialTypedEventBus`, so its change notifications stay in the current JavaScript context. Pass a `BroadcastTypedEventBus` to enable browser cross-tab synchronization; its default messenger uses `BroadcastChannel` with a `StorageEvent` fallback. A shared bus must represent the same logical storage key. A broadcast bus with the public `messageTransformer` capability gets an automatic snapshot codec when no caller codec is configured. That codec and its snapshot table stay bound to the exact same serializer object for the bus lifetime, even after all KeyStorage instances are destroyed. Passing a different key or a different serializer object to that automatic bus throws; use a new bus for a different key, format, or deserialization configuration. Separate but equivalent explicitly supplied serializer objects are not treated as interchangeable. When both instances omit `serializer`, they reuse the first instance's default JSON serializer, including across duplicate package modules. Ownership and snapshot state are shared across module copies in the same JavaScript global through a non-enumerable global registry of weak bus keys; no properties are added to the bus itself. Receiving caches and listeners use the serializer to restore custom class semantics for both `newValue` and `oldValue`.
+
+`keyStorage.eventBus` is the supplied bus itself. A preconfigured `messageTransformer` takes precedence; the caller owns transport encoding and decoding of ordinary `StorageEvent` values, including custom class restoration. KeyStorage never installs an automatic codec on a bus that started with a caller codec. `destroy()` removes the instance's internal listener and leaves the automatic codec and snapshot table available for direct bus subscribers and pending messages. Clearing or replacing the codec is an explicit caller override: creating another KeyStorage does not reinstall or replace it. Existing automatic owners keep the same snapshot table, so explicitly restoring the original codec does not orphan their snapshots. In-flight emissions retain the transformer captured at dispatch; incoming messages use the caller-selected codec present when they arrive. The automatic codec captures each dispatch's wire snapshot before local listeners run. A prepared storage snapshot belongs to its originating dispatch; reentrant or later direct emits encode their own current public fields. Messenger serialization and posting still happen after local delivery, and caller codecs retain their default timing. For caller codecs and non-broadcast buses, all shared instances must also use the same value semantics and deserialization configuration because listeners receive the same public event object.
+
+With the default transformer, prepared storage snapshots are attached only at the messenger boundary and decoded before any receiving handler runs. Subscribers registered on the supplied bus before or after KeyStorage construction, through `eventBus.on`, or through `addListener` all receive standard enumerable `newValue` and `oldValue` fields. Spreading or JSON-serializing these events does not expose transport metadata. Local notifications preserve object identity; ordinary custom local buses receive the same standard events.
+
+Wire messages retain their ordinary standard fields for legacy receivers. BroadcastChannel
+uses its native structured-clone semantics, preserving Date, Map, NaN, and undefined
+properties. A non-enumerable wire `toJSON` is used only by JSON transports: it projects
+each supported standard field using its original property key and omits unsupported
+JSON values such as BigInt or cycles. If native cloning fails with `DataCloneError`,
+the automatic transformer retries once with only the prepared string snapshots.
+Neither preparation nor retry traverses the original values; native messenger
+serialization retains its normal getter and `toJSON` behavior after local dispatch.
+Values requiring snapshot-only transport cannot be restored by legacy receivers.
+The default channel and storage keys do not change.
+
+Legacy messages without snapshots keep their standard fields unless the serializer
+explicitly implements `deserializeLegacy(value: unknown): T`. This optional hook may
+restore a known old wire shape; arbitrary lost class prototypes cannot be recovered.
+A failed legacy old-value decode leaves `oldValue` undefined, while a failed new-value
+decode is warned and the message is not dispatched. Snapshot-aware endpoints sharing
+the same key and channel across contexts must use compatible serialization formats
+and decoding semantics. A serializer format change requires application migration
+or a caller-provided independent channel; the generic serializer API does not detect
+incompatible formats, including parsers that silently return an incorrect value.
+
+For the automatic transformer, the old snapshot serializes the actual local `oldValue`, including a cached value or source default, so local and remote notifications describe the same transition. If that value cannot be serialized or the receiver cannot decode it, remote `oldValue` is undefined and a valid new value still updates the cache and listeners. Local buses and caller codecs do not perform this extra old-value serialization. Asynchronous event delivery failures are reported with a warning; synchronous serialization, storage read, write, and removal failures still propagate to the caller. Incoming new-value decoding failures are warned and dropped without changing the receiving cache.
 
 ```typescript
 import {
@@ -192,6 +226,11 @@ const typedStringStorage = new KeyStorage<string>({
 ```
 
 ### Custom Serializer
+
+`Serializer<Serialized, Deserialized>` defines `serialize(value)`,
+`deserialize(value)`, and optional `deserializeLegacy(value: unknown)` for restoring
+known legacy broadcast values. Only serialized snapshots use `deserialize`; the
+legacy hook is never guessed from or replaced by a serialize/deserialize round trip.
 
 ```typescript
 import type { Serializer } from '@ahoo-wang/fetcher-storage';


### PR DESCRIPTION
## Description

Restore serialized storage values before dispatching remote events, so receiving caches and all subscribers retain custom class behavior. Local notifications keep object identity and standard fields. Optional field presence survives native BroadcastChannel transport; JSON retains its native omission of undefined values. BroadcastChannel preserves native cloneable values; JSON fallback retains serializer snapshots for BigInt and cyclic values. Known legacy TokenStorage messages recover JWT getters and the receiving expiration policy.

An automatic broadcast codec is bound to one storage key and serializer object for the bus lifetime, including when multiple copies of Storage or CoSec are loaded. Caller overrides remain in place; shared TokenStorage instances reuse their serializer and reject conflicting expiration policies. Each dispatch captures its own snapshot before local listeners, including reentrant sends of the same event; later direct emits encode their current fields. Local and remote old values agree, and asynchronous notification failures are reported without undoing completed storage writes. Optional Eventbus fallback and legacy serializer hooks are documented with their compatibility limits. Cross-format migrations require an application migration or separate channel.

This series prepares version 5.0.0. No release or tag is published.

## Validation

The combined stack was validated once, then this scoped fix was inserted into this layer. Every resulting layer tree and the unchanged combined tested tree were verified before publishing:

- `pnpm build`
- `pnpm test:unit` — 274 files, 3729 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .`
- `git diff --check`

Node.js 24.11.0, pnpm 10.34.5. Regressions include real BroadcastChannel and StorageMessenger transport, retained and reentrant event dispatch, shared bus lifecycle across module copies, optional field presence, legacy JWT decoding, and rejected notification delivery. No new dependencies or build configuration changes.

## Review and CI

Ready for review. Merge requires a completed GitHub Codex review, no unresolved review threads, and five successful CI workflows for the current head. Codacy quality-rule findings are tracked separately with source evidence.

Native GitHub stack #1418, layer 8 of 16. Keep this PR separate and squash layers in stack order. Verify rewritten heads before proceeding to the next layer.

Split index: #1399.
