### PR TITLE
fix(cosec): prevent stale refreshes from replacing the active session

### DIFF
--- a/packages/cosec/src/authorizationRequestInterceptor.ts
+++ b/packages/cosec/src/authorizationRequestInterceptor.ts
@@ -12,13 +12,18 @@
  */
 
 import type { FetchExchange, RequestInterceptor } from '@ahoo-wang/fetcher';
-import { DEFAULT_INTERCEPTOR_ORDER_STEP } from '@ahoo-wang/fetcher';
+import {
+  DEFAULT_INTERCEPTOR_ORDER_STEP,
+  getHeader,
+  setHeader,
+} from '@ahoo-wang/fetcher';
 import {
   COSEC_REQUEST_INTERCEPTOR_ORDER,
   IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY,
 } from './cosecRequestInterceptor';
 import type { JwtTokenManagerCapable } from './types';
 import { CoSecHeaders } from './types';
+import { assertTokenSession, TOKEN_SESSION_ATTRIBUTE } from './refreshSession';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface AuthorizationInterceptorOptions extends JwtTokenManagerCapable {}
@@ -63,11 +68,16 @@ export class AuthorizationRequestInterceptor implements RequestInterceptor {
   async intercept(exchange: FetchExchange): Promise<void> {
     // Get the current token from token manager
     let currentToken = this.options.tokenManager.currentToken;
+    assertTokenSession(exchange, currentToken);
 
     const requestHeaders = exchange.ensureRequestHeaders();
 
-    // Skip if no token exists or Authorization header is already set
-    if (!currentToken || requestHeaders[CoSecHeaders.AUTHORIZATION]) {
+    // Caller-provided credentials remain outside the managed session.
+    if (getHeader(requestHeaders, CoSecHeaders.AUTHORIZATION) !== undefined) {
+      return;
+    }
+    if (!currentToken) {
+      exchange.attributes.set(TOKEN_SESSION_ATTRIBUTE, null);
       return;
     }
 
@@ -77,16 +87,20 @@ export class AuthorizationRequestInterceptor implements RequestInterceptor {
       currentToken.isRefreshNeeded &&
       currentToken.isRefreshable
     ) {
-      await this.options.tokenManager.refresh();
+      await this.options.tokenManager.refresh(exchange);
     }
 
     // Get the current token again (might have been refreshed)
     currentToken = this.options.tokenManager.currentToken;
+    assertTokenSession(exchange, currentToken);
 
     // Add Authorization header if we have a token
     if (currentToken) {
-      requestHeaders[CoSecHeaders.AUTHORIZATION] =
-        `Bearer ${currentToken.access.token}`;
+      const authorization = `Bearer ${currentToken.access.token}`;
+      setHeader(requestHeaders, CoSecHeaders.AUTHORIZATION, authorization);
+      // Only this injected credential may be replaced during a 401 retry.
+      exchange.attributes.set(this.name, authorization);
+      exchange.attributes.set(TOKEN_SESSION_ATTRIBUTE, currentToken);
     }
   }
 }

--- a/packages/cosec/src/authorizationResponseInterceptor.ts
+++ b/packages/cosec/src/authorizationResponseInterceptor.ts
@@ -13,8 +13,17 @@
 
 import { CoSecHeaders, ResponseCodes } from './types';
 import type { FetchExchange } from '@ahoo-wang/fetcher';
-import { type ResponseInterceptor } from '@ahoo-wang/fetcher';
-import type { AuthorizationInterceptorOptions } from './authorizationRequestInterceptor';
+import {
+  deleteHeader,
+  getHeader,
+  type ResponseInterceptor,
+} from '@ahoo-wang/fetcher';
+import { IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY } from './cosecRequestInterceptor';
+import { assertTokenSession, TOKEN_SESSION_ATTRIBUTE } from './refreshSession';
+import {
+  AUTHORIZATION_REQUEST_INTERCEPTOR_NAME,
+  type AuthorizationInterceptorOptions,
+} from './authorizationRequestInterceptor';
 
 /**
  * The name of the AuthorizationResponseInterceptor.
@@ -41,8 +50,7 @@ export const AUTHORIZATION_RESPONSE_MAX_RETRY = 1;
  * Attribute key storing how many times an exchange has been refreshed and
  * retried, used to bound the refresh-retry loop.
  */
-const AUTHORIZATION_RETRY_COUNT_ATTRIBUTE =
-  'AuthorizationResponseRetryCount';
+const AUTHORIZATION_RETRY_COUNT_ATTRIBUTE = 'AuthorizationResponseRetryCount';
 
 /**
  * CoSecResponseInterceptor is responsible for handling unauthorized responses (401)
@@ -77,11 +85,31 @@ export class AuthorizationResponseInterceptor implements ResponseInterceptor {
     }
 
     // Only handle unauthorized responses (401)
-    if (response.status !== ResponseCodes.UNAUTHORIZED) {
+    if (
+      response.status !== ResponseCodes.UNAUTHORIZED ||
+      exchange.attributes?.has(IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY)
+    ) {
       return;
     }
 
-    if (!this.options.tokenManager.isRefreshable) {
+    const authorization = getHeader(
+      exchange.request?.headers,
+      CoSecHeaders.AUTHORIZATION,
+    );
+    if (
+      exchange.attributes?.get(AUTHORIZATION_REQUEST_INTERCEPTOR_NAME) !==
+      authorization
+    ) {
+      return;
+    }
+
+    const currentToken = this.options.tokenManager.currentToken;
+    assertTokenSession(exchange, currentToken);
+    if (
+      !this.options.tokenManager.isRefreshable &&
+      (!exchange.attributes?.has(TOKEN_SESSION_ATTRIBUTE) ||
+        exchange.attributes.get(TOKEN_SESSION_ATTRIBUTE) === currentToken)
+    ) {
       return;
     }
 
@@ -92,24 +120,21 @@ export class AuthorizationResponseInterceptor implements ResponseInterceptor {
     const attributes = (exchange.attributes ??= new Map<string, unknown>());
     const retryCount =
       (attributes.get(AUTHORIZATION_RETRY_COUNT_ATTRIBUTE) as
-        | number
-        | undefined) ?? 0;
+        number | undefined) ?? 0;
     if (retryCount >= AUTHORIZATION_RESPONSE_MAX_RETRY) {
       return;
     }
     attributes.set(AUTHORIZATION_RETRY_COUNT_ATTRIBUTE, retryCount + 1);
 
-    try {
-      await this.options.tokenManager.refresh();
-    } catch (error) {
-      // If token refresh fails, clear stored tokens and re-throw the error
-      this.options.tokenManager.tokenStorage.remove();
-      throw error;
-    }
+    // The manager owns cleanup for the session that started the refresh.
+    await this.options.tokenManager.refresh(exchange);
+    assertTokenSession(exchange, this.options.tokenManager.currentToken);
     // Retrying re-runs the whole request interceptor chain. Drop the stale
     // Authorization header so AuthorizationRequestInterceptor re-adds it
     // with the refreshed token — it skips requests that already carry one.
-    delete exchange.request?.headers?.[CoSecHeaders.AUTHORIZATION];
+    if (exchange.request?.headers) {
+      deleteHeader(exchange.request.headers, CoSecHeaders.AUTHORIZATION);
+    }
     // Retry the original request with the new token. A failure of the retry
     // itself (network error, another 401, ...) propagates unchanged: it must
     // not clear the freshly refreshed and still valid token.

--- a/packages/cosec/src/cosecRequestInterceptor.ts
+++ b/packages/cosec/src/cosecRequestInterceptor.ts
@@ -14,6 +14,7 @@
 import type { FetchExchange } from '@ahoo-wang/fetcher';
 import {
   DEFAULT_INTERCEPTOR_ORDER_STEP,
+  setHeader,
   type RequestInterceptor,
 } from '@ahoo-wang/fetcher';
 import type { AppIdCapable, DeviceIdStorageCapable } from './types';
@@ -372,11 +373,11 @@ export class CoSecRequestInterceptor implements RequestInterceptor {
     const requestHeaders = exchange.ensureRequestHeaders();
 
     // Add CoSec headers to the request
-    requestHeaders[CoSecHeaders.APP_ID] = this.appId;
-    requestHeaders[CoSecHeaders.DEVICE_ID] = deviceId;
-    requestHeaders[CoSecHeaders.REQUEST_ID] = requestId;
+    setHeader(requestHeaders, CoSecHeaders.APP_ID, this.appId);
+    setHeader(requestHeaders, CoSecHeaders.DEVICE_ID, deviceId);
+    setHeader(requestHeaders, CoSecHeaders.REQUEST_ID, requestId);
     if (spaceId) {
-      requestHeaders[CoSecHeaders.SPACE_ID] = spaceId;
+      setHeader(requestHeaders, CoSecHeaders.SPACE_ID, spaceId);
     }
   }
 }

--- a/packages/cosec/src/jwtToken.ts
+++ b/packages/cosec/src/jwtToken.ts
@@ -15,6 +15,7 @@ import type { CoSecJwtPayload, EarlyPeriodCapable, JwtPayload } from './jwts';
 import { isTokenExpired, parseJwtPayload } from './jwts';
 import type { CompositeToken } from './tokenRefresher';
 import type { Serializer } from '@ahoo-wang/fetcher-storage';
+import { idGenerator } from './idGenerator';
 
 /**
  * Interface for JWT token with typed payload.
@@ -180,10 +181,12 @@ export class JwtCompositeToken
    *
    * @param token The composite token containing access and refresh token strings
    * @param earlyPeriod The early expiration period in seconds (default: 0)
+   * @param sessionId Session generation retained when restoring or refreshing a token.
    */
   constructor(
     public readonly token: CompositeToken,
     public readonly earlyPeriod: number = 0,
+    public readonly sessionId: string = idGenerator.generateId(),
   ) {
     this.access = new JwtToken(token.accessToken, earlyPeriod);
     this.refresh = new JwtToken(token.refreshToken, earlyPeriod);
@@ -215,6 +218,21 @@ export class JwtCompositeToken
   get authenticated(): boolean {
     return !this.access.isExpired;
   }
+}
+
+// A non-cryptographic fingerprint identifies the exact legacy record across tabs.
+// It is not an authentication or integrity check; new sign-ins use random IDs.
+function legacyTokenSessionId(token: CompositeToken): string {
+  let hash = 0x6c62272e07bb014262b821756295c58dn;
+  for (const byte of new TextEncoder().encode(
+    JSON.stringify([token.accessToken, token.refreshToken]),
+  )) {
+    hash = BigInt.asUintN(
+      128,
+      (hash ^ BigInt(byte)) * 0x1000000000000000000013bn,
+    );
+  }
+  return `legacy:${hash.toString(16).padStart(32, '0')}`;
 }
 
 /**
@@ -253,8 +271,18 @@ export class JwtCompositeTokenSerializer
    * @throws Error if the parsed object doesn't match the expected CompositeToken structure
    */
   deserialize(value: string): JwtCompositeToken {
-    const compositeToken = JSON.parse(value) as CompositeToken;
-    return new JwtCompositeToken(compositeToken, this.earlyPeriod);
+    const { sessionId, ...compositeToken } = JSON.parse(
+      value,
+    ) as CompositeToken & {
+      sessionId?: unknown;
+    };
+    return new JwtCompositeToken(
+      compositeToken,
+      this.earlyPeriod,
+      typeof sessionId === 'string' && sessionId.length > 0
+        ? sessionId
+        : legacyTokenSessionId(compositeToken),
+    );
   }
 
   /**
@@ -266,7 +294,7 @@ export class JwtCompositeTokenSerializer
    * @returns A JSON string representation of the composite token
    */
   serialize(value: JwtCompositeToken): string {
-    return JSON.stringify(value.token);
+    return JSON.stringify({ ...value.token, sessionId: value.sessionId });
   }
 }
 

--- a/packages/cosec/src/jwtTokenManager.ts
+++ b/packages/cosec/src/jwtTokenManager.ts
@@ -12,9 +12,15 @@
  */
 
 import type { TokenStorage } from './tokenStorage';
