### PR TITLE
fix(wow): preserve explicit paths and reject invalid array indices

### DIFF
--- a/packages/wow/src/getPropertyValue.ts
+++ b/packages/wow/src/getPropertyValue.ts
@@ -63,7 +63,7 @@ export function getPropertyValue<T = any>(
   let current: any = object;
   for (const segment of pathSegments) {
     if (Array.isArray(current)) {
-      const index = parseInt(segment, 10);
+      const index = /^\d+$/.test(segment) ? Number(segment) : NaN;
       if (isNaN(index) || index < 0 || !Number.isInteger(index)) {
         return defaultValue;
       }

--- a/packages/wow/src/query/queryClients.ts
+++ b/packages/wow/src/query/queryClients.ts
@@ -24,7 +24,7 @@ import { LoadOwnerStateAggregateClient } from './state';
 /**
  * Configuration options for query clients.
  *
- * This interface extends ApiMetadata (without basePath), AliasBoundedContext, and AggregateNameCapable
+ * This interface extends ApiMetadata (with optional basePath), AliasBoundedContext, and AggregateNameCapable
  * to provide a complete configuration for query clients. It includes optional context alias and
  * resource attribution path specifications.
  */
@@ -56,7 +56,7 @@ export function createQueryApiMetadata(
   if (options.contextAlias) {
     basePath = combineURLs(options.contextAlias, basePath);
   }
-  return { ...options, basePath };
+  return { ...options, basePath: options.basePath ?? basePath };
 }
 
 export class QueryClientFactory<
@@ -106,6 +106,7 @@ export class QueryClientFactory<
     const apiMetadata = createQueryApiMetadata({
       ...this.defaultOptions,
       ...options,
+      basePath: options?.basePath ?? this.defaultOptions.basePath,
     });
     return new SnapshotQueryClient(apiMetadata);
   }
@@ -142,6 +143,7 @@ export class QueryClientFactory<
     const apiMetadata = createQueryApiMetadata({
       ...this.defaultOptions,
       ...options,
+      basePath: options?.basePath ?? this.defaultOptions.basePath,
     });
     return new LoadStateAggregateClient(apiMetadata);
   }
@@ -180,6 +182,7 @@ export class QueryClientFactory<
     const apiMetadata = createQueryApiMetadata({
       ...this.defaultOptions,
       ...options,
+      basePath: options?.basePath ?? this.defaultOptions.basePath,
     });
     return new LoadOwnerStateAggregateClient(apiMetadata);
   }
@@ -208,6 +211,7 @@ export class QueryClientFactory<
     const apiMetadata = createQueryApiMetadata({
       ...this.defaultOptions,
       ...options,
+      basePath: options?.basePath ?? this.defaultOptions.basePath,
     });
     return new EventStreamQueryClient(apiMetadata);
   }

--- a/packages/wow/test/getPropertyValue.test.ts
+++ b/packages/wow/test/getPropertyValue.test.ts
@@ -202,3 +202,12 @@ describe('getPropertyValue', () => {
     });
   });
 });
+
+it('rejects array index strings with non-numeric suffixes', () => {
+  expect(getPropertyValue(['first', 'second'], ['1oops'], 'missing')).toBe(
+    'missing',
+  );
+  expect(getPropertyValue(['first', 'second'], ['1.5'], 'missing')).toBe(
+    'missing',
+  );
+});

