### PR TITLE
fix(generator): preserve component references and endpoint contracts

### DIFF
--- a/packages/generator/src/aggregate/aggregateResolver.ts
+++ b/packages/generator/src/aggregate/aggregateResolver.ts
@@ -14,7 +14,6 @@
 import type {
   OpenAPI,
   Operation,
-  Parameter,
   Reference,
   RequestBody,
   Schema,
@@ -33,17 +32,17 @@ import {
   extractOkResponse,
   extractOperationEndpoints,
   extractOperationOkResponseJsonSchema,
-  extractParameter,
+  extractPathParameters,
   extractRequestBody,
   extractSchema,
   isReference,
   keySchema,
 } from '../utils';
+import { COMPONENTS_RESPONSES_REF } from '../utils/components';
 import type { EventStreamSchema } from './types';
 import { operationIdToCommandName, tagsToAggregates } from './utils';
 
 const CommandOkResponseRef = '#/components/responses/wow.CommandOk';
-const IdParameterRef = '#/components/parameters/wow.id';
 
 /**
  * Resolves aggregate definitions from OpenAPI specifications.
@@ -69,7 +68,10 @@ export class AggregateResolver {
    * @private
    */
   private build() {
-    const endpoints = extractOperationEndpoints(this.openAPI.paths);
+    const endpoints = extractOperationEndpoints(
+      this.openAPI.paths,
+      this.openAPI.components,
+    );
     for (const endpoint of endpoints) {
       this.commands(endpoint.path, endpoint);
       this.state(endpoint.operation);
@@ -116,42 +118,49 @@ export class AggregateResolver {
     if (!commandName) {
       return;
     }
-    const okResponse = extractOkResponse(operation);
-    if (!okResponse) {
-      return;
+    let okResponse = extractOkResponse(operation);
+    const visited = new Set<string>();
+    while (
+      okResponse &&
+      isReference(okResponse) &&
+      okResponse.$ref !== CommandOkResponseRef
+    ) {
+      if (!okResponse.$ref.startsWith(COMPONENTS_RESPONSES_REF)) return;
+      if (visited.has(okResponse.$ref)) {
+        throw new TypeError(`Cyclic component reference: ${okResponse.$ref}`);
+      }
+      visited.add(okResponse.$ref);
+      okResponse =
+        this.openAPI.components?.responses?.[
+          okResponse.$ref.slice(COMPONENTS_RESPONSES_REF.length)
+        ];
     }
-    if (!isReference(okResponse)) {
-      return;
-    }
-    if (okResponse.$ref !== CommandOkResponseRef) {
+    if (
+      !okResponse ||
+      !isReference(okResponse) ||
+      okResponse.$ref !== CommandOkResponseRef
+    ) {
       return;
     }
     if (!operation.requestBody) {
       return;
     }
 
-    const parameters = operation.parameters ?? [];
-    const idRefParameter = parameters
-      .filter(p => isReference(p) && p.$ref === IdParameterRef)
-      .at(0) as Reference | undefined;
-    const pathParameters = parameters.filter(
-      p => !isReference(p) && p.in === 'path',
-    ) as Parameter[];
-    if (idRefParameter) {
-      const idParameter = extractParameter(
-        idRefParameter,
-        this.openAPI.components!,
-      );
-      pathParameters.push(idParameter!);
-    }
-    const requestBody = operation.requestBody as RequestBody;
-    const commandRefSchema = requestBody.content[
-      ContentTypeValues.APPLICATION_JSON
-    ].schema as Reference;
+    const pathParameters = extractPathParameters(
+      operation,
+      this.openAPI.components ?? {},
+    );
+    const requestBody = isReference(operation.requestBody)
+      ? extractRequestBody(operation.requestBody, this.openAPI.components ?? {})
+      : operation.requestBody;
+    const commandRefSchema =
+      requestBody?.content?.[ContentTypeValues.APPLICATION_JSON]?.schema;
+    if (!isReference(commandRefSchema)) return;
     const commandKeyedSchema = keySchema(
       commandRefSchema,
-      this.openAPI.components!,
+      this.openAPI.components ?? {},
     );
+    if (!commandKeyedSchema.schema) return;
     commandKeyedSchema.schema.title =
       commandKeyedSchema.schema.title || operation.summary;
     commandKeyedSchema.schema.description =
@@ -183,7 +192,10 @@ export class AggregateResolver {
     if (!operation.operationId?.endsWith('.snapshot_state.single')) {
       return;
     }
-    const stateRefSchema = extractOperationOkResponseJsonSchema(operation);
+    const stateRefSchema = extractOperationOkResponseJsonSchema(
+      operation,
+      this.openAPI.components,
+    );
     if (!isReference(stateRefSchema)) {
       return;
     }
@@ -211,8 +223,10 @@ export class AggregateResolver {
     if (!operation.operationId?.endsWith('.event.list_query')) {
       return;
     }
-    const eventStreamArraySchema =
-      extractOperationOkResponseJsonSchema(operation);
+    const eventStreamArraySchema = extractOperationOkResponseJsonSchema(
+      operation,
+      this.openAPI.components,
+    );
     if (isReference(eventStreamArraySchema)) {
       return;
     }

--- a/packages/generator/src/client/apiClientGenerator.ts
+++ b/packages/generator/src/client/apiClientGenerator.ts
@@ -61,8 +61,8 @@ import {
   addImportFetcher,
   createDecoratorClass,
   DEFAULT_RETURN_TYPE,
-  STREAM_RESULT_EXTRACTOR_METADATA,
   STRING_RETURN_TYPE,
+  STREAM_RESULT_EXTRACTOR_METADATA,
 } from './decorators';
 import { methodToDecorator, resolveMethodName } from './utils';
 
@@ -387,28 +387,27 @@ export class ApiClientGenerator implements Generator {
     sourceFile: SourceFile,
     operation: Operation,
   ): MethodReturnType {
-    const okResponse = extractOkResponse(operation);
+    const okResponse = extractOkResponse(
+      operation,
+      this.context.openAPI.components,
+    );
     if (!okResponse) {
       this.context.logger.info(
         `No OK response found for operation ${operation.operationId}, using default return type: ${this.defaultReturnType.type}`,
       );
       return this.defaultReturnType;
     }
+    const responseJsonSchema = extractResponseJsonSchema(okResponse);
     const jsonSchema =
-      extractResponseJsonSchema(okResponse) ||
-      extractResponseWildcardSchema(okResponse);
+      responseJsonSchema || extractResponseWildcardSchema(okResponse);
     if (jsonSchema) {
       const returnType = this.resolveSchemaReturnType(sourceFile, jsonSchema);
       this.context.logger.info(
         `Resolved JSON/wildcard response return type for operation ${operation.operationId}: ${returnType}`,
       );
-      return {
-        type: returnType,
-        metadata:
-          returnType === STRING_RETURN_TYPE.type
-            ? STRING_RETURN_TYPE.metadata
-            : undefined,
-      };
+      return !responseJsonSchema && returnType === STRING_RETURN_TYPE.type
+        ? STRING_RETURN_TYPE
+        : { type: returnType };
     }
     const eventStreamSchema = extractResponseEventStreamSchema(okResponse);
     if (eventStreamSchema) {
@@ -517,6 +516,7 @@ export class ApiClientGenerator implements Generator {
     const operations: Map<string, Set<OperationEndpoint>> = new Map();
     const availableEndpoints = extractOperationEndpoints(
       this.context.openAPI.paths,
+      this.context.openAPI.components,
     ).filter(endpoint => {
       if (!endpoint.operation.operationId) {
         return false;

--- a/packages/generator/src/model/modelGenerator.ts
+++ b/packages/generator/src/model/modelGenerator.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import type { Schema } from '@ahoo-wang/fetcher-openapi';
+import type { Reference, Schema } from '@ahoo-wang/fetcher-openapi';
 import type { SourceFile } from 'ts-morph';
 
 import type { GenerateContext, Generator } from '../generateContext';
@@ -70,14 +70,11 @@ export class ModelGenerator implements Generator {
   }
 
   private filterSchemas(
-    schemas: Record<string, Schema>,
+    schemas: Record<string, Schema | Reference>,
     aggregatedTypeNames: Set<string>,
-  ): KeySchema[] {
+  ): KeySchema<Schema | Reference>[] {
     return Object.entries(schemas)
-      .map(([schemaKey, schema]) => ({
-        key: schemaKey,
-        schema,
-      }))
+      .map(([key, schema]) => ({ key, schema }))
       .filter(
         keySchema => !this.isWowSchema(keySchema.key, aggregatedTypeNames),
       );
@@ -157,7 +154,7 @@ export class ModelGenerator implements Generator {
    * 3. Union processing
    * 4. Type alias processing
    */
-  generateKeyedSchema(keySchema: KeySchema) {
+  generateKeyedSchema(keySchema: KeySchema<Schema | Reference>) {
     const modelInfo = resolveModelInfo(keySchema.key);
     const sourceFile = this.getOrCreateSourceFile(modelInfo);
     const typeGenerator = new TypeGenerator(

--- a/packages/generator/src/model/modelInfo.ts
+++ b/packages/generator/src/model/modelInfo.ts
@@ -14,6 +14,7 @@
 import type { Components, Reference, Schema } from '@ahoo-wang/fetcher-openapi';
 import type { Named } from '@ahoo-wang/fetcher-wow';
 import {
+  COMPONENTS_SCHEMAS_REF,
   extractComponentKey,
   extractSchema,
   pascalCase,
@@ -91,6 +92,11 @@ export function resolveReferenceModelInfo(
   reference: Reference,
   components?: Components,
 ): ModelInfo {
+  if (!reference.$ref.startsWith(COMPONENTS_SCHEMAS_REF)) {
+    throw new TypeError(
+      `Unsupported schema reference: ${reference.$ref}. Bundle or inline external schemas before generation.`,
+    );
+  }
   const componentKey = extractComponentKey(reference);
   const schema = components ? extractSchema(reference, components) : undefined;
   return resolveModelInfo(componentKey, schema);

--- a/packages/generator/src/model/typeGenerator.ts
+++ b/packages/generator/src/model/typeGenerator.ts
@@ -12,7 +12,7 @@
  */
 
 import type { ModelInfo } from './modelInfo';
-import { resolveReferenceModelInfo } from './modelInfo';
+import { resolveModelInfo, resolveReferenceModelInfo } from './modelInfo';
 import type { InterfaceDeclaration, JSDocableNode, SourceFile } from 'ts-morph';
 import type { Components, Reference, Schema } from '@ahoo-wang/fetcher-openapi';
 import type {
@@ -51,7 +51,7 @@ export class TypeGenerator implements Generator {
   constructor(
     private readonly modelInfo: ModelInfo,
     private readonly sourceFile: SourceFile,
-    private readonly keySchema: KeySchema,
+    private readonly keySchema: KeySchema<Schema | Reference>,
     private readonly outputDir: string,
     private readonly components?: Components,
   ) {}
@@ -65,6 +65,9 @@ export class TypeGenerator implements Generator {
 
   private process(): JSDocableNode | undefined {
     const { schema } = this.keySchema;
+    if (isReference(schema)) {
+      return this.processTypeAlias(schema);
+    }
     if (isEnum(schema)) {
       return this.processEnum(schema);
     }
@@ -85,12 +88,37 @@ export class TypeGenerator implements Generator {
 
   private resolveReference(schema: Reference) {
     const refModelInfo = resolveReferenceModelInfo(schema, this.components);
-    addImportModelInfo(
+    const declaration = addImportModelInfo(
       this.modelInfo,
       this.sourceFile,
       this.outputDir,
       refModelInfo,
     );
+    const namedImport = declaration
+      ?.getNamedImports()
+      .find(item => item.getName() === refModelInfo.name);
+    if (!namedImport) return refModelInfo;
+    const existingAlias = namedImport.getAliasNode()?.getText();
+    if (existingAlias) return { ...refModelInfo, name: existingAlias };
+
+    const reservedNames = new Set([
+      this.modelInfo.name,
+      ...Object.keys(this.components?.schemas ?? {})
+        .map(key => resolveModelInfo(key))
+        .filter(model => model.path === this.modelInfo.path)
+        .flatMap(model => [model.name, `${model.name}EnumText`]),
+      ...this.sourceFile
+        .getImportDeclarations()
+        .flatMap(item => item.getNamedImports())
+        .filter(item => item !== namedImport)
+        .map(item => item.getAliasNode()?.getText() ?? item.getName()),
+    ]);
+    if (reservedNames.has(refModelInfo.name)) {
+      let alias = `_${refModelInfo.name}`;
+      while (reservedNames.has(alias)) alias = `_${alias}`;
+      namedImport.setAlias(alias);
+      return { ...refModelInfo, name: alias };
+    }
     return refModelInfo;
   }
 
@@ -328,7 +356,9 @@ export class TypeGenerator implements Generator {
     return interfaceDeclaration;
   }
 
-  private processTypeAlias(schema: Schema): JSDocableNode | undefined {
+  private processTypeAlias(
+    schema: Schema | Reference,
+  ): JSDocableNode | undefined {
     return this.sourceFile.addTypeAlias({
       name: this.modelInfo.name,
       type: this.resolveType(schema),

--- a/packages/generator/src/utils/components.ts
+++ b/packages/generator/src/utils/components.ts
@@ -19,6 +19,7 @@ import type {
   Response,
   Schema,
 } from '@ahoo-wang/fetcher-openapi';
+import { isReference } from './references';
 
 /** Prefix for OpenAPI components references */
 export const COMPONENTS_PREFIX = '#/components/';
@@ -36,11 +37,11 @@ export const COMPONENTS_SCHEMAS_REF = `${COMPONENTS_PREFIX}schemas/`;
 /**
  * Represents a schema with its key identifier.
  */
-export interface KeySchema {
+export interface KeySchema<T extends Schema | Reference = Schema> {
   /** The schema key */
   key: string;
   /** The schema definition */
-  schema: Schema;
+  schema: T;
 }
 
 /**
@@ -58,12 +59,34 @@ export function extractComponentKey(reference: Reference): string {
  * @param components - The OpenAPI components object
  * @returns The schema if found, undefined otherwise
  */
+function resolveComponent<T>(
+  reference: Reference,
+  components: Record<string, T | Reference> | undefined,
+  prefix: string,
+): T | undefined {
+  const visited = new Set<string>();
+  let current: T | Reference | undefined = reference;
+  while (isReference(current)) {
+    // ponytail: local components only; bundle external references before generation.
+    if (!current.$ref.startsWith(prefix)) return undefined;
+    if (visited.has(current.$ref)) {
+      throw new TypeError(`Cyclic component reference: ${current.$ref}`);
+    }
+    visited.add(current.$ref);
+    current = components?.[current.$ref.slice(prefix.length)];
+  }
+  return current;
+}
+
 export function extractSchema(
   reference: Reference,
   components: Components,
 ): Schema | undefined {
-  const componentKey = extractComponentKey(reference);
-  return components.schemas?.[componentKey];
+  return resolveComponent(
+    reference,
+    components.schemas,
+    COMPONENTS_SCHEMAS_REF,
+  );
 }
 
 /**
@@ -76,8 +99,11 @@ export function extractResponse(
   reference: Reference,
   components: Components,
 ): Response | undefined {
-  const componentKey = extractComponentKey(reference);
-  return components.responses?.[componentKey];
+  return resolveComponent(
+    reference,
+    components.responses,
+    COMPONENTS_RESPONSES_REF,
+  );
 }
 
 /**
@@ -90,8 +116,11 @@ export function extractRequestBody(
   reference: Reference,
   components: Components,
 ): RequestBody | undefined {
-  const componentKey = extractComponentKey(reference);
-  return components.requestBodies?.[componentKey];
+  return resolveComponent(
+    reference,
+    components.requestBodies,
+    COMPONENTS_REQUEST_BODIES_REF,
+  );
 }
 
 /**
@@ -104,8 +133,11 @@ export function extractParameter(
   reference: Reference,
   components: Components,
 ): Parameter | undefined {
-  const componentKey = extractComponentKey(reference);
-  return components.parameters?.[componentKey];
+  return resolveComponent(
+    reference,
+    components.parameters,
+    COMPONENTS_PARAMETERS_REF,
+  );
 }
 
 /**

--- a/packages/generator/src/utils/operations.ts
+++ b/packages/generator/src/utils/operations.ts
@@ -22,7 +22,7 @@ import type {
   Response,
   Schema,
 } from '@ahoo-wang/fetcher-openapi';
-import { extractParameter } from './components';
+import { extractParameter, extractResponse } from './components';
 import { isReference } from './references';
 import { extractResponseJsonSchema } from './responses';
 import { isPrimitive, resolvePrimitiveType } from './schemas';
@@ -59,15 +59,43 @@ export function operationEndpointComparator(
   return 0;
 }
 
+function mergeParameters(
+  inherited: (Parameter | Reference)[],
+  own: (Parameter | Reference)[],
+  components?: Components,
+): (Parameter | Reference)[] {
+  const parameters = new Map<string, Parameter | Reference>();
+  for (const parameter of [...inherited, ...own]) {
+    const resolved = isReference(parameter)
+      ? components && extractParameter(parameter, components)
+      : parameter;
+    const key = resolved
+      ? `${resolved.in}:${resolved.name}`
+      : (parameter as Reference).$ref;
+    parameters.set(key, parameter);
+  }
+  return [...parameters.values()];
+}
+
 export function extractOperationEndpoints(
   paths: Paths,
+  components?: Components,
 ): Array<OperationEndpoint> {
   const operationEndpoints: OperationEndpoint[] = [];
   for (const [path, pathItem] of Object.entries(paths)) {
     extractOperations(pathItem).forEach(methodOperation => {
       operationEndpoints.push({
         method: methodOperation.method,
-        operation: methodOperation.operation,
+        operation: pathItem.parameters?.length
+          ? {
+              ...methodOperation.operation,
+              parameters: mergeParameters(
+                pathItem.parameters,
+                methodOperation.operation.parameters ?? [],
+                components,
+              ),
+            }
+          : methodOperation.operation,
         path,
       });
     });
@@ -99,23 +127,30 @@ export function extractOperations(pathItem: PathItem): MethodOperation[] {
 /**
  * Extracts the OK (200) response from an operation.
  * @param operation - The OpenAPI operation
+ * @param components - Optional components used to resolve response references
  * @returns The 200 response or undefined if not found
  */
 export function extractOkResponse(
   operation: Operation,
+  components?: Components,
 ): Response | Reference | undefined {
-  return operation.responses['200'];
+  const response = operation.responses['200'];
+  return components && isReference(response)
+    ? extractResponse(response, components)
+    : response;
 }
 
 /**
  * Extracts the JSON schema from the OK response of an operation.
  * @param operation - The OpenAPI operation
+ * @param components - Optional components used to resolve response references
  * @returns The JSON schema from the OK response or undefined if not found
  */
 export function extractOperationOkResponseJsonSchema(
   operation: Operation,
+  components?: Components,
 ): Schema | Reference | undefined {
-  const okResponse = extractOkResponse(operation);
+  const okResponse = extractOkResponse(operation, components);
   return extractResponseJsonSchema(okResponse);
 }
 
@@ -135,11 +170,11 @@ export function extractPathParameters(
   return operation.parameters
     .map(parameter => {
       if (isReference(parameter)) {
-        return extractParameter(parameter, components)!;
+        return extractParameter(parameter, components);
       }
       return parameter;
     })
-    .filter(parameter => parameter.in === 'path');
+    .filter((parameter): parameter is Parameter => parameter?.in === 'path');
 }
 
 const DEFAULT_PATH_PARAMETER_TYPE = 'string';

--- a/packages/generator/src/utils/sourceFiles.ts
+++ b/packages/generator/src/utils/sourceFiles.ts
@@ -119,6 +119,7 @@ export function addImport(
     }
     declaration.addNamedImport(namedImport);
   });
+  return declaration;
 }
 
 /**
@@ -133,8 +134,7 @@ export function addImportRefModel(
   refModelInfo: ModelInfo,
 ) {
   if (refModelInfo.path.startsWith(IMPORT_ALIAS)) {
-    addImport(sourceFile, refModelInfo.path, [refModelInfo.name]);
-    return;
+    return addImport(sourceFile, refModelInfo.path, [refModelInfo.name]);
   }
   const sourceDir = sourceFile.getDirectoryPath();
   const targetFilePath = join(outputDir, refModelInfo.path, MODEL_FILE_NAME);
@@ -145,7 +145,7 @@ export function addImportRefModel(
   if (!relativePath.startsWith('.')) {
     relativePath = './' + relativePath;
   }
-  addImport(sourceFile, relativePath, [refModelInfo.name]);
+  return addImport(sourceFile, relativePath, [refModelInfo.name]);
 }
 
 /**
@@ -164,7 +164,7 @@ export function addImportModelInfo(
   if (currentModel.path === refModel.path) {
     return;
   }
-  addImportRefModel(sourceFile, outputDir, refModel);
+  return addImportRefModel(sourceFile, outputDir, refModel);
 }
 
 /**

--- a/packages/generator/test/aggregate/aggregateResolver.test.ts
+++ b/packages/generator/test/aggregate/aggregateResolver.test.ts
@@ -13,6 +13,7 @@
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { AggregateResolver } from '../../src/aggregate';
+import { isReference as actualIsReference } from '../../src/utils/references';
 import { tagsToAggregates } from '../../src/aggregate';
 
 // Mock dependencies
@@ -27,7 +28,7 @@ vi.mock('../../src/utils', () => ({
   extractOperationOkResponseJsonSchema: vi.fn(),
   extractOperations: vi.fn(),
   extractOperationEndpoints: vi.fn(() => []),
-  extractParameter: vi.fn(),
+  extractPathParameters: vi.fn(() => []),
   extractRequestBody: vi.fn(),
   extractSchema: vi.fn(),
   isReference: vi.fn(),
@@ -39,7 +40,7 @@ import {
   extractOperationOkResponseJsonSchema,
   extractOperations,
   extractOperationEndpoints,
-  extractParameter,
+  extractPathParameters,
   extractRequestBody,
   extractSchema,
   isReference,
@@ -94,7 +95,10 @@ describe('AggregateResolver', () => {
 
       const aggregateResolver = new AggregateResolver(mockOpenAPI);
 
-      expect(extractOperationEndpoints).toHaveBeenCalledWith(mockOpenAPI.paths);
+      expect(extractOperationEndpoints).toHaveBeenCalledWith(
+        mockOpenAPI.paths,
+        mockOpenAPI.components,
+      );
       // Verify that commands, state, events, fields are called
       // Since they are private methods, we can't directly spy, but we can check side effects
     });
@@ -251,8 +255,10 @@ describe('AggregateResolver', () => {
       (extractOkResponse as any).mockReturnValue({
         $ref: '#/components/responses/wow.CommandOk',
       });
-      (isReference as any).mockReturnValue(true);
-      (extractParameter as any).mockReturnValue({ name: 'id', in: 'path' });
+      vi.mocked(isReference).mockImplementation(actualIsReference);
+      vi.mocked(extractPathParameters).mockReturnValue([
+        { name: 'id', in: 'path' },
+      ]);
       (keySchema as any).mockReturnValue({ schema: { title: 'Test' } });
 
       const methodOperation = {
@@ -283,8 +289,10 @@ describe('AggregateResolver', () => {
       (extractOkResponse as any).mockReturnValue({
         $ref: '#/components/responses/wow.CommandOk',
       });
-      (isReference as any).mockReturnValue(true);
-      (extractParameter as any).mockReturnValue({ name: 'id', in: 'path' });
+      vi.mocked(isReference).mockImplementation(actualIsReference);
+      vi.mocked(extractPathParameters).mockReturnValue([
+        { name: 'id', in: 'path' },
+      ]);
       (keySchema as any).mockReturnValue({ schema: { title: 'Test' } });
 
       const methodOperation = {

--- a/packages/generator/test/aggregate/commandAliases.test.ts
+++ b/packages/generator/test/aggregate/commandAliases.test.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from 'vitest';
+import { Project, ts } from 'ts-morph';
+import type {
+  OpenAPI,
+  Operation,
+  RequestBody,
+  Response,
+} from '@ahoo-wang/fetcher-openapi';
+import { AggregateResolver } from '../../src/aggregate';
+import { CodeGenerator } from '../../src';
+import { CommandClientGenerator } from '../../src/client';
+import { GenerateContext } from '../../src/generateContext';
+import { ModelGenerator } from '../../src/model';
+import { SilentLogger } from '../../src/utils/logger';
+
+function specification(): OpenAPI {
+  const body: RequestBody = {
+    content: {
+      'application/json': { schema: { $ref: '#/components/schemas/Rename' } },
+    },
+  };
+  const response: Response = { description: 'Command result' };
+  return {
+    openapi: '3.0.4',
+    info: {},
+    tags: [{ name: 'example.pet' }],
+    paths: {
+      '/pets/rename': {
+        post: {
+          operationId: 'example.pet.rename',
+          tags: ['example.pet'],
+          requestBody: body,
+          responses: {
+            '200': { $ref: '#/components/responses/wow.CommandOk' },
+          },
+        },
+      },
+      '/pets/state': {
+        post: {
+          operationId: 'example.pet.snapshot_state.single',
+          tags: ['example.pet'],
+          responses: {
+            '200': {
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/Pet' },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/pets/count': {
+        post: {
+          operationId: 'example.pet.snapshot.count',
+          tags: ['example.pet'],
+          requestBody: {
+            content: {},
+            'x-wow-query-fields': { $ref: '#/components/schemas/PetFields' },
+          },
+          responses: {},
+        },
+      },
+    },
+    components: {
+      responses: {
+        'wow.CommandOk': response,
+        Alias: { $ref: '#/components/responses/Second' },
+        Second: { $ref: '#/components/responses/wow.CommandOk' },
+        NonWow: response,
+      },
+      requestBodies: {
+        Rename: body,
+        Alias: { $ref: '#/components/requestBodies/Second' },
+        Second: { $ref: '#/components/requestBodies/Rename' },
+      },
+      schemas: {
+        Rename: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+        Pet: { type: 'object' },
+        PetFields: { type: 'string', enum: ['name'] },
+      },
+    },
+  };
+}
+
+function command(openAPI: OpenAPI): Operation {
+  return openAPI.paths['/pets/rename'].post!;
+}
+
+it.each([
+  'response aliases',
+  'request body reference',
+  'request body aliases',
+] as const)('generates and type-checks CommandClient with %s', mode => {
+  const openAPI = specification();
+  if (mode === 'response aliases')
+    command(openAPI).responses['200'] = {
+      $ref: '#/components/responses/Alias',
+    };
+  else
+    command(openAPI).requestBody = {
+      $ref: `#/components/requestBodies/${mode === 'request body reference' ? 'Rename' : 'Alias'}`,
+    };
+  const aggregates = new AggregateResolver(openAPI).resolve();
+  expect([...aggregates.get('example')!][0].commands.has('rename')).toBe(true);
+  const packageRoot = fileURLToPath(new URL('../../', import.meta.url));
+  const outputDir = mkdtempSync(join(packageRoot, '.command-alias-'));
+  try {
+    const project = new Project({
+      compilerOptions: {
+        strict: true,
+        skipLibCheck: true,
+        noEmit: true,
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        experimentalDecorators: true,
+        paths: Object.fromEntries(
+          [
+            'fetcher',
+            'decorator',
+            'eventstream',
+            'wow',
+            'openapi',
+            'eventbus',
+            'storage',
+          ].map(name => [
+            name === 'fetcher'
+              ? '@ahoo-wang/fetcher'
+              : `@ahoo-wang/fetcher-${name}`,
+            [resolve(packageRoot, '..', name, 'src/index.ts')],
+          ]),
+        ),
+      },
+    });
+    const context = new GenerateContext({
+      openAPI,
+      contextAggregates: aggregates,
+      project,
+      outputDir,
+      logger: new SilentLogger(),
+    });
+    new ModelGenerator(context).generate();
+    new CommandClientGenerator(context).generate();
+    new CodeGenerator({
+      inputPath: '',
+      outputDir,
+      logger: new SilentLogger(),
+    }).optimizeSourceFiles(project.getDirectoryOrThrow(outputDir));
+    const generated = project.getSourceFileOrThrow(
+      join(outputDir, 'example/pet/commandClient.ts'),
+    );
+    expect(
+      generated
+        .getClassOrThrow('PetCommandClient')
+        .getMethodOrThrow('rename')
+        .getParameters()[0]
+        .getTypeNodeOrThrow()
+        .getText(),
+    ).toBe('CommandRequest<RenameCommand>');
+    project.createSourceFile(
+      join(outputDir, 'consumer.ts'),
+      `
+        import { PetCommandClient } from './example/pet/commandClient';
+        import type { CommandResult } from '@ahoo-wang/fetcher-wow';
+        declare const client: PetCommandClient;
+        const result: Promise<CommandResult> = client.rename({body: {name: 'renamed'}});
+        // @ts-expect-error The generated command body requires a string name.
+        client.rename({body: {name: 123}});
+      `,
+    );
+    expect(
+      project
+        .getPreEmitDiagnostics()
+        .map(diagnostic => diagnostic.getMessageText()),
+    ).toEqual([]);
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+it('does not identify an arbitrary response with the same shape or target object as CommandOk', () => {
+  const openAPI = specification();
+  command(openAPI).responses['200'] = { $ref: '#/components/responses/NonWow' };
+  expect(
+    [...new AggregateResolver(openAPI).resolve().get('example')!][0].commands
+      .size,
+  ).toBe(0);
+});
+
+it('rejects cycles in command response aliases', () => {
+  const openAPI = specification();
+  command(openAPI).responses['200'] = { $ref: '#/components/responses/Alias' };
+  openAPI.components!.responses!.Second = {
+    $ref: '#/components/responses/Alias',
+  };
+  expect(() => new AggregateResolver(openAPI)).toThrow(/cyclic/i);
+});
+
+it.each([
+  { $ref: '#/components/requestBodies/Missing' },
+  { content: { 'application/json': { schema: { type: 'object' as const } } } },
+])(
+  'skips a command whose body cannot resolve to a component schema: %j',
+  requestBody => {
+    const openAPI = specification();
+    command(openAPI).requestBody = requestBody;
+    expect(
+      [...new AggregateResolver(openAPI).resolve().get('example')!][0].commands
+        .size,
+    ).toBe(0);
+  },
+);

--- a/packages/generator/test/client/apiClientGenerator.test.ts
+++ b/packages/generator/test/client/apiClientGenerator.test.ts
@@ -474,7 +474,6 @@ describe('ApiClientGenerator', () => {
 
       expect(result).toEqual({
         type: 'Promise<string>',
-        metadata: '{resultExtractor: ResultExtractors.Text }',
       });
     });
 

--- a/packages/generator/test/externalReferences.test.ts
+++ b/packages/generator/test/externalReferences.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it } from 'vitest';
+import { Project, ts } from 'ts-morph';
+import { ApiClientGenerator } from '../src/client';
+import { GenerateContext } from '../src/generateContext';
+import { ModelGenerator, resolveReferenceModelInfo } from '../src/model';
+import { SilentLogger } from '../src/utils/logger';
+import {
+  extractOperationEndpoints,
+  extractPathParameters,
+  extractResponse,
+} from '../src/utils';
+import type { OpenAPI } from '@ahoo-wang/fetcher-openapi';
+
+it.each([false, true])(
+  'does not resolve an external response as a local namesake (alias: %s)',
+  alias => {
+    const foreign = { $ref: 'common.yaml#/components/responses/Success' };
+    const openAPI: OpenAPI = {
+      openapi: '3.0.4',
+      info: {},
+      paths: {
+        '/items': {
+          get: {
+            tags: ['Items'],
+            operationId: 'items',
+            responses: {
+              '200': alias ? { $ref: '#/components/responses/Alias' } : foreign,
+            },
+          },
+        },
+      },
+      components: {
+        responses: {
+          Alias: foreign,
+          Success: {
+            content: { 'application/json': { schema: { type: 'string' } } },
+          },
+        },
+      },
+    };
+    expect(extractResponse(foreign, openAPI.components!)).toBeUndefined();
+    const project = new Project({
+      compilerOptions: {
+        strict: true,
+        skipLibCheck: true,
+        experimentalDecorators: true,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        target: ts.ScriptTarget.ES2022,
+      },
+    });
+    const outputDir = `${process.cwd()}/test-output/external-response`;
+    const context = new GenerateContext({
+      project,
+      outputDir,
+      openAPI,
+      contextAggregates: new Map(),
+      logger: new SilentLogger(),
+    });
+    new ApiClientGenerator(context).generate();
+    const method = project
+      .getSourceFileOrThrow(`${outputDir}/ItemsApiClient.ts`)
+      .getClassOrThrow('ItemsApiClient')
+      .getMethodOrThrow('items');
+    expect(method.getReturnTypeNodeOrThrow().getText()).toBe(
+      'Promise<Response>',
+    );
+    expect(method.getDecoratorOrThrow('get').getText()).toContain(
+      'ResultExtractors.Response',
+    );
+    expect(
+      project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+    ).toEqual([]);
+  },
+);
+
+it.each([false, true])(
+  'handles inherited external parameters without local substitution (namesake: %s)',
+  namesake => {
+    const openAPI: OpenAPI = {
+      openapi: '3.0.4',
+      info: {},
+      paths: {
+        '/items/{id}': {
+          parameters: [{ $ref: 'common.yaml#/components/parameters/Id' }],
+          get: { tags: ['Items'], operationId: 'item', responses: {} },
+        },
+      },
+      components: {
+        parameters: namesake
+          ? { Id: { in: 'path', name: 'wrong', schema: { type: 'integer' } } }
+          : {},
+      },
+    };
+    const [endpoint] = extractOperationEndpoints(
+      openAPI.paths,
+      openAPI.components,
+    );
+    expect(
+      extractPathParameters(endpoint.operation, openAPI.components!),
+    ).toEqual([]);
+    const project = new Project({ useInMemoryFileSystem: true });
+    const context = new GenerateContext({
+      project,
+      outputDir: '/out',
+      openAPI,
+      contextAggregates: new Map(),
+      logger: new SilentLogger(),
+    });
+    new ApiClientGenerator(context).generate();
+    const method = project
+      .getSourceFileOrThrow('/out/ItemsApiClient.ts')
+      .getClassOrThrow('ItemsApiClient')
+      .getMethodOrThrow('item');
+    expect(method.getParameters().map(p => p.getName())).toEqual([
+      'httpRequest',
+      'attributes',
+    ]);
+  },
+);
+
+it.each([false, true])(
+  'rejects external schema aliases without local binding (namesake: %s)',
+  namesake => {
+    const reference = { $ref: 'common.yaml#/components/schemas/User' };
+    const openAPI: OpenAPI = {
+      openapi: '3.0.4',
+      info: {},
+      paths: {},
+      components: {
+        schemas: {
+          Alias: reference,
+          ...(namesake
+            ? {
+                User: {
+                  type: 'object' as const,
+                  properties: { id: { type: 'string' as const } },
+                },
+              }
+            : {}),
+        },
+      },
+    };
+    const message = `Unsupported schema reference: ${reference.$ref}. Bundle or inline external schemas before generation.`;
+    expect(() =>
+      resolveReferenceModelInfo(reference, openAPI.components),
+    ).toThrow(message);
+    const context = new GenerateContext({
+      project: new Project({ useInMemoryFileSystem: true }),
+      outputDir: '/out',
+      openAPI,
+      contextAggregates: new Map(),
+      logger: new SilentLogger(),
+    });
+    expect(() => new ModelGenerator(context).generate()).toThrow(message);
+  },
+);

--- a/packages/generator/test/importAliases.test.ts
+++ b/packages/generator/test/importAliases.test.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import { expect, it } from 'vitest';
+import { Project } from 'ts-morph';
+import { GenerateContext } from '../src/generateContext';
+import { ModelGenerator } from '../src/model';
+
+it('compiles same-named component aliases and reuses their distinct imported names', () => {
+  const outputDir = mkdtempSync(join(tmpdir(), 'fetcher-import-alias-'));
+  try {
+    const project = new Project({ skipAddingFilesFromTsConfig: true });
+    const context = new GenerateContext({
+      project,
+      outputDir,
+      contextAggregates: new Map(),
+      logger: {
+        info() {},
+        success() {},
+        error() {},
+        progress() {},
+        progressWithCount() {},
+      },
+      openAPI: {
+        openapi: '3.0.4',
+        info: {},
+        paths: {},
+        components: {
+          schemas: {
+            User: { $ref: '#/components/schemas/shared.User' },
+            Reused: { $ref: '#/components/schemas/shared.User' },
+            Pair: {
+              type: 'object',
+              properties: {
+                left: { $ref: '#/components/schemas/shared.User' },
+                right: { $ref: '#/components/schemas/other.User' },
+              },
+            },
+            'shared.User': {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+            },
+            'other.User': {
+              type: 'object',
+              properties: { age: { type: 'number' } },
+            },
+          },
+        },
+      },
+    });
+    new ModelGenerator(context).generate();
+    project.saveSync();
+    writeFileSync(
+      join(outputDir, 'consumer.ts'),
+      `
+   import type { User, Reused, Pair } from './types';
+   const user: User = {id:'u'};
+   const reused: Reused = user;
+   const pair: Pair = {left:reused,right:{age:21}};
+   // @ts-expect-error The User alias preserves the shared target fields.
+   const wrongUser: User = {age:21};
+   // @ts-expect-error The second import still resolves the other target.
+   const wrongPair: Pair = {left:user,right:{id:'u'}};
+   void pair; void wrongUser; void wrongPair;
+  `,
+    );
+    writeFileSync(
+      join(outputDir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
+          types: [],
+        },
+        include: ['**/*.ts'],
+      }),
+    );
+    const require = createRequire(import.meta.url);
+    const result = spawnSync(
+      process.execPath,
+      [
+        require.resolve('typescript/lib/tsc.js'),
+        '-p',
+        join(outputDir, 'tsconfig.json'),
+      ],
+      { encoding: 'utf8' },
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+it.each([true, false])(
+  'reserves EnumText declarations regardless of schema order (enum first: %s)',
+  enumFirst => {
+    const project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { strict: true, skipLibCheck: true },
+    });
+    const status = {
+      'local.Status': {
+        type: 'string' as const,
+        enum: ['ON'],
+        'x-enum-text': { ON: 'On' },
+      },
+    };
+    const alias = {
+      'local.Alias': { $ref: '#/components/schemas/remote.StatusEnumText' },
+    };
+    const context = new GenerateContext({
+      project,
+      outputDir: '/out',
+      contextAggregates: new Map(),
+      logger: {
+        info() {},
+        success() {},
+        error() {},
+        progress() {},
+        progressWithCount() {},
+      },
+      openAPI: {
+        openapi: '3.0.4',
+        info: {},
+        paths: {},
+        components: {
+          schemas: {
+            ...(enumFirst ? status : alias),
+            ...(enumFirst ? alias : status),
+            'remote.StatusEnumText': {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+              required: ['id'],
+            },
+          },
+        },
+      },
+    });
+    new ModelGenerator(context).generate();
+    project.createSourceFile(
+      '/out/consumer.ts',
+      `
+    import { StatusEnumText } from './local/types';
+    import type { Alias } from './local/types';
+    const label: StatusEnumText = StatusEnumText.ON;
+    const value: Alias = {id: 'a'};
+    // @ts-expect-error The alias keeps the remote object type.
+    const wrong: Alias = label;
+    void value; void wrong;
+  `,
+    );
+    expect(
+      project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+    ).toEqual([]);
+  },
+);

--- a/packages/generator/test/openapiContracts.test.ts
+++ b/packages/generator/test/openapiContracts.test.ts
@@ -1,0 +1,370 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Project } from 'ts-morph';
+import { ApiClientGenerator, CommandClientGenerator } from '../src/client';
+import { AggregateResolver } from '../src/aggregate';
+import type { OpenAPI, Parameter, Reference } from '@ahoo-wang/fetcher-openapi';
+import { GenerateContext } from '../src/generateContext';
+import { ModelGenerator } from '../src/model';
+import {
+  extractOperationEndpoints,
+  extractOperationOkResponseJsonSchema,
+  extractPathParameters,
+  extractSchema,
+} from '../src/utils';
+
+const logger = {
+  info() {},
+  success() {},
+  error() {},
+  progress() {},
+  progressWithCount() {},
+};
+
+describe('review regressions', () => {
+  it('keeps component aliases assignable to their target enum across files', () => {
+    const project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: { strict: true, skipLibCheck: true },
+    });
+    const context = new GenerateContext({
+      project,
+      outputDir: '/out',
+      contextAggregates: new Map(),
+      logger,
+      openAPI: {
+        openapi: '3.0.4',
+        info: {},
+        paths: {},
+        components: {
+          schemas: {
+            'shared.Target': { type: 'string', enum: ['ON', 'OFF'] },
+            Alias: { $ref: '#/components/schemas/shared.Target' },
+            Chained: { $ref: '#/components/schemas/Alias' },
+          },
+        },
+      },
+    });
+    new ModelGenerator(context).generate();
+    project.getSourceFileOrThrow('/out/types.ts').addStatements(`
+      import { Target as ValueTarget } from './shared/types';
+      const alias: Alias = ValueTarget.ON;
+      declare const response: Alias;
+      const target: ValueTarget = response;
+      const chained: Chained = alias;
+    `);
+    expect(
+      project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+    ).toEqual([]);
+  });
+
+  it('uses JSON extraction for application/json string responses', () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const context = new GenerateContext({
+      project,
+      outputDir: '/out',
+      contextAggregates: new Map(),
+      logger,
+      openAPI: {
+        openapi: '3.0.4',
+        info: {},
+        paths: {
+          '/message': {
+            get: {
+              tags: ['Messages'],
+              operationId: 'message',
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': { schema: { type: 'string' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    new ApiClientGenerator(context).generate();
+    const method = project
+      .getSourceFileOrThrow('/out/MessagesApiClient.ts')
+      .getClassOrThrow('MessagesApiClient')
+      .getMethodOrThrow('message');
+    expect(
+      method
+        .getDecoratorOrThrow('get')
+        .getArguments()
+        .map(arg => arg.getText()),
+    ).toEqual(["'/message'"]);
+    expect(method.getReturnTypeNodeOrThrow().getText()).toBe('Promise<string>');
+  });
+
+  it.each([
+    ['application/json', 'Promise<string>', undefined],
+    ['*/*', 'Promise<string>', '{resultExtractor:ResultExtractors.Text}'],
+    [
+      'text/event-stream',
+      'Promise<JsonServerSentEventStream<any>>',
+      '{headers:{Accept:ContentTypeValues.TEXT_EVENT_STREAM},resultExtractor:JsonEventStreamResultExtractor,}',
+    ],
+  ])(
+    'preserves %s decoding through response aliases',
+    (contentType, returnType, metadata) => {
+      const project = new Project({ useInMemoryFileSystem: true });
+      const operation = {
+        tags: ['Messages'],
+        operationId: 'message',
+        responses: { '200': { $ref: '#/components/responses/Alias' } },
+      };
+      const components = {
+        responses: {
+          Alias: { $ref: '#/components/responses/Base' },
+          Base: {
+            content: { [contentType]: { schema: { type: 'string' as const } } },
+          },
+        },
+      };
+      const context = new GenerateContext({
+        project,
+        outputDir: '/out',
+        contextAggregates: new Map(),
+        logger,
+        openAPI: {
+          openapi: '3.0.4',
+          info: {},
+          paths: { '/message': { get: operation } },
+          components,
+        },
+      });
+      new ApiClientGenerator(context).generate();
+      const method = project
+        .getSourceFileOrThrow('/out/MessagesApiClient.ts')
+        .getClassOrThrow('MessagesApiClient')
+        .getMethodOrThrow('message');
+      expect(method.getReturnTypeNodeOrThrow().getText()).toBe(returnType);
+      expect(
+        method
+          .getDecoratorOrThrow('get')
+          .getArguments()
+          .map(arg => arg.getText().replace(/\s/g, '')),
+      ).toEqual(metadata ? ["'/message'", metadata] : ["'/message'"]);
+      if (contentType === 'application/json') {
+        expect(
+          extractOperationOkResponseJsonSchema(operation, components),
+        ).toEqual({ type: 'string' });
+      }
+    },
+  );
+
+  it('inherits path parameters and allows operation overrides', () => {
+    const [endpoint] = extractOperationEndpoints({
+      '/pets/{id}': {
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        get: { responses: {} },
+      },
+    });
+    expect(extractPathParameters(endpoint.operation, {})).toEqual([
+      { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+    ]);
+    const [overridden] = extractOperationEndpoints({
+      '/pets/{id}': {
+        parameters: [{ name: 'id', in: 'path', schema: { type: 'string' } }],
+        get: {
+          parameters: [{ name: 'id', in: 'path', schema: { type: 'integer' } }],
+          responses: {},
+        },
+      },
+    });
+    expect(extractPathParameters(overridden.operation, {})).toEqual([
+      { name: 'id', in: 'path', schema: { type: 'integer' } },
+    ]);
+  });
+
+  it.each(['path', 'operation', 'override'] as const)(
+    'binds component path parameters in command clients at %s level',
+    location => {
+      const parameters: (Parameter | Reference)[] = [
+        { $ref: '#/components/parameters/RegionAlias' },
+        { $ref: '#/components/parameters/wow.id' },
+        { $ref: '#/components/parameters/wow.tenantId' },
+        { $ref: '#/components/parameters/wow.ownerId' },
+        { $ref: '#/components/parameters/Filter' },
+      ];
+      const openAPI: OpenAPI = {
+        openapi: '3.0.4',
+        info: {},
+        tags: [{ name: 'example.pet' }],
+        paths: {
+          '/tenant/{tenantId}/owner/{ownerId}/pets/{region}/{id}/rename': {
+            parameters: location === 'operation' ? undefined : parameters,
+            post: {
+              tags: ['example.pet'],
+              operationId: 'example.pet.rename',
+              parameters:
+                location === 'operation'
+                  ? parameters
+                  : location === 'override'
+                    ? [{ $ref: '#/components/parameters/NumericRegion' }]
+                    : undefined,
+              requestBody: {
+                content: {
+                  'application/json': {
+                    schema: { $ref: '#/components/schemas/Rename' },
+                  },
+                },
+              },
+              responses: {
+                '200': { $ref: '#/components/responses/wow.CommandOk' },
+              },
+            },
+          },
+          '/pets/state': {
+            post: {
+              tags: ['example.pet'],
+              operationId: 'example.pet.snapshot_state.single',
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/Pet' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '/pets/count': {
+            post: {
+              tags: ['example.pet'],
+              operationId: 'example.pet.snapshot.count',
+              requestBody: {
+                'x-wow-query-fields': {
+                  $ref: '#/components/schemas/PetFields',
+                },
+                content: {},
+              },
+              responses: {},
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Rename: {
+              type: 'object',
+              properties: { name: { type: 'string' } },
+              required: ['name'],
+            },
+            Pet: { type: 'object' },
+            PetFields: { type: 'string', enum: ['name'] },
+          },
+          parameters: {
+            RegionAlias: { $ref: '#/components/parameters/Region' },
+            Region: {
+              name: 'region',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+            NumericRegion: {
+              name: 'region',
+              in: 'path',
+              required: true,
+              schema: { type: 'integer' },
+            },
+            'wow.id': {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+            'wow.tenantId': {
+              name: 'tenantId',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+            'wow.ownerId': {
+              name: 'ownerId',
+              in: 'path',
+              required: true,
+              schema: { type: 'string' },
+            },
+            Filter: { name: 'filter', in: 'query', schema: { type: 'string' } },
+          },
+        },
+      };
+      const project = new Project({ useInMemoryFileSystem: true });
+      const contextAggregates = new AggregateResolver(openAPI).resolve();
+      const context = new GenerateContext({
+        project,
+        outputDir: '/out',
+        openAPI,
+        contextAggregates,
+        logger,
+        config: { apiClients: { 'example.pet': { ignorePathParameters: [] } } },
+      });
+      new CommandClientGenerator(context).generate();
+      const commandFile = project.getSourceFileOrThrow(
+        '/out/example/pet/commandClient.ts',
+      );
+      const method = commandFile
+        .getClassOrThrow('PetCommandClient')
+        .getMethodOrThrow('rename');
+      expect(
+        method.getParameters().map(parameter => parameter.getName()),
+      ).toEqual(['region', 'id', 'commandRequest', 'attributes']);
+      for (const name of ['region', 'id']) {
+        const parameter = method.getParameterOrThrow(name);
+        expect(
+          parameter.getDecoratorOrThrow('path').getArguments()[0].getText(),
+        ).toBe(`'${name}'`);
+        expect(parameter.getTypeNodeOrThrow().getText()).toBe(
+          name === 'region' && location === 'override' ? 'number' : 'string',
+        );
+      }
+      expect(
+        commandFile
+          .getClassOrThrow('PetStreamCommandClient')
+          .getExtends()
+          ?.getText(),
+      ).toBe('PetCommandClient<CommandResultEventStream>');
+    },
+  );
+
+  it('resolves reusable component aliases and rejects reference cycles', () => {
+    const components = {
+      schemas: {
+        Alias: { $ref: '#/components/schemas/Value' },
+        Value: { type: 'string' as const },
+      },
+    };
+    expect(
+      extractSchema({ $ref: '#/components/schemas/Alias' }, components),
+    ).toEqual({ type: 'string' });
+    expect(() =>
+      extractSchema(
+        { $ref: '#/components/schemas/Alias' },
+        { schemas: { Alias: { $ref: '#/components/schemas/Alias' } } },
+      ),
+    ).toThrow(/cyclic/i);
+  });
+});

--- a/packages/openapi/src/components.ts
+++ b/packages/openapi/src/components.ts
@@ -40,15 +40,15 @@ import type { Extensible } from './extensions';
  * @property callbacks - An object to hold reusable Callback Objects
  */
 export interface Components extends Extensible {
-  schemas?: Record<string, Schema>;
-  responses?: Record<string, Response>;
-  parameters?: Record<string, Parameter>;
+  schemas?: Record<string, Schema | Reference>;
+  responses?: Record<string, Response | Reference>;
+  parameters?: Record<string, Parameter | Reference>;
   examples?: Record<string, Example | Reference>;
-  requestBodies?: Record<string, RequestBody>;
+  requestBodies?: Record<string, RequestBody | Reference>;
   headers?: Record<string, Header | Reference>;
-  securitySchemes?: Record<string, SecurityScheme>;
-  links?: Record<string, Link>;
-  callbacks?: Record<string, Callback>;
+  securitySchemes?: Record<string, SecurityScheme | Reference>;
+  links?: Record<string, Link | Reference>;
+  callbacks?: Record<string, Callback | Reference>;
 }
 
 /**

--- a/packages/openapi/test/componentReferences.test.ts
+++ b/packages/openapi/test/componentReferences.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it } from 'vitest';
+import ts from 'typescript';
+import { resolve } from 'node:path';
+
+it('accepts references in every reusable component map', () => {
+  const fileName = resolve('test/component-reference-contract.ts');
+  const source = `import type { Components } from '../src';
+const ref = { $ref: '#/components/schemas/Target' };
+const components: Components = {
+  schemas: { Alias: ref }, responses: { Alias: ref },
+  parameters: { Alias: ref }, requestBodies: { Alias: ref },
+  securitySchemes: { Alias: ref }, links: { Alias: ref }, callbacks: { Alias: ref },
+};`;
+  const options: ts.CompilerOptions = {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    types: [],
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (name, version, onError, shouldCreateNewSourceFile) =>
+    name === fileName
+      ? ts.createSourceFile(name, source, version)
+      : getSourceFile(name, version, onError, shouldCreateNewSourceFile);
+  const program = ts.createProgram([fileName], options, host);
+  expect(
+    ts
+      .getPreEmitDiagnostics(program)
+      .map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')),
+  ).toEqual([]);
+});

--- a/skills/fetcher-openapi-generator/references/api.md
+++ b/skills/fetcher-openapi-generator/references/api.md
@@ -86,6 +86,26 @@ await generator.generate();
 
 ## Code Generation Pipeline
 
+Component aliases are resolved locally; cyclic component aliases fail generation. When a referenced model shares a name with a declaration or another import in the generated file, the import receives a distinct local alias; repeated references reuse it. The public generated model keeps its original component name. Potential `EnumText` names are reserved before generation, so schema order cannot create an import collision.
+Schema aliases retain their target type identity (`type Alias = Target`), including
+enum aliases across model files. Response aliases are resolved before selecting
+the JSON, text, or event-stream decoder.
+Path-level parameters are inherited by operations; an operation overrides a
+parameter with the same name and location. API and command clients both resolve
+custom component parameter references and aliases before binding path arguments.
+Command clients retain `wow.id` and continue to omit `tenantId`/`ownerId` arguments.
+JSON string responses are decoded as JSON.
+
+Command identification follows local response aliases only when their chain reaches
+`#/components/responses/wow.CommandOk`; matching an unrelated response shape is not
+sufficient. Inline and locally referenced command request bodies are supported.
+Component lookup stays within the referenced local component category at every
+alias hop. External documents are not fetched or substituted with same-named local
+components. Unbundled external schema references fail with their URI and bundling
+guidance instead of generating a local model name. Unresolved response references keep the raw `Promise<Response>` fallback;
+unresolved parameter references do not produce named path arguments. Bundle or
+inline external references before generation for complete typed signatures.
+
 ```
 parseOpenAPI(inputPath) → AggregateResolver(openAPI).resolve()
   → ModelGenerator.generate() → ClientGenerator.generate()

--- a/skills/fetcher-openapi-types/references/api.md
+++ b/skills/fetcher-openapi-types/references/api.md
@@ -254,17 +254,17 @@ const securityReq: SecurityRequirement = {
 
 ### Components
 
-| Property          | Type                                   |
-| ----------------- | -------------------------------------- |
-| `schemas`         | `Record<string, Schema>`               |
-| `responses`       | `Record<string, Response>`             |
-| `parameters`      | `Record<string, Parameter>`            |
-| `examples`        | `Record<string, Example \| Reference>` |
-| `requestBodies`   | `Record<string, RequestBody>`          |
-| `headers`         | `Record<string, Header \| Reference>`  |
-| `securitySchemes` | `Record<string, SecurityScheme>`       |
-| `links`           | `Record<string, Link>`                 |
-| `callbacks`       | `Record<string, Callback>`             |
+| Property          | Type                                          |
+| ----------------- | --------------------------------------------- |
+| `schemas`         | `Record<string, Schema \| Reference>`         |
+| `responses`       | `Record<string, Response \| Reference>`       |
+| `parameters`      | `Record<string, Parameter \| Reference>`      |
+| `examples`        | `Record<string, Example \| Reference>`        |
+| `requestBodies`   | `Record<string, RequestBody \| Reference>`    |
+| `headers`         | `Record<string, Header \| Reference>`         |
+| `securitySchemes` | `Record<string, SecurityScheme \| Reference>` |
+| `links`           | `Record<string, Link \| Reference>`           |
+| `callbacks`       | `Record<string, Callback \| Reference>`       |
 
 ---
 


### PR DESCRIPTION
## Description

Reusable component references could produce colliding TypeScript imports, omit Wow command methods, or incorrectly select local components for external references. This PR preserves alias target types, assigns distinct import names when needed (including reserved `EnumText` declarations), and resolves local response/request-body aliases while retaining the canonical `wow.CommandOk` command marker.

API and command clients inherit and override path parameters through the shared resolver. Component lookup stays within its local category at every alias hop; unresolved parameter metadata is omitted safely, and unresolved response references keep the existing raw `Promise<Response>` fallback. External schemas fail with an actionable URI error instead of generating a local model name. External documents must be bundled or inlined for complete typed signatures. Response aliases preserve JSON, text and SSE extraction, including JSON string responses. The shared 5.0.0 prerequisite covers the public OpenAPI component type changes.

## Validation

The combined stack passed these checks before the scoped fix was inserted into this PR. Every later layer was replayed and verified against the unchanged tested tree, including its existing schema rules:

- `pnpm build`
- `pnpm test:unit` — 277 files, 3745 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .` — no errors
- `git diff --check`

Node.js 24.11.0, pnpm 10.34.5. Regressions include actual generated model/API/CommandClient compilation, checked invalid consumer assignments, canonical command recognition, and external-reference collisions. Existing lint warnings remain. No dependencies or build configuration changed.

## Review and CI

Ready for review. Merge requires a completed GitHub Codex review, no unresolved review threads, and five successful CI workflows for the current head. Codacy quality-rule findings remain separately documented with source evidence.

Native GitHub stack #1418, layer 10 of 16. Squash this layer separately and verify rewritten heads before advancing. No release or tag is published.

Split index: #1399.