-import type { TokenRefresher } from './tokenRefresher';
-import type { JwtCompositeToken, RefreshTokenStatusCapable } from './jwtToken';
-import { FetcherError } from '@ahoo-wang/fetcher';
+import { CoSecTokenRefresher, type TokenRefresher } from './tokenRefresher';
+import { JwtCompositeToken, type RefreshTokenStatusCapable } from './jwtToken';
+import { FetcherError, type FetchExchange } from '@ahoo-wang/fetcher';
+import { UNAUTHORIZED_ERROR_INTERCEPTOR_NAME } from './unauthorizedErrorInterceptor';
+import {
+  assertTokenSession,
+  isSameTokenSession,
+  TOKEN_SESSION_ATTRIBUTE,
+} from './refreshSession';
 
 export class RefreshTokenError extends FetcherError {
   constructor(
@@ -27,11 +33,24 @@ export class RefreshTokenError extends FetcherError {
   }
 }
 
+/** The session changed while refreshing; the original request must stop. */
+export class RefreshSessionChangedError extends FetcherError {
+  constructor(cause?: unknown) {
+    super('The token session changed during refresh.', cause);
+    this.name = 'RefreshSessionChangedError';
+    Object.setPrototypeOf(this, RefreshSessionChangedError.prototype);
+  }
+}
+
 /**
  * Manages JWT token refreshing operations and provides status information
  */
 export class JwtTokenManager implements RefreshTokenStatusCapable {
-  private refreshInProgress?: Promise<void>;
+  private refreshInProgress?: {
+    token: JwtCompositeToken;
+    promise: Promise<JwtCompositeToken>;
+    notification: { hasHandler: boolean; handled: boolean };
+  };
 
   /**
    * Creates a new JwtTokenManager instance
@@ -53,32 +72,128 @@ export class JwtTokenManager implements RefreshTokenStatusCapable {
 
   /**
    * Refreshes the JWT token
+   * @param exchange Optional originating request used to select the unauthorized notification owner
    * @returns Promise that resolves when refresh is complete
    * @throws Error if no token is found or refresh fails
+   * @throws RefreshSessionChangedError if the session changes while refreshing
    */
-  async refresh(): Promise<void> {
+  async refresh(exchange?: FetchExchange): Promise<void> {
     const jwtToken = this.currentToken;
     if (!jwtToken) {
       throw new Error('No token found');
     }
-    if (this.refreshInProgress) {
-      return this.refreshInProgress;
+    if (exchange) {
+      const previousToken = exchange.attributes.get(TOKEN_SESSION_ATTRIBUTE);
+      assertTokenSession(exchange, jwtToken);
+      exchange.attributes.set(TOKEN_SESSION_ATTRIBUTE, jwtToken);
+      if (
+        exchange.attributes.get(UNAUTHORIZED_ERROR_INTERCEPTOR_NAME) !== true
+      ) {
+        exchange.attributes.set(
+          UNAUTHORIZED_ERROR_INTERCEPTOR_NAME,
+          () =>
+            this.currentToken ===
+            exchange.attributes.get(TOKEN_SESSION_ATTRIBUTE),
+        );
+      }
+      if (previousToken && previousToken !== jwtToken) {
+        return;
+      }
     }
+    const inProgress =
+      this.refreshInProgress?.token === jwtToken
+        ? this.refreshInProgress
+        : undefined;
+    const notification = inProgress?.notification ?? {
+      hasHandler: false,
+      handled: false,
+    };
+    notification.hasHandler ||=
+      this.tokenRefresher instanceof CoSecTokenRefresher &&
+      (exchange?.fetcher.interceptors.error.interceptors.some(
+        interceptor => interceptor.name === UNAUTHORIZED_ERROR_INTERCEPTOR_NAME,
+      ) ??
+        false);
+    let promise = inProgress?.promise;
+    if (!promise) {
+      const refresh =
+        this.tokenRefresher instanceof CoSecTokenRefresher
+          ? this.tokenRefresher.refresh(jwtToken.token, () => {
+              if (this.currentToken !== jwtToken || notification.hasHandler)
+                return false;
+              notification.handled = true;
+              return true;
+            })
+          : this.tokenRefresher.refresh(jwtToken.token);
+      promise = refresh
+        .then(newToken => {
+          const currentToken = this.currentToken;
+          if (!currentToken || !isSameTokenSession(jwtToken, currentToken)) {
+            throw new RefreshSessionChangedError();
+          }
+          if (currentToken !== jwtToken) return currentToken;
+          const refreshedToken = new JwtCompositeToken(
+            newToken,
+            this.tokenStorage.earlyPeriod,
+            jwtToken.sessionId,
+          );
+          this.tokenStorage.set(refreshedToken);
+          return refreshedToken;
+        })
+        .catch(error => {
+          if (error instanceof RefreshSessionChangedError) {
+            throw error;
+          }
+          const currentToken = this.currentToken;
+          if (
+            currentToken &&
+            currentToken !== jwtToken &&
+            isSameTokenSession(jwtToken, currentToken)
+          ) {
+            return currentToken;
+          }
+          // The refresh client's own notification may have signed out this session.
+          if (
+            currentToken !== jwtToken &&
+            (currentToken !== null || !notification.handled)
+          ) {
+            throw new RefreshSessionChangedError(error);
+          }
+          if (currentToken === jwtToken) {
+            this.tokenStorage.remove();
+          }
+          throw new RefreshTokenError(jwtToken, error);
+        })
+        .finally(() => {
+          if (this.refreshInProgress?.promise === promise) {
+            this.refreshInProgress = undefined;
+          }
+        });
 
-    this.refreshInProgress = this.tokenRefresher
-      .refresh(jwtToken.token)
-      .then(newToken => {
-        this.tokenStorage.setCompositeToken(newToken);
-      })
-      .catch(error => {
-        this.tokenStorage.remove();
-        throw new RefreshTokenError(jwtToken, error);
-      })
-      .finally(() => {
-        this.refreshInProgress = undefined;
-      });
-
-    return this.refreshInProgress;
+      this.refreshInProgress = { token: jwtToken, promise, notification };
+    }
+    try {
+      const refreshedToken = await promise;
+      exchange?.attributes.set(TOKEN_SESSION_ATTRIBUTE, refreshedToken);
+      if (!isSameTokenSession(refreshedToken, this.currentToken)) {
+        throw new RefreshSessionChangedError();
+      }
+    } catch (error) {
+      if (error instanceof RefreshTokenError && exchange) {
+        exchange.attributes.set(TOKEN_SESSION_ATTRIBUTE, null);
+        if (
+          exchange.attributes.get(UNAUTHORIZED_ERROR_INTERCEPTOR_NAME) !== true
+        ) {
+          exchange.attributes.set(UNAUTHORIZED_ERROR_INTERCEPTOR_NAME, () => {
+            if (this.currentToken !== null || notification.handled)
+              return false;
+            notification.handled = true;
+            return true;
+          });
+        }
+      }
+      throw error;
+    }
   }
 
   /**

--- a/packages/cosec/src/refreshSession.ts
+++ b/packages/cosec/src/refreshSession.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { FetchExchange } from '@ahoo-wang/fetcher';
+import type { JwtCompositeToken } from './jwtToken';
+import { RefreshSessionChangedError } from './jwtTokenManager';
+
+export const TOKEN_SESSION_ATTRIBUTE = 'CoSec-Token-Session';
+
+export function isSameTokenSession(
+  expectedToken: JwtCompositeToken | null,
+  currentToken: JwtCompositeToken | null,
+): boolean {
+  return (
+    expectedToken === currentToken ||
+    (expectedToken !== null &&
+      currentToken !== null &&
+      typeof expectedToken.sessionId === 'string' &&
+      expectedToken.sessionId === currentToken.sessionId)
+  );
+}
+
+export function assertTokenSession(
+  exchange: FetchExchange,
+  currentToken: JwtCompositeToken | null,
+): void {
+  if (
+    exchange.attributes?.has(TOKEN_SESSION_ATTRIBUTE) &&
+    !isSameTokenSession(
+      exchange.attributes.get(TOKEN_SESSION_ATTRIBUTE),
+      currentToken,
+    )
+  ) {
+    throw new RefreshSessionChangedError();
+  }
+}

--- a/packages/cosec/src/tokenRefresher.ts
+++ b/packages/cosec/src/tokenRefresher.ts
@@ -14,6 +14,7 @@
 import type { Fetcher } from '@ahoo-wang/fetcher';
 import { ResultExtractors } from '@ahoo-wang/fetcher';
 import { IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY } from './cosecRequestInterceptor';
+import { UNAUTHORIZED_ERROR_INTERCEPTOR_NAME } from './unauthorizedErrorInterceptor';
 
 /**
  * Interface representing an access token used for authentication.
@@ -188,11 +189,24 @@ export class CoSecTokenRefresher implements TokenRefresher {
    *
    * @warning **Important**: Always include the `IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY` attribute
    * in refresh requests to avoid infinite loops caused by recursive token refresh attempts.
+   * @param shouldNotifyUnauthorized Optional manager guard, evaluated when a refresh error reaches the unauthorized interceptor
    */
-  refresh(token: CompositeToken): Promise<CompositeToken> {
+  refresh(
+    token: CompositeToken,
+    shouldNotifyUnauthorized?: () => boolean,
+  ): Promise<CompositeToken> {
     // Send a POST request to the configured endpoint with the token as body
     // and extract the response as JSON to return a new CompositeToken
 
+    const attributes = new Map<string, unknown>([
+      [IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY, true],
+    ]);
+    if (shouldNotifyUnauthorized) {
+      attributes.set(
+        UNAUTHORIZED_ERROR_INTERCEPTOR_NAME,
+        shouldNotifyUnauthorized,
+      );
+    }
     return this.options.fetcher.post<CompositeToken>(
       this.options.endpoint,
       {
@@ -200,7 +214,7 @@ export class CoSecTokenRefresher implements TokenRefresher {
       },
       {
         resultExtractor: ResultExtractors.Json,
-        attributes: new Map([[IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY, true]]),
+        attributes,
       },
     );
   }

--- a/packages/cosec/src/unauthorizedErrorInterceptor.ts
+++ b/packages/cosec/src/unauthorizedErrorInterceptor.ts
@@ -12,7 +12,10 @@
  */
 import type { ErrorInterceptor, FetchExchange } from '@ahoo-wang/fetcher';
 import { ResponseCodes } from './types';
-import { RefreshTokenError } from './jwtTokenManager';
+import {
+  RefreshSessionChangedError,
+  RefreshTokenError,
+} from './jwtTokenManager';
 
 /**
  * The name identifier for the UnauthorizedErrorInterceptor.
@@ -112,10 +115,19 @@ export class UnauthorizedErrorInterceptor implements ErrorInterceptor {
    * ```
    */
   async intercept(exchange: FetchExchange): Promise<void> {
+    const notification = exchange.attributes?.get(this.name);
+    if (
+      exchange.error instanceof RefreshSessionChangedError ||
+      notification === true
+    ) {
+      return;
+    }
     if (
       exchange.response?.status === ResponseCodes.UNAUTHORIZED ||
       exchange.error instanceof RefreshTokenError
     ) {
+      if (typeof notification === 'function' && !notification()) return;
+      exchange.attributes?.set(this.name, true);
       await this.options.onUnauthorized(exchange);
     }
   }

--- a/packages/cosec/test/anonymousSession.test.ts
+++ b/packages/cosec/test/anonymousSession.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Fetcher } from '@ahoo-wang/fetcher';
+import { InMemoryStorage } from '@ahoo-wang/fetcher-storage';
+import { SerialTypedEventBus } from '@ahoo-wang/fetcher-eventbus';
+import { it, expect, vi } from 'vitest';
+import {
+  AuthorizationRequestInterceptor,
+  AuthorizationResponseInterceptor,
+  JwtTokenManager,
+  TokenStorage,
+  UnauthorizedErrorInterceptor,
+} from '../src';
+
+const token = (id: string) => {
+  const jwt = `e30.${btoa(JSON.stringify({ jti: id, exp: Date.now() / 1000 + 7200 }))}.signature`;
+  return { accessToken: jwt, refreshToken: jwt };
+};
+
+it.each([true, false])(
+  'preserves initial anonymous ownership with request interceptor = %s',
+  async installRequest => {
+    const storage = new TokenStorage({
+      storage: new InMemoryStorage(),
+      eventBus: new SerialTypedEventBus('anonymous-session'),
+    });
+    const original = token('login');
+    const refreshed = token('refreshed');
+    const refresh = vi.fn(async () => refreshed);
+    const manager = new JwtTokenManager(storage, { refresh });
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    if (installRequest)
+      client.interceptors.request.use(
+        new AuthorizationRequestInterceptor({ tokenManager: manager }),
+      );
+    client.interceptors.response.use(
+      new AuthorizationResponseInterceptor({ tokenManager: manager }),
+    );
+    const unauthorized = vi.fn();
+    client.interceptors.error.use(
+      new UnauthorizedErrorInterceptor({ onUnauthorized: unauthorized }),
+    );
+    let started!: () => void;
+    const sentRequest = new Promise<void>(resolve => {
+      started = resolve;
+    });
+    let respond!: (response: Response) => void;
+    const sent: { method?: string; authorization: string | null }[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      sent.push({
+        method: init.method,
+        authorization: new Headers(init.headers).get('Authorization'),
+      });
+      if (sent.length === 1) {
+        started();
+        return new Promise<Response>(resolve => {
+          respond = resolve;
+        });
+      }
+      return new Response('', { status: 200 });
+    });
+    try {
+      const request = client.post('/anonymous').then(
+        response => ({ status: response.status }),
+        error => ({ error: error.exchange?.error?.name }),
+      );
+      await sentRequest;
+      storage.signIn(original);
+      const loggedIn = storage.get();
+      respond(new Response('', { status: 401 }));
+      expect(await request).toEqual(
+        installRequest
+          ? { error: 'RefreshSessionChangedError' }
+          : { status: 200 },
+      );
+      expect(sent[0]).toEqual({ method: 'POST', authorization: null });
+      expect(sent).toHaveLength(installRequest ? 1 : 2);
+      expect(refresh).toHaveBeenCalledTimes(installRequest ? 0 : 1);
+      expect(unauthorized).not.toHaveBeenCalled();
+      if (installRequest) expect(storage.get()).toBe(loggedIn);
+      else expect(storage.get()?.token).toEqual(refreshed);
+    } finally {
+      storage.destroy();
+      storage.eventBus.destroy();
+      vi.unstubAllGlobals();
+    }
+  },
+);

--- a/packages/cosec/test/authLifecycle.test.ts
+++ b/packages/cosec/test/authLifecycle.test.ts
@@ -1,0 +1,363 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Fetcher, type FetchExchange } from '@ahoo-wang/fetcher';
+import { SerialTypedEventBus } from '@ahoo-wang/fetcher-eventbus';
+import { InMemoryStorage } from '@ahoo-wang/fetcher-storage';
+import {
+  AuthorizationRequestInterceptor,
+  AuthorizationResponseInterceptor,
+  CoSecTokenRefresher,
+  ForbiddenErrorInterceptor,
+  IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY,
+  JwtTokenManager,
+  RefreshTokenError,
+  TokenStorage,
+  UnauthorizedErrorInterceptor,
+  type CompositeToken,
+} from '../src';
+
+const jwt = (sub: string, exp: number) =>
+  `e30.${btoa(JSON.stringify({ sub, exp }))}.signature`;
+const token = (sub: string): CompositeToken => ({
+  accessToken: jwt(sub, Date.now() / 1000 + 3600),
+  refreshToken: jwt(sub, Date.now() / 1000 + 7200),
+});
+
+describe('authentication lifecycle', () => {
+  let storage: TokenStorage;
+
+  beforeEach(() => {
+    storage = new TokenStorage({
+      storage: new InMemoryStorage(),
+      eventBus: new SerialTypedEventBus('auth-lifecycle'),
+    });
+    storage.signIn(token('original'));
+  });
+
+  afterEach(() => {
+    storage.destroy();
+    storage.eventBus.destroy();
+  });
+
+  it.each(['success', 'failure'] as const)(
+    'keeps a signed-out session signed out after refresh %s',
+    async outcome => {
+      let resolve!: (value: CompositeToken) => void;
+      let reject!: (error: Error) => void;
+      const manager = new JwtTokenManager(storage, {
+        refresh: () =>
+          new Promise((yes, no) => {
+            resolve = yes;
+            reject = no;
+          }),
+      });
+      const refresh = manager.refresh();
+      const settled = refresh.catch(() => undefined);
+      storage.signOut();
+      if (outcome === 'success') resolve(token('refreshed'));
+      else reject(new Error('refresh rejected'));
+      await settled;
+      expect(storage.get()).toBeNull();
+    },
+  );
+
+  it.each(['success', 'failure'] as const)(
+    'preserves a replacement session after old refresh %s',
+    async outcome => {
+      let resolve!: (value: CompositeToken) => void;
+      let reject!: (error: Error) => void;
+      const manager = new JwtTokenManager(storage, {
+        refresh: () =>
+          new Promise((yes, no) => {
+            resolve = yes;
+            reject = no;
+          }),
+      });
+      const settled = manager.refresh().catch(() => undefined);
+      const replacement = token('replacement');
+      storage.signOut();
+      storage.signIn(replacement);
+      if (outcome === 'success') resolve(token('refreshed'));
+      else reject(new Error('refresh rejected'));
+      await settled;
+      expect(storage.get()?.token).toEqual(replacement);
+    },
+  );
+
+  it.each(['proactive', '401'])(
+    'notifies once for a failed %s refresh through the same Fetcher',
+    async trigger => {
+      if (trigger === 'proactive') {
+        storage.signIn({
+          ...token('original'),
+          accessToken: jwt('original', Date.now() / 1000 - 1),
+        });
+      }
+      const client = new Fetcher({ baseURL: 'https://example.test' });
+      const manager = new JwtTokenManager(
+        storage,
+        new CoSecTokenRefresher({
+          fetcher: client,
+          endpoint: '/refresh',
+        }),
+      );
+      client.interceptors.request.use(
+        new AuthorizationRequestInterceptor({ tokenManager: manager }),
+      );
+      client.interceptors.response.use(
+        new AuthorizationResponseInterceptor({ tokenManager: manager }),
+      );
+      const unauthorized: FetchExchange[] = [];
+      client.interceptors.error.use(
+        new UnauthorizedErrorInterceptor({
+          onUnauthorized: exchange => {
+            unauthorized.push(exchange);
+          },
+        }),
+      );
+      const requested: string[] = [];
+      vi.stubGlobal('fetch', async (url: string) => {
+        requested.push(url);
+        return new Response('', { status: 401 });
+      });
+      const result = client.get('/resource').then(
+        () => 'resolved',
+        () => 'rejected',
+      );
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const outcome = await Promise.race([
+          result,
+          new Promise(resolve => {
+            timer = setTimeout(() => resolve('pending'), 100);
+          }),
+        ]);
+        expect(outcome).toBe('rejected');
+        expect(requested).toEqual(
+          trigger === 'proactive'
+            ? ['https://example.test/refresh']
+            : ['https://example.test/resource', 'https://example.test/refresh'],
+        );
+        expect(storage.get()).toBeNull();
+        expect(unauthorized).toHaveLength(1);
+        expect(unauthorized[0].request.url).toMatch(/\/resource$/);
+        expect(unauthorized[0].error).toBeInstanceOf(RefreshTokenError);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  );
+
+  it.each([401, 403])(
+    'preserves %i notification when only refresh is ignored',
+    async status => {
+      const client = new Fetcher({ baseURL: 'https://example.test' });
+      const manager = new JwtTokenManager(storage, {
+        refresh: async old => old,
+      });
+      client.interceptors.request.use(
+        new AuthorizationRequestInterceptor({ tokenManager: manager }),
+      );
+      client.interceptors.response.use(
+        new AuthorizationResponseInterceptor({ tokenManager: manager }),
+      );
+      const notifications: string[] = [];
+      client.interceptors.error.use(
+        new UnauthorizedErrorInterceptor({
+          onUnauthorized: () => {
+            notifications.push('unauthorized');
+          },
+        }),
+      );
+      client.interceptors.error.use(
+        new ForbiddenErrorInterceptor({
+          onForbidden: async () => {
+            notifications.push('forbidden');
+          },
+        }),
+      );
+      vi.stubGlobal('fetch', async () => new Response('', { status }));
+
+      await expect(
+        client.post(
+          '/logout',
+          {},
+          {
+            attributes: new Map([[IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY, true]]),
+          },
+        ),
+      ).rejects.toMatchObject({ exchange: { response: { status } } });
+      expect(notifications).toEqual([
+        status === 401 ? 'unauthorized' : 'forbidden',
+      ]);
+    },
+  );
+
+  it('notifies once when the refreshed request still returns 401', async () => {
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    const refreshed = token('refreshed');
+    const manager = new JwtTokenManager(storage, {
+      refresh: async () => refreshed,
+    });
+    client.interceptors.request.use(
+      new AuthorizationRequestInterceptor({ tokenManager: manager }),
+    );
+    client.interceptors.response.use(
+      new AuthorizationResponseInterceptor({ tokenManager: manager }),
+    );
+    const unauthorized: FetchExchange[] = [];
+    client.interceptors.error.use(
+      new UnauthorizedErrorInterceptor({
+        onUnauthorized: exchange => {
+          unauthorized.push(exchange);
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', async () => new Response('', { status: 401 }));
+
+    await expect(client.get('/resource')).rejects.toMatchObject({
+      exchange: { response: { status: 401 } },
+    });
+    expect(unauthorized).toHaveLength(1);
+    expect(storage.get()?.token).toEqual(refreshed);
+  });
+
+  it('preserves an explicitly supplied lowercase authorization header', async () => {
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    const manager = new JwtTokenManager(storage, { refresh: async old => old });
+    client.interceptors.request.use(
+      new AuthorizationRequestInterceptor({ tokenManager: manager }),
+    );
+    let authorization: string | null = null;
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      authorization = new Headers(init.headers).get('authorization');
+      return new Response('{}');
+    });
+    await client.get('/resource', {
+      headers: { authorization: 'Bearer explicit' },
+    });
+    expect(authorization).toBe('Bearer explicit');
+  });
+
+  it.each([
+    ['Authorization', 'Bearer explicit'],
+    ['authorization', 'Bearer explicit'],
+    ['AUTHORIZATION', ''],
+  ])('does not retry a 401 with explicit %s: %j', async (name, credential) => {
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    const manager = new JwtTokenManager(storage, {
+      refresh: async () => token('refreshed'),
+    });
+    client.interceptors.request.use(
+      new AuthorizationRequestInterceptor({ tokenManager: manager }),
+    );
+    client.interceptors.response.use(
+      new AuthorizationResponseInterceptor({ tokenManager: manager }),
+    );
+    const original = storage.get();
+    const authorizations: (string | null)[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const authorization = new Headers(init.headers).get('authorization');
+      authorizations.push(authorization);
+      return new Response('', {
+        status: authorization === credential ? 401 : 200,
+      });
+    });
+
+    await expect(
+      client.post('/resource', { headers: { [name]: credential } }),
+    ).rejects.toMatchObject({ exchange: { response: { status: 401 } } });
+    expect(authorizations).toEqual([credential]);
+    expect(storage.get()).toBe(original);
+  });
+
+  it('retries a managed authorization header with the refreshed token', async () => {
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    const refreshed = token('refreshed');
+    const original = storage.get()!.token;
+    const manager = new JwtTokenManager(storage, {
+      refresh: async () => refreshed,
+    });
+    client.interceptors.request.use(
+      new AuthorizationRequestInterceptor({ tokenManager: manager }),
+    );
+    client.interceptors.response.use(
+      new AuthorizationResponseInterceptor({ tokenManager: manager }),
+    );
+    const authorizations: (string | null)[] = [];
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      authorizations.push(new Headers(init.headers).get('authorization'));
+      return new Response('', {
+        status: authorizations.length === 1 ? 401 : 200,
+      });
+    });
+
+    const response = await client.get('/resource');
+    expect(response.status).toBe(200);
+    expect(authorizations).toEqual([
+      `Bearer ${original.accessToken}`,
+      `Bearer ${refreshed.accessToken}`,
+    ]);
+    expect(storage.get()?.token).toEqual(refreshed);
+  });
+
+  it.each(['success', 'failure'] as const)(
+    'deduplicates replacement-session refresh independently of old refresh %s',
+    async outcome => {
+      const original = storage.get()!.token;
+      const replacement = token('replacement');
+      const refreshed = token('replacement-refreshed');
+      const requestedTokens: string[] = [];
+      let resolveOld!: (value: CompositeToken) => void;
+      let rejectOld!: (error: Error) => void;
+      let resolveNew!: (value: CompositeToken) => void;
+      const manager = new JwtTokenManager(storage, {
+        refresh: current => {
+          requestedTokens.push(current.accessToken);
+          return new Promise((resolve, reject) => {
+            if (current.accessToken === original.accessToken) {
+              resolveOld = resolve;
+              rejectOld = reject;
+            } else {
+              resolveNew = resolve;
+            }
+          });
+        },
+      });
+      const first = manager.refresh().catch(() => undefined);
+      storage.signOut();
+      storage.signIn(replacement);
+      const second = manager.refresh().then(
+        () => 'refreshed',
+        () => 'rejected',
+      );
+      expect(requestedTokens).toEqual([
+        original.accessToken,
+        replacement.accessToken,
+      ]);
+
+      if (outcome === 'success') resolveOld(token('old-refreshed'));
+      else rejectOld(new Error('old refresh failed'));
+      await first;
+      expect(storage.get()?.token).toEqual(replacement);
+      const third = manager.refresh();
+      expect(requestedTokens).toHaveLength(2);
+
+      resolveNew(refreshed);
+      await expect(second).resolves.toBe('refreshed');
+      await third;
+      expect(storage.get()?.token).toEqual(refreshed);
+    },
+  );
+});

--- a/packages/cosec/test/authorizationResponseInterceptor.rotation.test.ts
+++ b/packages/cosec/test/authorizationResponseInterceptor.rotation.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Fetcher } from '@ahoo-wang/fetcher';
+import { InMemoryStorage } from '@ahoo-wang/fetcher-storage';
+import { SerialTypedEventBus } from '@ahoo-wang/fetcher-eventbus';
+import {
+  AuthorizationRequestInterceptor,
+  AuthorizationResponseInterceptor,
+  CoSecTokenRefresher,
+  JwtTokenManager,
+  TokenStorage,
+  UnauthorizedErrorInterceptor,
+} from '../src';
+
+const jwt = (version: string, exp: number) =>
+  `e30.${btoa(JSON.stringify({ sub: 'same-user', jti: version, exp }))}.signature`;
+const token = (version: string) => ({
+  accessToken: jwt(version, Date.now() / 1000 + 3600),
+  refreshToken: jwt(version, Date.now() / 1000 + 7200),
+});
+
+describe('authorization after token rotation', () => {
+  let storage: TokenStorage;
+  beforeEach(() => {
+    storage = new TokenStorage({
+      storage: new InMemoryStorage(),
+      eventBus: new SerialTypedEventBus('token-rotation'),
+    });
+  });
+  afterEach(() => {
+    storage.destroy();
+    storage.eventBus.destroy();
+  });
+
+  it.each([
+    'success',
+    'unauthorized',
+    'refresh expired',
+    'two rotations',
+    'new login',
+  ] as const)(
+    'handles a late original-token 401 after rotation: %s',
+    async outcome => {
+      const original = token('A');
+      const refreshed = {
+        ...token('B'),
+        ...(outcome === 'refresh expired'
+          ? { refreshToken: jwt('B', Date.now() / 1000 - 1) }
+          : {}),
+      };
+      const successor = token('C');
+      let expectedToken = refreshed;
+      storage.signIn(original);
+      const client = new Fetcher({ baseURL: 'https://example.test' });
+      const refresher = new CoSecTokenRefresher({
+        fetcher: client,
+        endpoint: '/refresh',
+      });
+      const refresh = vi.spyOn(refresher, 'refresh');
+      const manager = new JwtTokenManager(storage, refresher);
+      client.interceptors.request.use(
+        new AuthorizationRequestInterceptor({ tokenManager: manager }),
+      );
+      client.interceptors.response.use(
+        new AuthorizationResponseInterceptor({ tokenManager: manager }),
+      );
+      const onUnauthorized = vi.fn();
+      client.interceptors.error.use(
+        new UnauthorizedErrorInterceptor({ onUnauthorized }),
+      );
+
+      let bothStarted!: () => void;
+      const started = new Promise<void>(resolve => {
+        bothStarted = resolve;
+      });
+      const pending = new Map<string, (response: Response) => void>();
+      const sent: { path: string; authorization: string | null }[] = [];
+      vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+        const path = new URL(url).pathname;
+        if (path === '/refresh')
+          return Response.json(
+            outcome === 'two rotations' && refresh.mock.calls.length > 1
+              ? successor
+              : refreshed,
+          );
+        const authorization = new Headers(init.headers).get('Authorization');
+        sent.push({ path, authorization });
+        if (authorization === `Bearer ${original.accessToken}`) {
+          return new Promise<Response>(resolve => {
+            pending.set(path, resolve);
+            if (pending.size === 2) bothStarted();
+          });
+        }
+        return new Response('', {
+          status: path === '/late' && outcome === 'unauthorized' ? 401 : 200,
+        });
+      });
+      const settled = (path: string) =>
+        client.get(path).then(
+          response => ({ status: response.status }),
+          error => ({
+            status: error.exchange?.response?.status,
+            error: error.exchange?.error?.name,
+          }),
+        );
+      const first = settled('/first');
+      const late = settled('/late');
+      await started;
+      pending.get('/first')!(new Response('', { status: 401 }));
+      expect(await first).toEqual({ status: 200 });
+      expect(storage.get()?.token).toEqual(refreshed);
+      expect(refresh).toHaveBeenCalledTimes(1);
+
+      if (outcome === 'two rotations') {
+        await manager.refresh();
+        expectedToken = successor;
+      }
+      if (outcome === 'new login') {
+        const previousSession = storage.get()!;
+        storage.signOut();
+        storage.signIn(previousSession.token);
+        expect(storage.get()).not.toBe(previousSession);
+      }
+      pending.get('/late')!(new Response('', { status: 401 }));
+      const result = await late;
+      if (outcome === 'new login') {
+        expect(result).toMatchObject({ error: 'RefreshSessionChangedError' });
+        expect(sent.filter(request => request.path === '/late')).toEqual([
+          { path: '/late', authorization: `Bearer ${original.accessToken}` },
+        ]);
+      } else {
+        expect(result.status).toBe(outcome === 'unauthorized' ? 401 : 200);
+        expect(sent.filter(request => request.path === '/late')).toEqual([
+          { path: '/late', authorization: `Bearer ${original.accessToken}` },
+          {
+            path: '/late',
+            authorization: `Bearer ${expectedToken.accessToken}`,
+          },
+        ]);
+      }
+      expect(refresh).toHaveBeenCalledTimes(
+        outcome === 'two rotations' ? 2 : 1,
+      );
+      expect(onUnauthorized).toHaveBeenCalledTimes(
+        outcome === 'unauthorized' ? 1 : 0,
+      );
+      expect(storage.get()?.token).toEqual(expectedToken);
+    },
+  );
+});