--- a/packages/wow/test/query/queryClientFactory.test.ts
+++ b/packages/wow/test/query/queryClientFactory.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it } from 'vitest';
+import type { QueryClientOptions } from '../../src';
+import { QueryClientFactory, ResourceAttributionPathSpec } from '../../src';
+
+it.each([
+  'createSnapshotQueryClient',
+  'createLoadStateAggregateClient',
+  'createOwnerLoadStateAggregateClient',
+  'createEventStreamQueryClient',
+] as const)('preserves basePath precedence in %s', method => {
+  const cases: {
+    defaultBasePath?: string;
+    options?: QueryClientOptions;
+    expected: string;
+  }[] = [
+    {
+      defaultBasePath: '/factory',
+      options: { basePath: undefined },
+      expected: '/factory',
+    },
+    { defaultBasePath: '', options: { basePath: undefined }, expected: '' },
+    { defaultBasePath: '/factory', expected: '/factory' },
+    {
+      defaultBasePath: '/factory',
+      options: { basePath: '/client' },
+      expected: '/client',
+    },
+    { defaultBasePath: '/factory', options: { basePath: '' }, expected: '' },
+    {
+      options: { basePath: undefined, aggregateName: 'client' },
+      expected: 'context/tenant/{tenantId}/client',
+    },
+  ];
+  for (const { defaultBasePath, options, expected } of cases) {
+    const factory = new QueryClientFactory({
+      basePath: defaultBasePath,
+      contextAlias: 'context',
+      resourceAttribution: ResourceAttributionPathSpec.TENANT,
+      aggregateName: 'default',
+    });
+    expect(factory[method](options).apiMetadata?.basePath).toBe(expected);
+  }
+});

--- a/packages/wow/test/query/queryClients.test.ts
+++ b/packages/wow/test/query/queryClients.test.ts
@@ -204,3 +204,15 @@ describe('queryClients', () => {
     });
   });
 });
+
+it('preserves an explicitly configured basePath', () => {
+  expect(
+    createQueryApiMetadata({
+      basePath: '/custom/pets',
+      aggregateName: 'ignored',
+    }).basePath,
+  ).toBe('/custom/pets');
+  expect(
+    createQueryApiMetadata({ basePath: '', aggregateName: 'ignored' }).basePath,
+  ).toBe('');
+});

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -572,6 +572,12 @@ const timeBased = await ownerClient.loadTimeBased(Date.now());
 
 ## QueryClientFactory<S, FIELDS, DomainEventBody>
 
+An explicit `basePath` in factory defaults or per-client options takes precedence
+over the path assembled from context, resource attribution, and aggregate name.
+Per-client `basePath` overrides the factory default only when it is not nullish;
+`basePath: undefined` retains the factory path. An empty string is an explicit
+override too.
+
 Factory for creating pre-configured typed query clients.
 
 ### Setup
@@ -1024,3 +1030,6 @@ for await (const event of stream) {
 - `@ahoo-wang/fetcher-eventstream` - SSE streaming support (loads transitively with fetcher-wow)
 - `@ahoo-wang/fetcher-decorator` - ApiMetadata type, decorators for auto-implemented methods
 - `@ahoo-wang/fetcher-wow` - Wow CQRS/DDD types and clients
+
+`getPropertyValue` accepts only complete non-negative integer array indices;
+segments such as `1oops` and `1.5` return the supplied default value.


### PR DESCRIPTION
## Description

A nullish per-client basePath preserves the factory default across all four query-client constructors.

Honor explicitly supplied query-client base paths and reject negative or invalid array indices during nested property lookup.

The branch incorporates the validated 5.0.0 package and peer metadata from its prerequisite.

## Type of change

- [x] Bug fix
- [x] Documentation update

## How Has This Been Tested?

Focused package regressions passed in isolated snapshots. The combined stack passed these checks before its verified source tree was split back into the owning PRs:

- `pnpm build`
- `pnpm test:unit` — combined stack: 263 files, 3657 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .` — no errors
- `git diff --check`

Node.js 24.11.0, pnpm 10.34.5. The shared lockfile passes frozen validation; third-party dependency resolutions are unchanged. The TypeScript flag is command-line only. Existing lint warnings remain. Source regressions were reproduced before fixing; English/Chinese wiki changes were built where included.

## Review and CI

Ready for review. Each merge candidate requires a completed GitHub Codex review, no unresolved review threads, and five successful CI workflows for its current head. Old-head results do not satisfy that gate. Codacy quality-rule findings are tracked separately with source evidence.

Native GitHub stack #1418, layer 9 of 16. Keep this PR separate and squash layers in stack order. GitHub rebases the remaining layers after each partial merge; verify their new Codex reviews and CI before continuing.

Split index: #1399.