--- a/packages/cosec/test/authorizationResponseInterceptor.test.ts
+++ b/packages/cosec/test/authorizationResponseInterceptor.test.ts
@@ -42,7 +42,9 @@ describe('AuthorizationResponseInterceptor', () => {
 
     mockTokenStorage = {
       get: vi.fn(),
-      setCompositeToken: vi.fn(),
+      set: vi.fn().mockImplementation(token => {
+        mockTokenStorage.get = vi.fn().mockReturnValue(token);
+      }),
       remove: vi.fn(),
     } as unknown as TokenStorage;
 
@@ -136,35 +138,6 @@ describe('AuthorizationResponseInterceptor', () => {
     expect(mockFetcher.interceptors.exchange).toHaveBeenCalledWith(exchange);
   });
 
-  // Regression test: retrying re-runs the whole request interceptor chain,
-  // where AuthorizationRequestInterceptor skips requests that already carry an
-  // Authorization header. The stale header must be dropped before the retry,
-  // otherwise the retried request sends the old token again and 401s forever.
-  it('should drop the stale Authorization header before retrying', async () => {
-    const exchange = {
-      response: {
-        status: ResponseCodes.UNAUTHORIZED,
-      } as Response,
-      fetcher: mockFetcher,
-      request: {
-        headers: { Authorization: 'Bearer stale-token' },
-      },
-      attributes: new Map(),
-    } as unknown as FetchExchange;
-
-    mockTokenStorage.get = vi.fn().mockReturnValue({
-      token: 'current-token',
-    });
-
-    mockTokenRefresher.refresh = vi.fn().mockResolvedValue('new-token');
-
-    await interceptor.intercept(exchange);
-
-    expect(mockTokenRefresher.refresh).toHaveBeenCalled();
-    expect(mockFetcher.interceptors.exchange).toHaveBeenCalledWith(exchange);
-    expect(exchange.request?.headers?.Authorization).toBeUndefined();
-  });
-
   it('should clear tokens and throw error when token refresh fails', async () => {
     const exchange = {
       response: {
@@ -200,9 +173,6 @@ describe('AuthorizationResponseInterceptor', () => {
         status: ResponseCodes.UNAUTHORIZED,
       } as Response,
       fetcher: mockFetcher,
-      request: {
-        headers: { Authorization: 'Bearer stale-token' },
-      },
       attributes: new Map(),
     } as unknown as FetchExchange;
 
@@ -242,7 +212,7 @@ describe('AuthorizationResponseInterceptor', () => {
 
     expect(mockTokenStorage.get).toHaveBeenCalled();
     expect(mockTokenRefresher.refresh).not.toHaveBeenCalled();
-    expect(mockTokenStorage.remove).toHaveBeenCalled();
+    expect(mockTokenStorage.remove).not.toHaveBeenCalled();
     expect(mockFetcher.interceptors.exchange).not.toHaveBeenCalled();
   });
 

--- a/packages/cosec/test/concurrentCrossTabRefresh.test.ts
+++ b/packages/cosec/test/concurrentCrossTabRefresh.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Fetcher } from '@ahoo-wang/fetcher';
+import { InMemoryStorage } from '@ahoo-wang/fetcher-storage';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  AuthorizationRequestInterceptor,
+  AuthorizationResponseInterceptor,
+  JwtTokenManager,
+  TokenStorage,
+} from '../src';
+
+const token = (version: string) => {
+  const jwt = `e30.${btoa(JSON.stringify({ sub: 'same-user', jti: version, exp: Date.now() / 1000 + 7200 }))}.signature`;
+  return { accessToken: jwt, refreshToken: jwt };
+};
+
+describe('concurrent cross-tab refresh completion', () => {
+  it.each([
+    ['refresh', 'success'],
+    ['refresh', 'failure'],
+    ['sign in', 'success'],
+    ['sign in', 'failure'],
+  ] as const)(
+    'handles another tab completing %s before the local refresh %s',
+    async (operation, outcome) => {
+      const key = `cosec-concurrent-${crypto.randomUUID()}`;
+      const backing = new InMemoryStorage();
+      const first = new TokenStorage({ key, storage: backing });
+      first.signIn(token('A'));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      const second = new TokenStorage({ key, storage: backing });
+      const original = second.get()!;
+      const winner = token('B');
+      const discarded = token('C');
+      let complete!: (value: ReturnType<typeof token>) => void;
+      let fail!: (error: Error) => void;
+      let started!: () => void;
+      const refreshStarted = new Promise<void>(resolve => {
+        started = resolve;
+      });
+      const refresh = vi.fn(() => {
+        started();
+        return new Promise<ReturnType<typeof token>>((resolve, reject) => {
+          complete = resolve;
+          fail = reject;
+        });
+      });
+      const manager = new JwtTokenManager(second, { refresh });
+      const client = new Fetcher({ baseURL: 'https://example.test' });
+      client.interceptors.request.use(
+        new AuthorizationRequestInterceptor({ tokenManager: manager }),
+      );
+      client.interceptors.response.use(
+        new AuthorizationResponseInterceptor({ tokenManager: manager }),
+      );
+      const sent: (string | null)[] = [];
+      vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+        sent.push(new Headers(init.headers).get('Authorization'));
+        return new Response('', { status: sent.length === 1 ? 401 : 200 });
+      });
+      try {
+        const request = client.get('/data').then(
+          response => ({ status: response.status }),
+          error => ({ error: error.exchange?.error?.name }),
+        );
+        await refreshStarted;
+        if (operation === 'refresh') {
+          await new JwtTokenManager(first, {
+            refresh: async () => winner,
+          }).refresh();
+        } else {
+          first.signIn(winner);
+        }
+        await vi.waitFor(() => expect(second.get()).not.toBe(original));
+        const received = second.get();
+        if (outcome === 'success') complete(discarded);
+        else fail(new Error('Refresh credential already rotated'));
+        expect(await request).toEqual(
+          operation === 'refresh'
+            ? { status: 200 }
+            : { error: 'RefreshSessionChangedError' },
+        );
+        expect(second.get()).toBe(received);
+        expect(first.get()?.token).toEqual(winner);
+        expect(second.get()?.token).toEqual(winner);
+        expect(sent).toEqual(
+          operation === 'refresh'
+            ? [
+                `Bearer ${original.token.accessToken}`,
+                `Bearer ${winner.accessToken}`,
+              ]
+            : [`Bearer ${original.token.accessToken}`],
+        );
+        expect(refresh).toHaveBeenCalledOnce();
+      } finally {
+        first.destroy();
+        first.eventBus.destroy();
+        second.destroy();
+        second.eventBus.destroy();
+        vi.unstubAllGlobals();
+      }
+    },
+  );
+});

--- a/packages/cosec/test/crossTabSession.test.ts
+++ b/packages/cosec/test/crossTabSession.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Fetcher } from '@ahoo-wang/fetcher';
+import { InMemoryStorage } from '@ahoo-wang/fetcher-storage';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  AuthorizationRequestInterceptor,
+  AuthorizationResponseInterceptor,
+  JwtTokenManager,
+  JwtCompositeTokenSerializer,
+  TokenStorage,
+} from '../src';
+
+const token = (version: string) => {
+  const jwt = `e30.${btoa(JSON.stringify({ sub: 'same-user', jti: version, exp: Date.now() / 1000 + 7200 }))}.signature`;
+  return { accessToken: jwt, refreshToken: jwt };
+};
+
+describe.each(['current', 'legacy'] as const)(
+  '%s token sessions through real BroadcastChannel',
+  format => {
+    it.each(['refresh', 'sign out and sign in', 'direct sign in'] as const)(
+      'handles a delayed 401 after another tab performs %s',
+      async operation => {
+        const key = `cosec-cross-tab-${crypto.randomUUID()}`;
+        const backing = new InMemoryStorage();
+        const original = token('A');
+        if (format === 'legacy') backing.setItem(key, JSON.stringify(original));
+        const first = new TokenStorage({ key, storage: backing });
+        if (format === 'current') first.signIn(original);
+        // Let the first write finish before connecting the second context.
+        await new Promise(resolve => setTimeout(resolve, 0));
+        const second = new TokenStorage({ key, storage: backing });
+        try {
+          const receivedA = second.get()!;
+          expect(receivedA).not.toBe(first.get());
+          const rotated = token('B');
+          const refreshFirst = vi.fn(async () => rotated);
+          const managerFirst = new JwtTokenManager(first, {
+            refresh: refreshFirst,
+          });
+          const refreshSecond = vi.fn(async () => rotated);
+          const managerSecond = new JwtTokenManager(second, {
+            refresh: refreshSecond,
+          });
+          const client = new Fetcher({ baseURL: 'https://example.test' });
+          client.interceptors.request.use(
+            new AuthorizationRequestInterceptor({
+              tokenManager: managerSecond,
+            }),
+          );
+          client.interceptors.response.use(
+            new AuthorizationResponseInterceptor({
+              tokenManager: managerSecond,
+            }),
+          );
+          let started!: () => void;
+          const requestStarted = new Promise<void>(resolve => {
+            started = resolve;
+          });
+          let finish!: (response: Response) => void;
+          const sent: (string | null)[] = [];
+          vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+            sent.push(new Headers(init.headers).get('Authorization'));
+            if (sent.length === 1) {
+              started();
+              return new Promise<Response>(resolve => {
+                finish = resolve;
+              });
+            }
+            return new Response('', { status: 200 });
+          });
+          const request = client.get('/delayed').then(
+            response => ({ status: response.status }),
+            error => ({ error: error.exchange?.error?.name }),
+          );
+          await requestStarted;
+          if (operation === 'refresh') {
+            await managerFirst.refresh();
+          } else {
+            if (operation === 'sign out and sign in') first.signOut();
+            // Identical JWT strings must still be a different login session.
+            first.signIn(original);
+          }
+          await vi.waitFor(() => expect(second.get()).not.toBe(receivedA));
+          expect(second.get()).not.toBe(first.get());
+          finish(new Response('', { status: 401 }));
+          const result = await request;
+          if (operation === 'refresh') {
+            expect(result).toEqual({ status: 200 });
+            expect(sent).toEqual([
+              `Bearer ${original.accessToken}`,
+              `Bearer ${rotated.accessToken}`,
+            ]);
+            expect(refreshFirst).toHaveBeenCalledOnce();
+          } else {
+            expect(result).toEqual({ error: 'RefreshSessionChangedError' });
+            expect(sent).toEqual([`Bearer ${original.accessToken}`]);
+            expect(refreshFirst).not.toHaveBeenCalled();
+          }
+          expect(refreshSecond).not.toHaveBeenCalled();
+        } finally {
+          first.destroy();
+          first.eventBus.destroy();
+          second.destroy();
+          second.eventBus.destroy();
+          vi.unstubAllGlobals();
+        }
+      },
+    );
+  },
+);
+
+describe('legacy session identifiers', () => {
+  it('uses canonical token fields, retains the migrated ID, and hides raw JWTs', () => {
+    const original = token('canonical');
+    const first = new JwtCompositeTokenSerializer().deserialize(
+      JSON.stringify(original),
+    );
+    const second = new JwtCompositeTokenSerializer().deserialize(
+      JSON.stringify({
+        refreshToken: original.refreshToken,
+        accessToken: original.accessToken,
+      }),
+    );
+    expect(first.sessionId).toBe(second.sessionId);
+    expect(first.sessionId).toMatch(/^legacy:[0-9a-f]{32}$/);
+    expect(first.sessionId).not.toContain(original.accessToken);
+    expect(first.sessionId).not.toContain(original.refreshToken);
+    const restored = new JwtCompositeTokenSerializer().deserialize(
+      new JwtCompositeTokenSerializer().serialize(first),
+    );
+    expect(restored.sessionId).toBe(first.sessionId);
+    expect(restored.token).toEqual(original);
+  });
+
+  it('separates different access or refresh strings even for the same JWT subject', () => {
+    const original = token('first');
+    const changed = token('second');
+    const serializer = new JwtCompositeTokenSerializer();
+    const first = serializer.deserialize(JSON.stringify(original));
+    for (const pair of [
+      { ...original, accessToken: changed.accessToken },
+      { ...original, refreshToken: changed.refreshToken },
+    ]) {
+      expect(serializer.deserialize(JSON.stringify(pair)).sessionId).not.toBe(
+        first.sessionId,
+      );
+    }
+  });
+});

--- a/packages/cosec/test/refreshNotificationOwnership.test.ts
+++ b/packages/cosec/test/refreshNotificationOwnership.test.ts
@@ -1,0 +1,272 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Fetcher, deleteHeader, type FetchExchange } from '@ahoo-wang/fetcher';
+import { InMemoryStorage } from '@ahoo-wang/fetcher-storage';
+import { SerialTypedEventBus } from '@ahoo-wang/fetcher-eventbus';
+import {
+  AuthorizationRequestInterceptor,
+  AuthorizationResponseInterceptor,
+  CoSecTokenRefresher,
+  JwtTokenManager,
+  TokenStorage,
+  UnauthorizedErrorInterceptor,
+} from '../src';
+
+const jwt = (sub: string, exp: number) =>
+  `e30.${btoa(JSON.stringify({ sub, exp }))}.signature`;
+const token = (sub: string, expired = false) => ({
+  accessToken: jwt(sub, Date.now() / 1000 + (expired ? -1 : 3600)),
+  refreshToken: jwt(sub, Date.now() / 1000 + 7200),
+});
+
+describe('shared refresh notification ownership', () => {
+  let storage: TokenStorage;
+  beforeEach(() => {
+    storage = new TokenStorage({
+      storage: new InMemoryStorage(),
+      eventBus: new SerialTypedEventBus('refresh-notification-ownership'),
+    });
+  });
+  afterEach(() => {
+    storage.destroy();
+    storage.eventBus.destroy();
+  });
+
+  function configure(client: Fetcher, manager: JwtTokenManager) {
+    client.interceptors.request.use(
+      new AuthorizationRequestInterceptor({ tokenManager: manager }),
+    );
+    client.interceptors.response.use(
+      new AuthorizationResponseInterceptor({ tokenManager: manager }),
+    );
+  }
+
+  it.each(['proactive', '401'])(
+    'notifies once across later waiters of a shared %s refresh',
+    async trigger => {
+      storage.signIn(token('original', trigger === 'proactive'));
+      const clients = Array.from(
+        { length: 3 },
+        () => new Fetcher({ baseURL: 'https://example.test' }),
+      );
+      const refreshClient = new Fetcher({ baseURL: 'https://example.test' });
+      const refresher = new CoSecTokenRefresher({
+        fetcher: refreshClient,
+        endpoint: '/refresh',
+      });
+      const manager = new JwtTokenManager(storage, refresher);
+      const refreshCalls = vi.spyOn(manager, 'refresh');
+      const notifications: string[] = [];
+      for (const client of clients) configure(client, manager);
+      for (const client of [refreshClient, ...clients.slice(1)]) {
+        client.interceptors.error.use(
+          new UnauthorizedErrorInterceptor({
+            onUnauthorized: exchange => {
+              notifications.push(
+                new URL(exchange.request.url, 'https://example.test').pathname,
+              );
+            },
+          }),
+        );
+      }
+      let release!: (response: Response) => void;
+      let markStarted!: () => void;
+      const started = new Promise<void>(resolve => {
+        markStarted = resolve;
+      });
+      let refreshRequests = 0;
+      vi.stubGlobal('fetch', async (url: string) => {
+        if (url.endsWith('/refresh')) {
+          refreshRequests++;
+          markStarted();
+          return new Promise<Response>(resolve => {
+            release = resolve;
+          });
+        }
+        return new Response('', { status: 401 });
+      });
+      const first = clients[0].post('/first').catch(error => error);
+      await started;
+      const others = clients
+        .slice(1)
+        .map((client, index) =>
+          client.post(`/later-${index}`).catch(error => error),
+        );
+      await vi.waitFor(() => expect(refreshCalls).toHaveBeenCalledTimes(3));
+      release(new Response('', { status: 401 }));
+      const results = await Promise.all([first, ...others]);
+      expect(results).toEqual(
+        Array.from({ length: 3 }, () =>
+          expect.objectContaining({
+            exchange: expect.objectContaining({
+              error: expect.objectContaining({ name: 'RefreshTokenError' }),
+            }),
+          }),
+        ),
+      );
+      expect(refreshRequests).toBe(1);
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]).toMatch(/^\/later-/);
+      expect(storage.get()).toBeNull();
+    },
+  );
+
+  it.each(['resolve', 'reject', 'sign-out-reject', 'sign-in-reject'])(
+    'does not notify a waiter after the refresh callback starts and ends with %s',
+    async outcome => {
+      storage.signIn(token('original', true));
+      const client = new Fetcher({ baseURL: 'https://example.test' });
+      const laterClient = new Fetcher({ baseURL: 'https://example.test' });
+      const refreshClient = new Fetcher({ baseURL: 'https://example.test' });
+      const manager = new JwtTokenManager(
+        storage,
+        new CoSecTokenRefresher({
+          fetcher: refreshClient,
+          endpoint: '/refresh',
+        }),
+      );
+      configure(client, manager);
+      configure(laterClient, manager);
+      let releaseNotification!: () => void;
+      let notificationStarted!: () => void;
+      const started = new Promise<void>(resolve => {
+        notificationStarted = resolve;
+      });
+      const notifications: string[] = [];
+      const callbackError = new Error('unauthorized callback failed');
+      const replacement = token('replacement');
+      refreshClient.interceptors.error.use(
+        new UnauthorizedErrorInterceptor({
+          onUnauthorized: async exchange => {
+            notifications.push(
+              new URL(exchange.request.url, 'https://example.test').pathname,
+            );
+            notificationStarted();
+            await new Promise<void>(resolve => {
+              releaseNotification = resolve;
+            });
+            if (outcome === 'sign-out-reject') storage.signOut();
+            if (outcome === 'sign-in-reject') storage.signIn(replacement);
+            if (outcome !== 'resolve') throw callbackError;
+          },
+        }),
+      );
+      laterClient.interceptors.error.use(
+        new UnauthorizedErrorInterceptor({
+          onUnauthorized: exchange => {
+            notifications.push(
+              new URL(exchange.request.url, 'https://example.test').pathname,
+            );
+          },
+        }),
+      );
+      const refreshCalls = vi.spyOn(manager, 'refresh');
+      vi.stubGlobal('fetch', async () => new Response('', { status: 401 }));
+      const first = client.post('/first').catch(error => error);
+      await started;
+      const later = laterClient.post('/later').catch(error => error);
+      await vi.waitFor(() => expect(refreshCalls).toHaveBeenCalledTimes(2));
+      releaseNotification();
+      const results = await Promise.all([first, later]);
+      expect(notifications).toEqual(['/refresh']);
+      for (const result of results) {
+        expect(result.exchange.error.name).toBe(
+          outcome === 'sign-in-reject'
+            ? 'RefreshSessionChangedError'
+            : 'RefreshTokenError',
+        );
+        if (outcome !== 'resolve') {
+          expect(result.exchange.error.cause).toBe(callbackError);
+        }
+      }
+      if (outcome === 'sign-in-reject') {
+        expect(storage.get()?.token.accessToken).toBe(replacement.accessToken);
+      } else {
+        expect(storage.get()).toBeNull();
+      }
+    },
+  );
+
+  it('does not claim a notification for a non-401 refresh error', async () => {
+    const refreshClient = new Fetcher({ baseURL: 'https://example.test' });
+    const claimNotification = vi.fn(() => true);
+    const onUnauthorized = vi.fn();
+    refreshClient.interceptors.error.use(
+      new UnauthorizedErrorInterceptor({ onUnauthorized }),
+    );
+    const refresher = new CoSecTokenRefresher({
+      fetcher: refreshClient,
+      endpoint: '/refresh',
+    });
+    vi.stubGlobal('fetch', async () => new Response('', { status: 500 }));
+    await expect(
+      refresher.refresh(token('original'), claimNotification),
+    ).rejects.toMatchObject({ exchange: { response: { status: 500 } } });
+    expect(claimNotification).not.toHaveBeenCalled();
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it.each(['object', 'headers', 'tuples'])(
+    'does not replay an anonymous POST after a later interceptor deletes %s authorization',
+    async shape => {
+      storage.signIn(token('original'));
+      const original = storage.get();
+      const refresh = vi.fn(async () => token('refreshed'));
+      const manager = new JwtTokenManager(storage, { refresh });
+      const client = new Fetcher({ baseURL: 'https://example.test' });
+      configure(client, manager);
+      client.interceptors.request.use({
+        name: 'anonymous-endpoint',
+        order: 0,
+        intercept: async (exchange: FetchExchange) => {
+          deleteHeader(exchange.ensureRequestHeaders(), 'Authorization');
+        },
+      });
+      const authorizations: (string | null)[] = [];
+      vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+        authorizations.push(new Headers(init.headers).get('Authorization'));
+        return new Response('', { status: 401 });
+      });
+      const headers =
+        shape === 'headers' ? new Headers() : shape === 'tuples' ? [] : {};
+      await expect(
+        client.post('/anonymous', { headers }),
+      ).rejects.toMatchObject({
+        exchange: { response: { status: 401 } },
+      });
+      expect(authorizations).toEqual([null]);
+      expect(refresh).not.toHaveBeenCalled();
+      expect(storage.get()).toBe(original);
+    },
+  );
+
+  it('keeps the response-only refresh path when no credential was injected', async () => {
+    storage.signIn(token('original'));
+    const refresh = vi.fn(async () => token('refreshed'));
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    client.interceptors.response.use(
+      new AuthorizationResponseInterceptor({
+        tokenManager: new JwtTokenManager(storage, { refresh }),
+      }),
+    );
+    let requests = 0;
+    vi.stubGlobal(
+      'fetch',
+      async () => new Response('', { status: ++requests === 1 ? 401 : 200 }),
+    );
+    expect((await client.get('/resource')).status).toBe(200);
+    expect(requests).toBe(2);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cosec/test/sessionOwnership.test.ts
+++ b/packages/cosec/test/sessionOwnership.test.ts
@@ -1,0 +1,256 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Fetcher } from '@ahoo-wang/fetcher';
+import { InMemoryStorage } from '@ahoo-wang/fetcher-storage';
+import { SerialTypedEventBus } from '@ahoo-wang/fetcher-eventbus';
+import {
+  AuthorizationRequestInterceptor,
+  AuthorizationResponseInterceptor,
+  CoSecTokenRefresher,
+  JwtTokenManager,
+  TokenStorage,
+  UnauthorizedErrorInterceptor,
+} from '../src';
+
+const jwt = (sub: string, exp: number) =>
+  `e30.${btoa(JSON.stringify({ sub, exp }))}.signature`;
+const token = (sub: string, expired = false) => ({
+  accessToken: jwt(sub, Date.now() / 1000 + (expired ? -1 : 3600)),
+  refreshToken: jwt(sub, Date.now() / 1000 + 7200),
+});
+
+describe('refresh session ownership', () => {
+  let storage: TokenStorage;
+  beforeEach(() => {
+    storage = new TokenStorage({
+      storage: new InMemoryStorage(),
+      eventBus: new SerialTypedEventBus('session-ownership'),
+    });
+  });
+  afterEach(() => {
+    storage.destroy();
+    storage.eventBus.destroy();
+  });
+
+  function configure(client: Fetcher, refreshClient = client) {
+    const manager = new JwtTokenManager(
+      storage,
+      new CoSecTokenRefresher({ fetcher: refreshClient, endpoint: '/refresh' }),
+    );
+    client.interceptors.request.use(
+      new AuthorizationRequestInterceptor({ tokenManager: manager }),
+    );
+    client.interceptors.response.use(
+      new AuthorizationResponseInterceptor({ tokenManager: manager }),
+    );
+    return manager;
+  }
+
+  it('does not refresh a replacement session for an earlier managed 401', async () => {
+    const original = token('A');
+    const replacement = token('B');
+    storage.signIn(original);
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    configure(client);
+    const requests: (string | null)[] = [];
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      if (url.endsWith('/refresh')) return Response.json(token('B-refreshed'));
+      requests.push(new Headers(init.headers).get('Authorization'));
+      if (requests.length === 1) {
+        storage.signOut();
+        storage.signIn(replacement);
+        return new Response('', { status: 401 });
+      }
+      return new Response('');
+    });
+    await expect(client.post('/transfer')).rejects.toMatchObject({
+      exchange: { error: { name: 'RefreshSessionChangedError' } },
+    });
+    expect(requests).toEqual([`Bearer ${original.accessToken}`]);
+    expect(storage.get()?.token).toEqual(replacement);
+  });
+
+  it.each([
+    ['proactive', 'success'],
+    ['401', 'success'],
+    ['proactive', 'failure'],
+    ['401', 'failure'],
+  ])(
+    'preserves session B when %s refresh %s emits a storage event',
+    async (trigger, outcome) => {
+      const original = token('A', trigger === 'proactive');
+      const replacement = token('B');
+      const refreshed = token('A-refreshed');
+      storage.signIn(original);
+      const client = new Fetcher({ baseURL: 'https://example.test' });
+      configure(client);
+      const notifications: (string | undefined)[] = [];
+      client.interceptors.error.use(
+        new UnauthorizedErrorInterceptor({
+          onUnauthorized: () => {
+            notifications.push(storage.currentUser?.sub);
+            storage.signOut();
+          },
+        }),
+      );
+      storage.addListener({
+        name: 'replace-on-refresh-write',
+        handle: event => {
+          if (
+            outcome === 'success'
+              ? event.newValue?.token.accessToken === refreshed.accessToken
+              : event.newValue === null &&
+                event.oldValue?.token.accessToken === original.accessToken
+          ) {
+            storage.signOut();
+            storage.signIn(replacement);
+          }
+        },
+      });
+      const requests: (string | null)[] = [];
+      vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+        if (url.endsWith('/refresh'))
+          return outcome === 'success'
+            ? Response.json(refreshed)
+            : new Response('', { status: 401 });
+        requests.push(new Headers(init.headers).get('Authorization'));
+        return new Response('', {
+          status: trigger === '401' && requests.length === 1 ? 401 : 200,
+        });
+      });
+      const result = await client.post('/transfer').then(
+        () => 'resolved',
+        error => error.exchange?.error?.name,
+      );
+      expect(result).toBe(
+        outcome === 'success'
+          ? 'RefreshSessionChangedError'
+          : 'RefreshTokenError',
+      );
+      expect(storage.get()?.token).toEqual(replacement);
+      expect(notifications).toEqual([]);
+      expect(requests).toEqual(
+        trigger === 'proactive' ? [] : [`Bearer ${original.accessToken}`],
+      );
+    },
+  );
+
+  it.each([
+    ['proactive', 'success', 'same'],
+    ['401', 'success', 'same'],
+    ['proactive', 'failure', 'same'],
+    ['401', 'failure', 'same'],
+    ['proactive', 'failure', 'refresh-only'],
+    ['401', 'failure', 'refresh-only'],
+  ])(
+    'aborts the old %s request after replacement and refresh %s (%s handler)',
+    async (trigger, outcome, handler) => {
+      const original = token('A', trigger === 'proactive');
+      const replacement = token('B');
+      storage.signIn(original);
+      const client = new Fetcher({ baseURL: 'https://example.test' });
+      const refreshClient =
+        handler === 'same'
+          ? client
+          : new Fetcher({ baseURL: 'https://example.test' });
+      configure(client, refreshClient);
+      let notifications = 0;
+      refreshClient.interceptors.error.use(
+        new UnauthorizedErrorInterceptor({
+          onUnauthorized: () => {
+            notifications++;
+            storage.signOut();
+          },
+        }),
+      );
+      let markStarted!: () => void;
+      const started = new Promise<void>(resolve => {
+        markStarted = resolve;
+      });
+      let finishRefresh!: (response: Response) => void;
+      const requests: (string | null)[] = [];
+      vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+        if (url.endsWith('/refresh')) {
+          markStarted();
+          return new Promise<Response>(resolve => {
+            finishRefresh = resolve;
+          });
+        }
+        requests.push(new Headers(init.headers).get('Authorization'));
+        return new Response('', {
+          status: trigger === '401' && requests.length === 1 ? 401 : 200,
+        });
+      });
+      const request = client.post('/transfer').then(
+        () => 'resolved',
+        () => 'rejected',
+      );
+      await started;
+      storage.signOut();
+      storage.signIn(replacement);
+      finishRefresh(
+        outcome === 'success'
+          ? new Response(JSON.stringify(token('A-refreshed')))
+          : new Response('', { status: 401 }),
+      );
+
+      expect(await request).toBe('rejected');
+      expect(storage.get()?.token).toEqual(replacement);
+      expect(notifications).toBe(0);
+      expect(requests).toEqual(
+        trigger === 'proactive' ? [] : [`Bearer ${original.accessToken}`],
+      );
+    },
+  );
+
+  it('notifies a direct refresher 401 without an outer exchange', async () => {
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    const notifications: string[] = [];
+    client.interceptors.error.use(
+      new UnauthorizedErrorInterceptor({
+        onUnauthorized: exchange => {
+          notifications.push(exchange.request.url);
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', async () => new Response('', { status: 401 }));
+    const refresher = new CoSecTokenRefresher({
+      fetcher: client,
+      endpoint: '/refresh',
+    });
+    await expect(refresher.refresh(token('A'))).rejects.toBeDefined();
+    expect(notifications).toEqual(['https://example.test/refresh']);
+  });
+
+  it('notifies on the refresh client when the API client has no handler', async () => {
+    storage.signIn(token('A'));
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    const refreshClient = new Fetcher({ baseURL: 'https://example.test' });
+    configure(client, refreshClient);
+    const notifications: string[] = [];
+    refreshClient.interceptors.error.use(
+      new UnauthorizedErrorInterceptor({
+        onUnauthorized: exchange => {
+          notifications.push(exchange.request.url);
+          storage.signOut();
+        },
+      }),
+    );
+    vi.stubGlobal('fetch', async () => new Response('', { status: 401 }));
+    await expect(client.post('/transfer')).rejects.toMatchObject({
+      exchange: { error: { name: 'RefreshTokenError' } },
+    });
+    expect(notifications).toEqual(['https://example.test/refresh']);
+    expect(storage.get()).toBeNull();
+  });
+});

--- a/skills/fetcher-cosec-auth/references/api.md
+++ b/skills/fetcher-cosec-auth/references/api.md
@@ -147,7 +147,9 @@ interface CoSecJwtPayload extends JwtPayload {
 
 ### JwtCompositeToken
 
-Manages access/refresh token pairs as a single unit.
+Manages access/refresh token pairs as a single unit. Each instance has a readonly
+`sessionId` generated for a new login. The optional third constructor argument
+restores an existing session generation; managed refreshes preserve it.
 
 ```typescript
 import { JwtCompositeToken } from '@ahoo-wang/fetcher-cosec';
@@ -173,6 +175,16 @@ const serializer = new JwtCompositeTokenSerializer(300);
 const serialized = serializer.serialize(compositeToken);
 const restored = serializer.deserialize(serialized);
 ```
+
+The stored JSON contains `accessToken`, `refreshToken`, and `sessionId`. The
+session generation survives storage restoration and cross-tab broadcasts;
+`restored.token` still contains only the original token fields. Legacy JSON
+without `sessionId` derives a stable, non-cryptographic 128-bit fingerprint of the exact token pair
+so independent tabs retain the same generation during migration. The ID contains
+no raw JWT, does not infer identity from the subject, and survives later
+refreshes. Every explicit `signIn()` still creates a fresh random generation,
+even when the same token pair is reused. This legacy record identifier is not an
+authentication or integrity check; the server still validates JWTs.
 
 ---
 
@@ -268,7 +280,33 @@ deviceStorage.get(); // string | null
 
 ## JwtTokenManager
 
-Manages JWT token lifecycle with deduplicated concurrent refresh calls.
+Manages JWT token lifecycle with concurrent refresh calls deduplicated only for
+the same current token instance. A replacement session starts its own refresh
+without waiting for an older session. A refresh only writes or removes the
+token instance that started it; signing out or replacing the session prevents
+an old result from overwriting the new state.
+If the session changes while refreshing, `RefreshSessionChangedError` rejects
+the original request without sending or retrying it as the replacement user.
+It does not trigger `onUnauthorized`, including when the original response was 401.
+This protection also covers sign-in from token-storage write/removal listeners.
+Each exchange keeps the concrete refresh result and rechecks ownership after
+awaiting refresh, before selecting Authorization, and before unauthorized
+notification. An old `RefreshTokenError` may still propagate after cleanup,
+but its callback cannot sign out a replacement session.
+The request interceptor also records an anonymous start when no token is present.
+A later login cannot replay that earlier anonymous request with the new session;
+a response-only interceptor configuration keeps its existing behavior.
+Tokens created by a successful managed refresh inherit the same login session.
+If another tab finishes refreshing that session first, the pending refresh
+reuses the already stored successor when its duplicate request succeeds or fails.
+A late 401 for an earlier token reuses the stored successor without refreshing
+it again, including successors received from another tab. `signIn` starts a separate session even for the same user or composite
+token object.
+
+`refresh(exchange?: FetchExchange): Promise<void>` accepts the originating
+exchange from authorization interceptors to reuse its session's newer token and
+identify its notification handler.
+Direct calls can continue to omit it.
 
 ```typescript
 import { JwtTokenManager, TokenStorage } from '@ahoo-wang/fetcher-cosec';
@@ -279,7 +317,7 @@ tokenManager.currentToken; // JwtCompositeToken | null
 tokenManager.isRefreshNeeded; // boolean
 tokenManager.isRefreshable; // boolean
 
-await tokenManager.refresh(); // deduplicates concurrent calls
+await tokenManager.refresh(); // deduplicates calls for the same session
 ```
 
 ---
@@ -294,7 +332,20 @@ interface TokenRefresher {
 
 ### CoSecTokenRefresher (Built-in Implementation)
 
-Sends POST requests via a Fetcher instance. Automatically includes `IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY` to prevent infinite loops.
+Sends POST requests via a Fetcher instance. Automatically includes
+`IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY` to prevent infinite loops. Direct calls
+retain the refresh Fetcher's `onUnauthorized` callback. A manager suppresses
+that callback when the session changed or any request waiting on that refresh
+has its own unauthorized interceptor. Otherwise the refresh Fetcher retains
+notification responsibility. Concurrent waiters share one failure notification;
+a notification already started by the refresh Fetcher is not repeated, even
+if its callback throws or rejects. Notification ownership is claimed before
+the callback starts; unrelated refresh errors do not claim it.
+
+The built-in method accepts an optional coordination guard:
+`refresh(token: CompositeToken, shouldNotifyUnauthorized?: () => boolean)`.
+The manager supplies it; ordinary callers can omit it. The `TokenRefresher`
+interface remains the single-token contract above.
 
 ```typescript
 import { CoSecTokenRefresher } from '@ahoo-wang/fetcher-cosec';
@@ -379,7 +430,7 @@ fetcher.interceptors.request.use(
 
 **Behavior:**
 
-1. Skips if Authorization header already present
+1. Skips if Authorization header already present (case-insensitive, including an empty value)
 2. Refreshes token if `isRefreshNeeded && isRefreshable` (unless `IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY` set)
 3. Adds `Authorization: Bearer <access-token>`
 
@@ -397,10 +448,10 @@ fetcher.interceptors.response.use(
 
 **Behavior:**
 
-1. Detects 401 responses (skips entirely when the current token is not refreshable)
-2. Calls `tokenManager.refresh()`
-3. Retries the original request with the new token — at most once per exchange
-4. On refresh failure: clears tokens and throws. A failure of the retried request itself propagates normally without clearing the freshly refreshed token
+1. Detects 401 responses (skips when the exchange carries `IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY`, Authorization was supplied by the caller, or a later interceptor replaced or removed the injected header)
+2. Calls `tokenManager.refresh(exchange)` to reuse a known successor from the same session, or refreshes the current token if it is refreshable
+3. Removes only the managed Authorization header and retries with the new token — at most once per exchange
+4. On refresh failure: the manager clears only the original, unchanged session and throws. The response interceptor does not clear a replacement session. A failure of the retried request itself propagates normally without clearing the freshly refreshed token
 
 ### Skip Token Refresh for Specific Requests
 
@@ -472,7 +523,12 @@ fetcher.interceptors.error.use(
 );
 ```
 
-**Triggers on:** HTTP 401 responses and `RefreshTokenError` exceptions.
+**Triggers on:** HTTP 401 responses and `RefreshTokenError` exceptions, once
+per exchange, with one notification shared by requests whose token refresh
+failed together. The built-in refresh request defers notification when any
+waiting request has an unauthorized handler. `RefreshSessionChangedError`
+does not notify the replacement session. `IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY`
+alone only disables refresh and does not suppress normal 401 notifications.
 
 ### ForbiddenErrorInterceptor (403)
 
@@ -540,27 +596,28 @@ const data = await fetcher.get('/api/protected-resource');
 
 ## Key Classes and Exports
 
-| Class / Export                          | Purpose                                           |
-| --------------------------------------- | ------------------------------------------------- |
-| `CoSecConfigurer`                       | Declarative configuration for all CoSec features  |
-| `CoSecHeaders`                          | Header name constants (DEVICE_ID, APP_ID, etc.)   |
-| `JwtToken<Payload>`                     | Parse JWT with typed payload and expiration check |
-| `JwtCompositeToken`                     | Access/refresh token pair with status checks      |
-| `JwtCompositeTokenSerializer`           | Serialize/deserialize composite tokens            |
-| `CoSecJwtPayload`                       | Extended JWT payload (tenantId, roles, policies)  |
-| `JwtTokenManager`                       | Token lifecycle management with dedup refresh     |
-| `CoSecTokenRefresher`                   | Built-in TokenRefresher using Fetcher POST        |
-| `TokenStorage`                          | JWT token persistence with cross-tab sync         |
-| `DeviceIdStorage`                       | Device ID persistence and generation              |
-| `SpaceIdStorage`                        | Space ID persistence (used by space providers)    |
-| `parseJwtPayload` / `isTokenExpired`    | Low-level JWT utilities for custom token logic    |
-| `AuthorizationRequestInterceptor`       | Adds Bearer token to requests                     |
-| `AuthorizationResponseInterceptor`      | Handles 401 and retries with fresh token          |
-| `CoSecRequestInterceptor`               | Adds CoSec headers (appId, deviceId, requestId)   |
-| `ResourceAttributionRequestInterceptor` | Injects tenantId/ownerId into URL path params     |
-| `UnauthorizedErrorInterceptor`          | Custom 401 error handling                         |
-| `ForbiddenErrorInterceptor`             | Custom 403 error handling                         |
-| `SpaceIdProvider`                       | Multi-tenant space resolution interface           |
-| `DefaultSpaceIdProvider`                | Predicate + storage based space resolution        |
-| `RefreshTokenError`                     | Error thrown when token refresh fails             |
-| `IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY`    | Attribute key to skip auto-refresh for a request  |
+| Class / Export                          | Purpose                                                                              |
+| --------------------------------------- | ------------------------------------------------------------------------------------ |
+| `CoSecConfigurer`                       | Declarative configuration for all CoSec features                                     |
+| `CoSecHeaders`                          | Header name constants (DEVICE_ID, APP_ID, etc.)                                      |
+| `JwtToken<Payload>`                     | Parse JWT with typed payload and expiration check                                    |
+| `JwtCompositeToken`                     | Access/refresh token pair with status checks                                         |
+| `JwtCompositeTokenSerializer`           | Serialize/deserialize composite tokens                                               |
+| `CoSecJwtPayload`                       | Extended JWT payload (tenantId, roles, policies)                                     |
+| `JwtTokenManager`                       | Token lifecycle management with dedup refresh                                        |
+| `CoSecTokenRefresher`                   | Built-in TokenRefresher using Fetcher POST                                           |
+| `TokenStorage`                          | JWT token persistence with cross-tab sync                                            |
+| `DeviceIdStorage`                       | Device ID persistence and generation                                                 |
+| `SpaceIdStorage`                        | Space ID persistence (used by space providers)                                       |
+| `parseJwtPayload` / `isTokenExpired`    | Low-level JWT utilities for custom token logic                                       |
+| `AuthorizationRequestInterceptor`       | Adds Bearer token to requests                                                        |
+| `AuthorizationResponseInterceptor`      | Handles 401 and retries with fresh token                                             |
+| `CoSecRequestInterceptor`               | Adds CoSec headers (appId, deviceId, requestId)                                      |
+| `ResourceAttributionRequestInterceptor` | Injects tenantId/ownerId into URL path params                                        |
+| `UnauthorizedErrorInterceptor`          | Custom 401 error handling                                                            |
+| `ForbiddenErrorInterceptor`             | Custom 403 error handling                                                            |
+| `SpaceIdProvider`                       | Multi-tenant space resolution interface                                              |
+| `DefaultSpaceIdProvider`                | Predicate + storage based space resolution                                           |
+| `RefreshTokenError`                     | Error thrown when token refresh fails                                                |
+| `RefreshSessionChangedError`            | Stops a refresh request after its session changes, without unauthorized side effects |
+| `IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY`    | Attribute key to skip auto-refresh for a request                                     |

--- a/wiki/reference/cosec.md
+++ b/wiki/reference/cosec.md
@@ -81,10 +81,14 @@ const cosec = new CoSecConfigurer({
 cosec.applyTo(api);
 ```
 
-Use a refresh Fetcher that is not configured with this CoSec configurer. The
-built-in refresher marks its request with
-`IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY`, preventing the request interceptor from
-trying to refresh again ([`tokenRefresher.ts:192`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/tokenRefresher.ts#L192)).
+The example uses a separate Fetcher for refresh traffic. The same configured
+Fetcher is also supported: the built-in refresher marks its request with
+`IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY` to skip recursive refresh in both request
+and response interceptors. Its 401 notification is deferred to the originating
+request only when that request's Fetcher has an unauthorized handler. Direct
+refresher calls and a separate refresh Fetcher retain their handler when there
+is no outer handler. An old session's refresh does not notify a replacement session
+([`tokenRefresher.ts:194`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/tokenRefresher.ts#L194)).
 
 ## Token lifecycle and state
 
@@ -103,7 +107,7 @@ does **not** sign out or erase persisted tokens
 | `authenticated` | `boolean` | `true` only when the access JWT is not expired |
 | `currentUser` | `CoSecJwtPayload \| null` | Decoded payload only; never proof of trust |
 | `JwtTokenManager.currentToken` | `JwtCompositeToken \| null` | Current wrapped pair |
-| `JwtTokenManager.refresh()` | `Promise<void>` | Replaces the stored pair or fails and removes it |
+| `JwtTokenManager.refresh()` | `Promise<void>` | Updates or removes only the unchanged session that started the refresh |
 
 `earlyPeriod` defaults to `0` seconds. It shifts expiration earlier for both
 access and refresh JWTs; malformed JWTs are considered expired
@@ -129,8 +133,8 @@ CoSecRequest
 | --- | --- | --- |
 | Request identity | `CoSecRequestInterceptor` | Sets app, device, unique request, and optional space headers |
 | Resource attribution | `ResourceAttributionRequestInterceptor` | Fills missing URL-template `tenantId` and `ownerId` from decoded claims |
-| Bearer request | `AuthorizationRequestInterceptor` | Keeps an explicit `Authorization` header for that request phase; otherwise refreshes if needed and adds `Bearer` |
-| 401 response | `AuthorizationResponseInterceptor` | Refreshes, drops stale Bearer, then reruns the exchange at most once |
+| Bearer request | `AuthorizationRequestInterceptor` | Keeps an explicit `Authorization` header regardless of case; otherwise refreshes if needed and adds `Bearer` |
+| 401 response | `AuthorizationResponseInterceptor` | Preserves caller credentials; otherwise refreshes, drops managed stale Bearer, and retries at most once |
 | Final errors | `UnauthorizedErrorInterceptor`, `ForbiddenErrorInterceptor` | Invoke application callbacks; they do not repair permissions |
 
 The request order is ascending numeric `order`: `CoSecRequestInterceptor`, then
@@ -148,50 +152,62 @@ Use its constructor options only when your templates use different parameter
 names.
 
 Before sending a request, `AuthorizationRequestInterceptor` preserves an
-explicit `Authorization` Header. With an owned token, it refreshes only when
+explicit `Authorization` header regardless of case, including an empty value.
+With a managed token, it refreshes only when
 the access token needs refresh, the refresh JWT remains valid, and the request
 does not contain the ignore-refresh attribute
 ([`authorizationRequestInterceptor.ts:63`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationRequestInterceptor.ts#L63)).
-That preservation applies only to the initial request-interceptor pass: on a
-401, `AuthorizationResponseInterceptor` does not inspect who supplied the
-header. It can refresh, deletes that header, and retries with the managed token.
-For a deliberately different credential, use an independent Fetcher that does
-not install CoSec's authorization-response interceptor
-([`authorizationResponseInterceptor.ts:102`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L102)).
+On a 401, `AuthorizationResponseInterceptor` skips automatic refresh and retry
+when the header was supplied by the caller or replaced after CoSec injected it.
+Only CoSec's injected header can be removed for a retry with the managed token
+([`authorizationResponseInterceptor.ts:95`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L95)).
 
 ## Concurrent refresh, retry, and errors
 
-`JwtTokenManager` stores one in-flight refresh promise. Simultaneous callers
-await that same promise; a successful refresh writes the new pair. A refresh
-failure removes stored state and throws `RefreshTokenError` wrapping the old
-token and original cause ([`jwtTokenManager.ts:59`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L59)).
+`JwtTokenManager` shares an in-flight refresh promise only between callers with
+the same current token instance. A replacement session starts its own refresh
+without waiting for an older session. Success writes the new pair only if the
+starting token is still current; failure removes only that unchanged session
+and throws `RefreshTokenError` wrapping its token and original cause
+([`jwtTokenManager.ts:83`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L83)).
+
+If the session changes during refresh, `RefreshSessionChangedError` rejects
+the original request. It neither sends nor retries that request using the
+replacement session, and it does not trigger `onUnauthorized` for the old 401.
+Authorization interceptors pass their exchange to `refresh(exchange?)` so the
+manager can select the actual notification handler; direct calls can omit it.
+Session changes from token-storage write or removal listeners receive the same
+protection. The exchange retains its refresh result and checks ownership again
+before choosing Authorization and before an unauthorized callback runs.
 
 A 401 response is separate from proactive expiry refresh. The response
 interceptor retries one exchange at most once (`AUTHORIZATION_RESPONSE_MAX_RETRY
-=== 1`). It refreshes only when a refresh token is still usable, removes the
-stale Bearer header before retry, and propagates a retry failure without
-clearing an otherwise fresh token
-([`authorizationResponseInterceptor.ts:72`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L72)).
+=== 1`). It refreshes only when a refresh token is still usable and the request
+does not carry caller credentials or the ignore-refresh attribute. It removes
+the managed stale Bearer header before retry and propagates a retry failure
+without clearing an otherwise fresh token
+([`authorizationResponseInterceptor.ts:80`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L80)).
 
 | Failure | Result |
 | --- | --- |
 | No current token and `refresh()` is called directly | Rejects with `Error('No token found')` |
-| Refresh endpoint / parsing fails | Token storage is removed; `RefreshTokenError` propagates |
+| Refresh endpoint / parsing fails | Only the unchanged starting session is removed; `RefreshTokenError` propagates |
+| Session changes during refresh | `RefreshSessionChangedError` stops the original request; the replacement session is preserved without unauthorized notification |
 | Refresh JWT expired | No 401 refresh/retry; the original response continues |
 | Retry still returns 401 | No second refresh/retry; final error pipeline may run |
-| 401 with configured `onUnauthorized` | Callback runs for 401 or `RefreshTokenError` |
+| 401 with configured `onUnauthorized` | Callback runs once per exchange for 401 or `RefreshTokenError`; a built-in refresh defers only to an existing outer handler |
 | 403 with configured `onForbidden` | Callback runs for 403 only |
 
 ## Cleanup, security, and troubleshooting
 
-`signOut()` does not cancel an in-progress `JwtTokenManager.refresh()`. A refresh
-that succeeds later unconditionally writes its new pair, so it can restore a
-token after sign-out ([`jwtTokenManager.ts:68`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L68)).
-For final logout, stop admitting new protected requests, coordinate cancellation
-or completion of in-flight requests that can trigger refresh, then call
-`signOut()` after that work settles; call it again as the final cleanup if a
-refresh may have completed during the transition. When the storage object itself
-is no longer used, also call `destroy()`. Do not log `CompositeToken`, raw JWT
+`signOut()` clears stored state immediately. It does not cancel an in-progress
+`JwtTokenManager.refresh()`, but the manager discards its late result instead of
+restoring the signed-out token. If another `signIn()` replaces the session,
+the old refresh cannot overwrite or remove that replacement
+([`jwtTokenManager.ts:120`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L120)).
+Applications can still cancel in-flight requests when their results are no
+longer needed. When the storage object itself is no longer used, also call
+`destroy()`. Do not log `CompositeToken`, raw JWT
 strings, Authorization headers, or decoded payloads that contain sensitive
 claims. `parseJwtPayload()` is a
 decode helper, not signature verification; invalid parsing returns `null`, and
@@ -203,10 +219,10 @@ so do not rely on it as a redaction boundary
 | --- | --- |
 | No `Authorization` header | Supply `tokenRefresher`, sign in a valid access JWT, and check that the request did not set its own header. |
 | Repeated 401 | The client retries only once; inspect server-side authorization and refresh endpoint behavior without logging token data. |
-| Token unexpectedly disappears | A failed refresh intentionally removes storage; handle `RefreshTokenError` through `onUnauthorized`. |
+| Token unexpectedly disappears | A failed refresh removes its unchanged starting session; handle `RefreshTokenError` through `onUnauthorized`. |
 | Wrong tenant/owner path | Ensure `{tenantId}` / `{ownerId}` are in the URL template, or pass the explicit values to override attribution. |
 | Tokens survive component teardown | `destroy()` is cleanup only; call `signOut()` to remove the stored entry. |
-| Token reappears after logout | Coordinate in-flight refresh/request work, then perform final `signOut()`; sign-out alone cannot cancel refresh. |
+| Token reappears after logout | The manager discards old refresh results after sign-out; check later `signIn()` calls or other token-storage writers. |
 | Browser security concern | Default `localStorage` is plaintext; move credentials to an HttpOnly/server-side design or provide a reviewed storage adapter. |
 
 ## Source references
@@ -214,5 +230,5 @@ so do not rely on it as a redaction boundary
 - [packages/cosec/src/index.ts:14](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/index.ts#L14)
 - [packages/cosec/src/cosecConfigurer.ts:445](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/cosecConfigurer.ts#L445)
 - [packages/cosec/src/tokenStorage.ts:60](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/tokenStorage.ts#L60)
-- [packages/cosec/src/jwtTokenManager.ts:59](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L59)
+- [packages/cosec/src/jwtTokenManager.ts:83](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L83)
 - [packages/cosec/src/authorizationResponseInterceptor.ts:29](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L29)

--- a/wiki/zh/reference/cosec.md
+++ b/wiki/zh/reference/cosec.md
@@ -76,9 +76,12 @@ const cosec = new CoSecConfigurer({
 cosec.applyTo(api);
 ```
 
-刷新使用的 Fetcher 不应配置这一个 CoSec Configurer。内置 Refresher 会使用
-`IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY` 标记请求，从而防止 Request Interceptor 再次尝试刷新
-([`tokenRefresher.ts:192`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/tokenRefresher.ts#L192))。
+示例为刷新流量使用独立 Fetcher，也支持复用已配置 CoSec 的 Fetcher。内置 Refresher 使用
+`IGNORE_REFRESH_TOKEN_ATTRIBUTE_KEY` 标记请求，让请求和响应拦截器都跳过递归刷新。
+仅当原始请求的 Fetcher 配置了未授权处理器时，内部刷新请求才交由外层统一通知。
+直接调用刷新器，或外层没有处理器而独立刷新 Fetcher 有处理器时，仍由刷新 Fetcher 通知。
+旧会话的刷新不会向替换后的会话触发未授权通知
+([`tokenRefresher.ts:194`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/tokenRefresher.ts#L194))。
 
 ## Token 生命周期与状态
 
@@ -96,7 +99,7 @@ cosec.applyTo(api);
 | `authenticated` | `boolean` | 仅当 access JWT 未过期时为 `true` |
 | `currentUser` | `CoSecJwtPayload \| null` | 仅解码 Payload；绝不是信任凭据 |
 | `JwtTokenManager.currentToken` | `JwtCompositeToken \| null` | 当前包装后的 Token Pair |
-| `JwtTokenManager.refresh()` | `Promise<void>` | 替换已存储 Pair，或失败后移除它 |
+| `JwtTokenManager.refresh()` | `Promise<void>` | 仅更新或移除发起刷新后仍未改变的会话 |
 
 `earlyPeriod` 默认 `0` 秒。它会让 access 和 refresh JWT 都提前视为过期；畸形 JWT 会被视为
 过期 ([`tokenStorage.ts:60`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/tokenStorage.ts#L60)，
@@ -120,8 +123,8 @@ CoSecRequest
 | --- | --- | --- |
 | 请求身份 | `CoSecRequestInterceptor` | 设置应用、设备、唯一请求和可选空间 Header |
 | 资源归属 | `ResourceAttributionRequestInterceptor` | 从解码 Claim 填充缺失的 URL Template `tenantId` 与 `ownerId` |
-| Bearer 请求 | `AuthorizationRequestInterceptor` | 在该请求阶段保留显式 `Authorization` Header；否则按需刷新并添加 `Bearer` |
-| 401 响应 | `AuthorizationResponseInterceptor` | 刷新、移除过期 Bearer，然后至多重跑一次 Exchange |
+| Bearer 请求 | `AuthorizationRequestInterceptor` | 不区分大小写地保留显式 `Authorization` Header；否则按需刷新并添加 `Bearer` |
+| 401 响应 | `AuthorizationResponseInterceptor` | 保留调用方凭据；否则刷新、移除受管的过期 Bearer，并至多重试一次 |
 | 最终错误 | `UnauthorizedErrorInterceptor`、`ForbiddenErrorInterceptor` | 调用应用 Callback；不修复权限 |
 
 Request 顺序按数值 `order` 升序：`CoSecRequestInterceptor`，然后
@@ -136,42 +139,53 @@ Resource Attribution 由 URL Template 选择：只有 Template 含默认 `tenant
 ([`resourceAttributionRequestInterceptor.ts:84`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/resourceAttributionRequestInterceptor.ts#L84))。
 仅当 Template 使用不同参数名时，才在构造函数中传入自定义 Options。
 
-发送请求前，`AuthorizationRequestInterceptor` 会保留显式 `Authorization` Header。存在受管 Token
+发送请求前，`AuthorizationRequestInterceptor` 会保留显式 `Authorization` Header，
+不区分大小写，空值也会保留。存在受管 Token
 时，它只在 Access Token 需要刷新、Refresh JWT 仍有效且请求不带忽略刷新 Attribute 时刷新
 ([`authorizationRequestInterceptor.ts:63`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationRequestInterceptor.ts#L63))。
-该保留只适用于初始 Request Interceptor Pass：401 时，`AuthorizationResponseInterceptor` 不会检查
-Header 来自哪里。它可能刷新、删除该 Header，并使用受管 Token 重试。需要有意使用不同凭据时，
-应使用未安装 CoSec Authorization Response Interceptor 的独立 Fetcher
-([`authorizationResponseInterceptor.ts:102`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L102))。
+收到 401 时，如果 Header 由调用方提供，或在 CoSec 注入后被替换，
+`AuthorizationResponseInterceptor` 会跳过自动刷新和重试。
+只有 CoSec 自己注入的 Header 才能在重试时被移除并换成受管的新 Token
+([`authorizationResponseInterceptor.ts:95`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L95))。
 
 ## 并发刷新、重试与错误
 
-`JwtTokenManager` 保存一个进行中的 Refresh Promise。并发调用会 Await 同一个 Promise；成功会写入
-新 Pair。刷新失败会移除存储状态，并抛出包装旧 Token 与原始 Cause 的 `RefreshTokenError`
-([`jwtTokenManager.ts:59`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L59))。
+`JwtTokenManager` 仅让当前 Token 实例相同的调用共享进行中的刷新 Promise。
+替换后的会话会发起自己的刷新，无需等待旧会话。刷新成功仅在原 Token 仍是当前值时写入新 Token 对；
+失败仅移除这个未改变的会话，并抛出包装其 Token 与原始原因的 `RefreshTokenError`
+([`jwtTokenManager.ts:83`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L83))。
+
+如果刷新期间会话发生变化，`RefreshSessionChangedError` 会中止原始请求，
+不会用替换后的会话发送或重试它，也不会因旧请求的 401 触发 `onUnauthorized`。
+认证拦截器通过 `refresh(exchange?)` 传入原始 Exchange，让 Manager 选择实际的通知处理器；
+直接调用时可以省略参数。
+在 Token Storage 写入或移除的监听器中切换会话，同样受到保护。
+Exchange 会保留自己的刷新结果，在选择 Authorization 和实际执行未授权回调前再次核对归属。
 
 401 Response 与主动过期刷新不同。Response Interceptor 每个 Exchange 至多重试一次
-（`AUTHORIZATION_RESPONSE_MAX_RETRY === 1`）。它只在 Refresh Token 可用时刷新，重试前会移除
-过期 Bearer Header；重试自身失败会原样传播，不会清除仍可能有效的新 Token
-([`authorizationResponseInterceptor.ts:72`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L72))。
+（`AUTHORIZATION_RESPONSE_MAX_RETRY === 1`）。它只在 Refresh Token 可用、请求没有调用方凭据，
+且不带忽略刷新属性时刷新。重试前会移除受管的过期 Bearer Header；重试自身失败会原样传播，
+不会清除仍可能有效的新 Token
+([`authorizationResponseInterceptor.ts:80`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L80))。
 
 | 失败 | 结果 |
 | --- | --- |
 | 直接调用 `refresh()` 但没有当前 Token | 以 `Error('No token found')` Reject |
-| Refresh Endpoint / 解析失败 | 移除 Token Storage；传播 `RefreshTokenError` |
+| Refresh Endpoint / 解析失败 | 仅移除发起刷新后仍未改变的会话；传播 `RefreshTokenError` |
+| 刷新期间会话变化 | `RefreshSessionChangedError` 中止原始请求；保留新会话且不触发未授权通知 |
 | Refresh JWT 已过期 | 不对 401 刷新/重试；原 Response 继续 |
 | 重试仍返回 401 | 不做第二次刷新/重试；可能进入最终 Error Pipeline |
-| 401 且配置了 `onUnauthorized` | 401 或 `RefreshTokenError` 时运行 Callback |
+| 401 且配置了 `onUnauthorized` | 401 或 `RefreshTokenError` 时，每个 Exchange 仅通知一次；内置刷新仅在外层确有处理器时交由外层通知 |
 | 403 且配置了 `onForbidden` | 仅在 403 时运行 Callback |
 
 ## 清理、安全与排障
 
-`signOut()` 不会取消进行中的 `JwtTokenManager.refresh()`。之后成功的 Refresh 会无条件写入新 Pair，
-因此可能在 Sign-out 后恢复 Token
-([`jwtTokenManager.ts:68`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L68))。
-最终 Logout 应停止接纳新的受保护请求，协调取消或等待可能触发 Refresh 的进行中请求，再在其结束后
-调用 `signOut()`；若切换期间可能已完成 Refresh，则再次调用它作为最终清理。Storage Object 不再使用时
-再调用 `destroy()`。不要记录 `CompositeToken`、原始 JWT String、Authorization Header，或带敏感
+`signOut()` 会立即清除存储状态。它不会取消进行中的 `JwtTokenManager.refresh()`，
+但 Manager 会丢弃延迟返回的旧结果，不会恢复已退出的 Token。
+如果再次 `signIn()` 替换了会话，旧刷新也不能覆盖或移除新会话
+([`jwtTokenManager.ts:120`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L120))。
+应用仍可在不再需要结果时取消进行中的请求。Storage Object 不再使用时调用 `destroy()`。
+不要记录 `CompositeToken`、原始 JWT String、Authorization Header，或带敏感
 Claim 的解码 Payload。`parseJwtPayload()` 是 Decode Helper，不是签名验证；
 无效解析返回 `null`，且当前实现会将通用解析错误写到 `console.error`，因此不能把它当作脱敏边界
 ([`jwts.ts:91`](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwts.ts#L91))。
@@ -180,10 +194,10 @@ Claim 的解码 Payload。`parseJwtPayload()` 是 Decode Helper，不是签名�
 | --- | --- |
 | 没有 `Authorization` Header | 提供 `tokenRefresher`、Sign-in 有效 access JWT，并检查请求是否自行设置了 Header。 |
 | 反复 401 | 客户端仅重试一次；检查服务端授权和 Refresh Endpoint 行为，且不得记录 Token Data。 |
-| Token 意外消失 | Refresh 失败会有意移除 Storage；通过 `onUnauthorized` 处理 `RefreshTokenError`。 |
+| Token 意外消失 | Refresh 失败仅移除发起刷新后仍未改变的会话；通过 `onUnauthorized` 处理 `RefreshTokenError`。 |
 | Tenant/Owner Path 错误 | 确保 URL Template 中有 `{tenantId}` / `{ownerId}`，或显式传值覆盖归属。 |
 | Component 卸载后 Token 仍在 | `destroy()` 仅清理；调用 `signOut()` 才会移除存储项。 |
-| Logout 后 Token 再次出现 | 协调进行中的 Refresh/请求，然后执行最终 `signOut()`；单独 Sign-out 无法取消 Refresh。 |
+| Logout 后 Token 再次出现 | Manager 会丢弃退出后返回的旧刷新结果；检查后续 `signIn()` 调用或其他 Token Storage 写入方。 |
 | 浏览器安全顾虑 | 默认 `localStorage` 是明文；迁移到 HttpOnly/服务端设计，或提供经过评审的 Storage Adapter。 |
 
 ## 源码参考
@@ -191,5 +205,5 @@ Claim 的解码 Payload。`parseJwtPayload()` 是 Decode Helper，不是签名�
 - [packages/cosec/src/index.ts:14](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/index.ts#L14)
 - [packages/cosec/src/cosecConfigurer.ts:445](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/cosecConfigurer.ts#L445)
 - [packages/cosec/src/tokenStorage.ts:60](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/tokenStorage.ts#L60)
-- [packages/cosec/src/jwtTokenManager.ts:59](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L59)
+- [packages/cosec/src/jwtTokenManager.ts:83](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/jwtTokenManager.ts#L83)
 - [packages/cosec/src/authorizationResponseInterceptor.ts:29](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/cosec/src/authorizationResponseInterceptor.ts#L29)


### PR DESCRIPTION
## Description

Managed requests retain an anonymous-start sentinel, so a later login cannot replay an earlier anonymous POST. Shared refresh notification ownership is claimed before callbacks begin, including callbacks that reject; response-only configurations and replacement-session isolation remain intact.

A pending refresh reuses the same-session successor installed by another tab, including when its duplicate request fails. Legacy persisted tokens derive a stable record fingerprint across tabs; explicit sign-in always creates a new random session generation.

Refresh session generations survive persistence and cross-tab delivery. Shared refresh operations notify unauthorized handlers at most once, and a later interceptor removing Authorization keeps the request anonymous.

Keep refresh results and cleanup bound to the session that initiated them. A refresh request receiving 401 fails without waiting on itself, and authorization headers are handled case-insensitively.

Abort the original exchange when a refresh loses ownership of its initiating session, and prevent old refresh failures from notifying or signing out a replacement session. Preserve unauthorized notification ownership for direct refresh calls and separate fetchers. Session-switch and actual request-chain regressions cover these paths.

Late 401 responses reuse a known successor token from the same login, including multiple refresh rotations. A real sign-out/sign-in remains isolated even when it reuses the same raw token object. Unauthorized callbacks still belong to the concrete credential used by the exchange.

This series prepares version 5.0.0 for its public type changes; no release is published by these updates.

## Validation

Focused package regressions passed in isolated snapshots. The combined stack passed these checks before its verified source tree was split back into the owning PRs:

- `pnpm build`
- `pnpm test:unit` — combined stack: 265 files, 3672 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .`
- `git diff --check`

Node.js 24.11.0, pnpm 10.34.5. Existing lint warnings remain; no build configuration or third-party dependencies changed. Regressions were reproduced before behavior changes, and bilingual wiki updates were built.

## Review and CI

Ready for review. Each merge candidate requires a completed GitHub Codex review, no unresolved review threads, and five successful CI workflows for its current head. Old-head results do not satisfy that gate. Codacy quality-rule findings are tracked separately with source evidence.

Native GitHub stack #1418, layer 3 of 16. Keep this PR separate and squash layers in stack order. GitHub rebases the remaining layers after each partial merge; verify their new Codex reviews and CI before continuing.

Split index: #1399.
