### PR TITLE
fix(generator): preserve schema constraints in generated types

### DIFF
--- a/packages/generator/expected/compensation-spec/compensation/execution_failed/types.ts
+++ b/packages/generator/expected/compensation-spec/compensation/execution_failed/types.ts
@@ -32,7 +32,7 @@ export interface ApplyExecutionFailed {
     error: ErrorDetails;
     /** - format: int64 */
     executeAt: number;
-    recoverable: RecoverableType;
+    recoverable?: RecoverableType;
 }
 
 /**
@@ -225,8 +225,8 @@ export interface CreateExecutionFailed {
     /** - format: int64 */
     executeAt: number;
     function: FunctionInfo;
-    recoverable: RecoverableType;
-    retrySpec: (null | RetrySpec);
+    recoverable?: RecoverableType;
+    retrySpec?: globalThis.Exclude<(null | RetrySpec), string | number | boolean | readonly unknown[]> & ({ readonly [globalThis.Symbol.iterator]?: never } | null);
 }
 
 /**
@@ -265,11 +265,11 @@ export interface CreateExecutionFailed {
  * ```
  */
 export interface ErrorDetails {
-    bindingErrors: BindingError[];
+    bindingErrors?: BindingError[];
     errorCode: string;
     errorMsg: string;
     stackTrace: string;
-    readonly succeeded: boolean;
+    readonly succeeded?: boolean;
 }
 
 /**
@@ -366,54 +366,55 @@ export interface EventId {
  * ```
  */
 export enum ExecutionFailedAggregatedFields {
-    AGGREGATE_ID = `aggregateId`,
-    TENANT_ID = `tenantId`,
-    OWNER_ID = `ownerId`,
-    VERSION = `version`,
-    EVENT_ID = `eventId`,
-    FIRST_OPERATOR = `firstOperator`,
-    OPERATOR = `operator`,
-    FIRST_EVENT_TIME = `firstEventTime`,
-    EVENT_TIME = `eventTime`,
-    DELETED = `deleted`,
-    STATE = `state`,
-    STATE_ERROR = `state.error`,
-    STATE_ERROR_BINDING_ERRORS = `state.error.bindingErrors`,
-    STATE_ERROR_BINDING_ERRORS_MSG = `state.error.bindingErrors.msg`,
-    STATE_ERROR_BINDING_ERRORS_NAME = `state.error.bindingErrors.name`,
-    STATE_ERROR_ERROR_CODE = `state.error.errorCode`,
-    STATE_ERROR_ERROR_MSG = `state.error.errorMsg`,
-    STATE_ERROR_STACK_TRACE = `state.error.stackTrace`,
-    STATE_ERROR_SUCCEEDED = `state.error.succeeded`,
-    STATE_EVENT_ID = `state.eventId`,
-    STATE_EVENT_ID_AGGREGATE_ID = `state.eventId.aggregateId`,
-    STATE_EVENT_ID_AGGREGATE_ID_NAMED_AGGREGATE = `state.eventId.aggregateId.namedAggregate`,
-    STATE_EVENT_ID_AGGREGATE_ID_NAMED_AGGREGATE_AGGREGATE_NAME = `state.eventId.aggregateId.namedAggregate.aggregateName`,
-    STATE_EVENT_ID_AGGREGATE_ID_NAMED_AGGREGATE_CONTEXT_NAME = `state.eventId.aggregateId.namedAggregate.contextName`,
-    STATE_EVENT_ID_AGGREGATE_ID_ID = `state.eventId.aggregateId.id`,
-    STATE_EVENT_ID_AGGREGATE_ID_TENANT_ID = `state.eventId.aggregateId.tenantId`,
-    STATE_EVENT_ID_ID = `state.eventId.id`,
-    STATE_EVENT_ID_VERSION = `state.eventId.version`,
-    STATE_EXECUTE_AT = `state.executeAt`,
-    STATE_FUNCTION = `state.function`,
-    STATE_FUNCTION_CONTEXT_NAME = `state.function.contextName`,
-    STATE_FUNCTION_FUNCTION_KIND = `state.function.functionKind`,
-    STATE_FUNCTION_NAME = `state.function.name`,
-    STATE_FUNCTION_PROCESSOR_NAME = `state.function.processorName`,
-    STATE_ID = `state.id`,
-    STATE_RECOVERABLE = `state.recoverable`,
-    STATE_RETRY_SPEC = `state.retrySpec`,
-    STATE_RETRY_SPEC_EXECUTION_TIMEOUT = `state.retrySpec.executionTimeout`,
-    STATE_RETRY_SPEC_MAX_RETRIES = `state.retrySpec.maxRetries`,
-    STATE_RETRY_SPEC_MIN_BACKOFF = `state.retrySpec.minBackoff`,
-    STATE_RETRY_STATE = `state.retryState`,
-    STATE_RETRY_STATE_NEXT_RETRY_AT = `state.retryState.nextRetryAt`,
-    STATE_RETRY_STATE_RETRIES = `state.retryState.retries`,
-    STATE_RETRY_STATE_RETRY_AT = `state.retryState.retryAt`,
-    STATE_RETRY_STATE_TIMEOUT_AT = `state.retryState.timeoutAt`,
-    STATE_STATUS = `state.status`,
-    STATE_IS_BELOW_RETRY_THRESHOLD = `state.isBelowRetryThreshold`,
-    STATE_IS_RETRYABLE = `state.isRetryable`
+    '' = '',
+    AGGREGATE_ID = 'aggregateId',
+    TENANT_ID = 'tenantId',
+    OWNER_ID = 'ownerId',
+    VERSION = 'version',
+    EVENT_ID = 'eventId',
+    FIRST_OPERATOR = 'firstOperator',
+    OPERATOR = 'operator',
+    FIRST_EVENT_TIME = 'firstEventTime',
+    EVENT_TIME = 'eventTime',
+    DELETED = 'deleted',
+    STATE = 'state',
+    STATE_ERROR = 'state.error',
+    STATE_ERROR_BINDING_ERRORS = 'state.error.bindingErrors',
+    STATE_ERROR_BINDING_ERRORS_MSG = 'state.error.bindingErrors.msg',
+    STATE_ERROR_BINDING_ERRORS_NAME = 'state.error.bindingErrors.name',
+    STATE_ERROR_ERROR_CODE = 'state.error.errorCode',
+    STATE_ERROR_ERROR_MSG = 'state.error.errorMsg',
+    STATE_ERROR_STACK_TRACE = 'state.error.stackTrace',
+    STATE_ERROR_SUCCEEDED = 'state.error.succeeded',
+    STATE_EVENT_ID = 'state.eventId',
+    STATE_EVENT_ID_AGGREGATE_ID = 'state.eventId.aggregateId',
+    STATE_EVENT_ID_AGGREGATE_ID_NAMED_AGGREGATE = 'state.eventId.aggregateId.namedAggregate',
+    STATE_EVENT_ID_AGGREGATE_ID_NAMED_AGGREGATE_AGGREGATE_NAME = 'state.eventId.aggregateId.namedAggregate.aggregateName',
+    STATE_EVENT_ID_AGGREGATE_ID_NAMED_AGGREGATE_CONTEXT_NAME = 'state.eventId.aggregateId.namedAggregate.contextName',
+    STATE_EVENT_ID_AGGREGATE_ID_ID = 'state.eventId.aggregateId.id',
+    STATE_EVENT_ID_AGGREGATE_ID_TENANT_ID = 'state.eventId.aggregateId.tenantId',
+    STATE_EVENT_ID_ID = 'state.eventId.id',
+    STATE_EVENT_ID_VERSION = 'state.eventId.version',
+    STATE_EXECUTE_AT = 'state.executeAt',
+    STATE_FUNCTION = 'state.function',
+    STATE_FUNCTION_CONTEXT_NAME = 'state.function.contextName',
+    STATE_FUNCTION_FUNCTION_KIND = 'state.function.functionKind',
+    STATE_FUNCTION_NAME = 'state.function.name',
+    STATE_FUNCTION_PROCESSOR_NAME = 'state.function.processorName',
+    STATE_ID = 'state.id',
+    STATE_RECOVERABLE = 'state.recoverable',
+    STATE_RETRY_SPEC = 'state.retrySpec',
+    STATE_RETRY_SPEC_EXECUTION_TIMEOUT = 'state.retrySpec.executionTimeout',
+    STATE_RETRY_SPEC_MAX_RETRIES = 'state.retrySpec.maxRetries',
+    STATE_RETRY_SPEC_MIN_BACKOFF = 'state.retrySpec.minBackoff',
+    STATE_RETRY_STATE = 'state.retryState',
+    STATE_RETRY_STATE_NEXT_RETRY_AT = 'state.retryState.nextRetryAt',
+    STATE_RETRY_STATE_RETRIES = 'state.retryState.retries',
+    STATE_RETRY_STATE_RETRY_AT = 'state.retryState.retryAt',
+    STATE_RETRY_STATE_TIMEOUT_AT = 'state.retryState.timeoutAt',
+    STATE_STATUS = 'state.status',
+    STATE_IS_BELOW_RETRY_THRESHOLD = 'state.isBelowRetryThreshold',
+    STATE_IS_RETRYABLE = 'state.isRetryable'
 }
 
 /**
@@ -447,7 +448,7 @@ export interface ExecutionFailedApplied {
     error: ErrorDetails;
     /** - format: int64 */
     executeAt: number;
-    recoverable: RecoverableType;
+    recoverable?: RecoverableType;
 }
 
 /**
@@ -499,7 +500,7 @@ export interface ExecutionFailedCreated {
     /** - format: int64 */
     executeAt: number;
     function: FunctionInfo;
-    recoverable: RecoverableType;
+    recoverable?: RecoverableType;
     retrySpec: RetrySpec;
     retryState: RetryState;
 }
@@ -560,18 +561,18 @@ export interface ExecutionFailedCreated {
  * ```
  */
 export interface ExecutionFailedState {
-    readonly error: ErrorDetails;
-    readonly eventId: EventId;
+    readonly error?: ErrorDetails;
+    readonly eventId?: EventId;
     /** - format: int64 */
-    executeAt: number;
-    readonly function: FunctionInfo;
+    executeAt?: number;
+    readonly function?: FunctionInfo;
     id: string;
-    recoverable: RecoverableType;
-    readonly retrySpec: RetrySpec;
-    readonly retryState: RetryState;
-    status: ExecutionFailedStatus;
-    readonly isBelowRetryThreshold: boolean;
-    readonly isRetryable: boolean;
+    recoverable?: RecoverableType;
+    readonly retrySpec?: RetrySpec;
+    readonly retryState?: RetryState;
+    status?: ExecutionFailedStatus;
+    readonly isBelowRetryThreshold?: boolean;
+    readonly isRetryable?: boolean;
 }
 
 /**
@@ -589,9 +590,9 @@ export interface ExecutionFailedState {
  * ```
  */
 export enum ExecutionFailedStatus {
-    FAILED = `FAILED`,
-    PREPARED = `PREPARED`,
-    SUCCEEDED = `SUCCEEDED`
+    FAILED = 'FAILED',
+    PREPARED = 'PREPARED',
+    SUCCEEDED = 'SUCCEEDED'
 }
 
 /**
@@ -631,7 +632,7 @@ export interface ExecutionSuccessApplied {
  * }
  * ```
  */
-export type ForcePrepareCompensation = Record<string, any>;
+export type ForcePrepareCompensation = globalThis.Record<string, any>;
 
 /**
  * function_changed
@@ -707,7 +708,7 @@ export interface MarkRecoverable {
  * }
  * ```
  */
-export type PrepareCompensation = Record<string, any>;
+export type PrepareCompensation = globalThis.Record<string, any>;
 
 /**
  * recoverable_marked

--- a/packages/generator/expected/compensation-spec/compensation/types.ts
+++ b/packages/generator/expected/compensation-spec/compensation/types.ts
@@ -12,8 +12,8 @@
  * ```
  */
 export enum ApiVersion {
-    V2 = `V2`,
-    V3 = `V3`
+    V2 = 'V2',
+    V3 = 'V3'
 }
 
 /**
@@ -34,8 +34,8 @@ export enum ApiVersion {
  * ```
  */
 export interface Link {
-    href: string;
-    templated: boolean;
+    href?: string;
+    templated?: boolean;
 }
 
 /**
@@ -47,7 +47,7 @@ export interface Link {
  * }
  * ```
  */
-export type SecurityContext = Record<string, any>;
+export type SecurityContext = globalThis.Record<string, any>;
 /**
  * - key: compensation.StringLinkMap
  * - schema: 
@@ -60,7 +60,7 @@ export type SecurityContext = Record<string, any>;
  * }
  * ```
  */
-export type StringLinkMap = Record<string, Link>;
+export type StringLinkMap = globalThis.Record<string, Link>;
 /**
  * - key: compensation.StringObjectMap
  * - schema: 
@@ -70,7 +70,7 @@ export type StringLinkMap = Record<string, Link>;
  * }
  * ```
  */
-export type StringObjectMap = Record<string, any>;
+export type StringObjectMap = globalThis.Record<string, any>;
 
 /**
  * - key: compensation.WebServerNamespace
@@ -87,5 +87,5 @@ export type StringObjectMap = Record<string, any>;
  * ```
  */
 export interface WebServerNamespace {
-    value: string;
+    value?: string;
 }

--- a/packages/generator/expected/demo-spec/example/cart/types.ts
+++ b/packages/generator/expected/demo-spec/example/cart/types.ts
@@ -30,7 +30,7 @@ export interface CartData {
      * 购物车数量
      * - format: int32
      */
-    readonly size: number;
+    readonly size?: number;
 }
 
 /**
@@ -70,7 +70,7 @@ export interface AddCartItem {
      * - Numeric Constraints
      *   - exclusiveMinimum: 0
      */
-    quantity: number;
+    quantity?: number;
 }
 
 /**
@@ -104,24 +104,25 @@ export interface AddCartItem {
  * ```
  */
 export enum CartAggregatedFields {
-    AGGREGATE_ID = `aggregateId`,
-    TENANT_ID = `tenantId`,
-    OWNER_ID = `ownerId`,
-    SPACE_ID = `spaceId`,
-    VERSION = `version`,
-    EVENT_ID = `eventId`,
-    FIRST_OPERATOR = `firstOperator`,
-    OPERATOR = `operator`,
-    FIRST_EVENT_TIME = `firstEventTime`,
-    EVENT_TIME = `eventTime`,
-    TAGS = `tags`,
-    DELETED = `deleted`,
-    STATE = `state`,
-    STATE_ID = `state.id`,
-    STATE_ITEMS = `state.items`,
-    STATE_ITEMS_PRODUCT_ID = `state.items.productId`,
-    STATE_ITEMS_QUANTITY = `state.items.quantity`,
-    STATE_SIZE = `state.size`
+    '' = '',
+    AGGREGATE_ID = 'aggregateId',
+    TENANT_ID = 'tenantId',
+    OWNER_ID = 'ownerId',
+    SPACE_ID = 'spaceId',
+    VERSION = 'version',
+    EVENT_ID = 'eventId',
+    FIRST_OPERATOR = 'firstOperator',
+    OPERATOR = 'operator',
+    FIRST_EVENT_TIME = 'firstEventTime',
+    EVENT_TIME = 'eventTime',
+    TAGS = 'tags',
+    DELETED = 'deleted',
+    STATE = 'state',
+    STATE_ID = 'state.id',
+    STATE_ITEMS = 'state.items',
+    STATE_ITEMS_PRODUCT_ID = 'state.items.productId',
+    STATE_ITEMS_QUANTITY = 'state.items.quantity',
+    STATE_SIZE = 'state.size'
 }
 
 /**
@@ -148,7 +149,7 @@ export enum CartAggregatedFields {
 export interface CartItem {
     productId: string;
     /** - format: int32 */
-    quantity: number;
+    quantity?: number;
 }
 
 /**
@@ -254,12 +255,12 @@ export interface CartQuantityChanged {
  */
 export interface CartState {
     id: string;
-    items: CartItem[];
+    items?: CartItem[];
     /**
      * 购物车数量
      * - format: int32
      */
-    readonly size: number;
+    readonly size?: number;
 }
 
 /**
@@ -315,7 +316,7 @@ export interface ChangeQuantity {
  * }
  * ```
  */
-export type MockVariableCommand = Record<string, any>;
+export type MockVariableCommand = globalThis.Record<string, any>;
 
 /**
  * - key: example.cart.MockVariableCommand.MockEnum
@@ -332,9 +333,9 @@ export type MockVariableCommand = Record<string, any>;
  * ```
  */
 export enum MockVariableCommandMockEnum {
-    FIRST = `First`,
-    SECOND = `Second`,
-    THIRD = `Third`
+    FIRST = 'First',
+    SECOND = 'Second',
+    THIRD = 'Third'
 }
 
 /**
@@ -349,7 +350,7 @@ export enum MockVariableCommandMockEnum {
  * }
  * ```
  */
-export type MountedCommand = Record<string, any>;
+export type MountedCommand = globalThis.Record<string, any>;
 
 /**
  * 删除商品
@@ -395,4 +396,4 @@ export interface RemoveCartItem {
  * }
  * ```
  */
-export type ViewCart = Record<string, any>;
+export type ViewCart = globalThis.Record<string, any>;

--- a/packages/generator/expected/demo-spec/example/order/types.ts
+++ b/packages/generator/expected/demo-spec/example/order/types.ts
@@ -41,13 +41,13 @@
  * ```
  */
 export interface WowExampleOrderState {
-    readonly address: ShippingAddress;
+    readonly address?: ShippingAddress;
     id: string;
-    readonly items: OrderItem[];
-    paidAmount: number;
-    status: OrderStatus;
-    totalAmount: number;
-    readonly payable: number;
+    readonly items?: OrderItem[];
+    paidAmount?: number;
+    status?: OrderStatus;
+    totalAmount?: number;
+    readonly payable?: number;
 }
 
 /**
@@ -230,36 +230,37 @@ export interface CreateOrderItem {
  * ```
  */
 export enum OrderAggregatedFields {
-    AGGREGATE_ID = `aggregateId`,
-    TENANT_ID = `tenantId`,
-    OWNER_ID = `ownerId`,
-    SPACE_ID = `spaceId`,
-    VERSION = `version`,
-    EVENT_ID = `eventId`,
-    FIRST_OPERATOR = `firstOperator`,
-    OPERATOR = `operator`,
-    FIRST_EVENT_TIME = `firstEventTime`,
-    EVENT_TIME = `eventTime`,
-    TAGS = `tags`,
-    DELETED = `deleted`,
-    STATE = `state`,
-    STATE_ADDRESS = `state.address`,
-    STATE_ADDRESS_CITY = `state.address.city`,
-    STATE_ADDRESS_COUNTRY = `state.address.country`,
-    STATE_ADDRESS_DETAIL = `state.address.detail`,
-    STATE_ADDRESS_DISTRICT = `state.address.district`,
-    STATE_ADDRESS_PROVINCE = `state.address.province`,
-    STATE_ID = `state.id`,
-    STATE_ITEMS = `state.items`,
-    STATE_ITEMS_ID = `state.items.id`,
-    STATE_ITEMS_PRICE = `state.items.price`,
-    STATE_ITEMS_PRODUCT_ID = `state.items.productId`,
-    STATE_ITEMS_QUANTITY = `state.items.quantity`,
-    STATE_ITEMS_TOTAL_PRICE = `state.items.totalPrice`,
-    STATE_PAID_AMOUNT = `state.paidAmount`,
-    STATE_PAYABLE = `state.payable`,
-    STATE_STATUS = `state.status`,
-    STATE_TOTAL_AMOUNT = `state.totalAmount`
+    '' = '',
+    AGGREGATE_ID = 'aggregateId',
+    TENANT_ID = 'tenantId',
+    OWNER_ID = 'ownerId',
+    SPACE_ID = 'spaceId',
+    VERSION = 'version',
+    EVENT_ID = 'eventId',
+    FIRST_OPERATOR = 'firstOperator',
+    OPERATOR = 'operator',
+    FIRST_EVENT_TIME = 'firstEventTime',
+    EVENT_TIME = 'eventTime',
+    TAGS = 'tags',
+    DELETED = 'deleted',
+    STATE = 'state',
+    STATE_ADDRESS = 'state.address',
+    STATE_ADDRESS_CITY = 'state.address.city',
+    STATE_ADDRESS_COUNTRY = 'state.address.country',
+    STATE_ADDRESS_DETAIL = 'state.address.detail',
+    STATE_ADDRESS_DISTRICT = 'state.address.district',
+    STATE_ADDRESS_PROVINCE = 'state.address.province',
+    STATE_ID = 'state.id',
+    STATE_ITEMS = 'state.items',
+    STATE_ITEMS_ID = 'state.items.id',
+    STATE_ITEMS_PRICE = 'state.items.price',
+    STATE_ITEMS_PRODUCT_ID = 'state.items.productId',
+    STATE_ITEMS_QUANTITY = 'state.items.quantity',
+    STATE_ITEMS_TOTAL_PRICE = 'state.items.totalPrice',
+    STATE_PAID_AMOUNT = 'state.paidAmount',
+    STATE_PAYABLE = 'state.payable',
+    STATE_STATUS = 'state.status',
+    STATE_TOTAL_AMOUNT = 'state.totalAmount'
 }
 
 /**
@@ -343,7 +344,7 @@ export interface OrderItem {
     productId: string;
     /** - format: int32 */
     quantity: number;
-    readonly totalPrice: number;
+    readonly totalPrice?: number;
 }
 
 /**
@@ -385,7 +386,7 @@ export interface OrderPaid {
  * }
  * ```
  */
-export type OrderReceived = Record<string, any>;
+export type OrderReceived = globalThis.Record<string, any>;
 /**
  * order_shipped
  * - key: example.order.OrderShipped
@@ -397,13 +398,13 @@ export type OrderReceived = Record<string, any>;
  * }
  * ```
  */
-export type OrderShipped = Record<string, any>;
+export type OrderShipped = globalThis.Record<string, any>;
 
 export enum OrderStatusEnumText {
-    CREATED = `已创建`,
-    PAID = `已支付`,
-    SHIPPED = `已发货`,
-    RECEIVED = `已收货`
+    CREATED = '已创建',
+    PAID = '已支付',
+    SHIPPED = '已发货',
+    RECEIVED = '已收货'
 }
 
 /**
@@ -428,10 +429,10 @@ export enum OrderStatusEnumText {
  * ```
  */
 export enum OrderStatus {
-    CREATED = `CREATED`,
-    PAID = `PAID`,
-    SHIPPED = `SHIPPED`,
-    RECEIVED = `RECEIVED`
+    CREATED = 'CREATED',
+    PAID = 'PAID',
+    SHIPPED = 'SHIPPED',
+    RECEIVED = 'RECEIVED'
 }
 
 /**
@@ -485,7 +486,7 @@ export interface PayOrder {
  * }
  * ```
  */
-export type ReceiptOrder = Record<string, any>;
+export type ReceiptOrder = globalThis.Record<string, any>;
 /**
  * 发货
  * - key: example.order.ShipOrder
@@ -498,7 +499,7 @@ export type ReceiptOrder = Record<string, any>;
  * }
  * ```
  */
-export type ShipOrder = Record<string, any>;
+export type ShipOrder = globalThis.Record<string, any>;
 
 /**
  * - key: example.order.ShippingAddress

--- a/packages/generator/expected/demo-spec/example/types.ts
+++ b/packages/generator/expected/demo-spec/example/types.ts
@@ -12,8 +12,8 @@
  * ```
  */
 export enum ApiVersion {
-    V2 = `V2`,
-    V3 = `V3`
+    V2 = 'V2',
+    V3 = 'V3'
 }
 
 /**
@@ -34,8 +34,8 @@ export enum ApiVersion {
  * ```
  */
 export interface Link {
-    href: string;
-    templated: boolean;
+    href?: string;
+    templated?: boolean;
 }
 
 /**
@@ -47,7 +47,7 @@ export interface Link {
  * }
  * ```
  */
-export type SecurityContext = Record<string, any>;
+export type SecurityContext = globalThis.Record<string, any>;
 /**
  * - key: example.StringLinkMap
  * - schema: 
@@ -60,7 +60,7 @@ export type SecurityContext = Record<string, any>;
  * }
  * ```
  */
-export type StringLinkMap = Record<string, Link>;
+export type StringLinkMap = globalThis.Record<string, Link>;
 /**
  * - key: example.StringObjectMap
  * - schema: 
@@ -70,7 +70,7 @@ export type StringLinkMap = Record<string, Link>;
  * }
  * ```
  */
-export type StringObjectMap = Record<string, any>;
+export type StringObjectMap = globalThis.Record<string, any>;
 /**
  * - key: example.StringStringListMap
  * - schema: 
@@ -86,7 +86,7 @@ export type StringObjectMap = Record<string, any>;
  * }
  * ```
  */
-export type StringStringListMap = Record<string, string[]>;
+export type StringStringListMap = globalThis.Record<string, string[]>;
 
 /**
  * - key: example.WebServerNamespace
@@ -103,5 +103,5 @@ export type StringStringListMap = Record<string, string[]>;
  * ```
  */
 export interface WebServerNamespace {
-    value: string;
+    value?: string;
 }

--- a/packages/generator/src/model/typeGenerator.ts
+++ b/packages/generator/src/model/typeGenerator.ts
@@ -14,9 +14,9 @@
 import type { ModelInfo } from './modelInfo';
 import { resolveModelInfo, resolveReferenceModelInfo } from './modelInfo';
 import type { InterfaceDeclaration, JSDocableNode, SourceFile } from 'ts-morph';
+import { CodeBlockWriter, VariableDeclarationKind } from 'ts-morph';
 import type { Components, Reference, Schema } from '@ahoo-wang/fetcher-openapi';
 import type {
-  AllOfSchema,
   ArraySchema,
   CompositionSchema,
   EnumSchema,
@@ -28,9 +28,9 @@ import {
   addImportModelInfo,
   addMainSchemaJSDoc,
   addSchemaJSDoc,
+  extractSchema,
   getEnumText,
   getMapKeySchema,
-  isAllOf,
   isArray,
   isComposition,
   isEnum,
@@ -71,14 +71,21 @@ export class TypeGenerator implements Generator {
     if (isEnum(schema)) {
       return this.processEnum(schema);
     }
+    if (schema.const !== undefined) {
+      return this.processTypeAlias(schema);
+    }
+    if (
+      (schema.nullable && schema.type) ||
+      (isComposition(schema) &&
+        (schema.type || schema.properties || schema.required))
+    ) {
+      return this.processTypeAlias(schema);
+    }
     if (isObject(schema)) {
       return this.processInterface(schema);
     }
     if (isArray(schema)) {
       return this.processArray(schema);
-    }
-    if (isAllOf(schema)) {
-      return this.processIntersection(schema);
     }
     if (isComposition(schema)) {
       return this.processComposition(schema);
@@ -124,25 +131,58 @@ export class TypeGenerator implements Generator {
 
   private resolveAdditionalProperties(schema: Schema): string {
     if (
-      schema.additionalProperties === undefined ||
-      schema.additionalProperties === false
+      schema.additionalProperties === false ||
+      (schema.additionalProperties === undefined &&
+        !schema.required?.some(
+          name => !Object.hasOwn(schema.properties ?? {}, name),
+        ))
     ) {
       return '';
     }
 
-    if (schema.additionalProperties === true) {
+    if (
+      schema.additionalProperties === true ||
+      schema.additionalProperties === undefined
+    ) {
       return '[key: string]: any';
     }
 
-    const valueType = this.resolveType(schema.additionalProperties);
-    return `[key: string]: ${valueType}`;
+    return `[key: string]: ${this.resolveAdditionalPropertyType(schema)}`;
+  }
+
+  private resolveAdditionalPropertyType(schema: Schema): string {
+    return this.resolveType(
+      typeof schema.additionalProperties === 'object'
+        ? schema.additionalProperties
+        : {},
+    );
+  }
+
+  private requiresAdditionalPropertiesIntersection(schema: Schema): boolean {
+    return (
+      typeof schema.additionalProperties === 'object' &&
+      Object.keys(schema.properties ?? {}).some(
+        name => !schema.required?.includes(name),
+      )
+    );
+  }
+
+  private resolveRequiredAdditionalPropertyType(schema: Schema): string {
+    if (schema.additionalProperties === false) return 'never';
+    if (typeof schema.additionalProperties === 'object') {
+      return this.resolveType(schema.additionalProperties);
+    }
+    return 'null | string | number | boolean | globalThis.Record<string, unknown> | readonly unknown[]';
   }
 
   private resolvePropertyDefinitions(schema: ObjectSchema): string[] {
     const { properties } = schema;
     return Object.entries(properties).map(([propName, propSchema]) => {
       const type = this.resolveType(propSchema);
-      const resolvedPropName = resolvePropertyName(propName);
+      const resolvedPropName =
+        (isReadOnly(propSchema) ? 'readonly ' : '') +
+        resolvePropertyName(propName) +
+        (schema.required?.includes(propName) ? '' : '?');
       if (!isReference(propSchema)) {
         const jsDocDescriptions = schemaJSDoc(propSchema);
         const doc = jsDoc(jsDocDescriptions, '\n * ');
@@ -166,16 +206,32 @@ export class TypeGenerator implements Generator {
       parts.push(...propertyDefs);
     }
 
-    const additionalProps = this.resolveAdditionalProperties(schema);
+    for (const name of schema.required ?? []) {
+      if (!Object.hasOwn(schema.properties ?? {}, name)) {
+        parts.push(
+          `${resolvePropertyName(name)}: ${this.resolveRequiredAdditionalPropertyType(schema)}`,
+        );
+      }
+    }
+    const mapType =
+      isMap(schema) && getMapKeySchema(schema)
+        ? this.resolveMapType(schema)
+        : this.requiresAdditionalPropertiesIntersection(schema)
+          ? `globalThis.Record<string, ${this.resolveAdditionalPropertyType(schema)}>`
+          : undefined;
+    const additionalProps = mapType
+      ? ''
+      : this.resolveAdditionalProperties(schema);
     if (additionalProps) {
       parts.push(additionalProps);
     }
 
     if (parts.length === 0) {
-      return 'Record<string, any>';
+      return 'globalThis.Record<string, any>';
     }
 
-    return `{\n  ${parts.join(';\n  ')}; \n}`;
+    const objectType = `{\n  ${parts.join(';\n  ')}; \n}`;
+    return mapType ? `(${objectType} & ${mapType})` : objectType;
   }
 
   private resolveMapValueType(schema: MapSchema): string {
@@ -200,41 +256,193 @@ export class TypeGenerator implements Generator {
   private resolveMapType(schema: MapSchema): string {
     const keyType = this.resolveMapKeyType(schema);
     const valueType = this.resolveMapValueType(schema);
-    return `Record<${keyType},${valueType}>`;
+    return `globalThis.Record<${keyType},${valueType}>`;
+  }
+
+  private resolveCompositionConstraints(schema: Schema | Reference): {
+    objectConstrained: boolean;
+  } {
+    const resolve = (member: Schema | Reference): Schema | undefined =>
+      isReference(member)
+        ? this.components && extractSchema(member, this.components)
+        : member;
+    const root = resolve(schema);
+    const nodes = new Map<Schema, (Schema | undefined)[][]>();
+    const constrained = new Set<Schema>();
+    const pending = root ? [root] : [];
+    for (const current of pending) {
+      if (nodes.has(current)) continue;
+      const groups = [current.allOf, current.oneOf, current.anyOf].map(
+        members => members?.map(resolve) ?? [],
+      );
+      nodes.set(current, groups);
+      for (const members of groups) {
+        for (const member of members) {
+          if (member && !nodes.has(member)) pending.push(member);
+        }
+      }
+      if (
+        current.type === 'object' ||
+        current.type === 'null' ||
+        (Array.isArray(current.type) &&
+          current.type.length > 0 &&
+          current.type.every(type => type === 'object' || type === 'null'))
+      )
+        constrained.add(current);
+    }
+
+    // ponytail: O(V * (V + E)); use a dependency worklist for very large graphs.
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const [current, [allOf, oneOf, anyOf]] of nodes) {
+        if (constrained.has(current)) continue;
+        const isConstrained = (member: Schema | undefined) =>
+          member !== undefined && constrained.has(member);
+        if (
+          allOf.some(isConstrained) ||
+          [oneOf, anyOf].some(
+            members => members.length > 0 && members.every(isConstrained),
+          )
+        ) {
+          constrained.add(current);
+          changed = true;
+        }
+      }
+    }
+    return { objectConstrained: root !== undefined && constrained.has(root) };
   }
 
   resolveType(schema: Schema | Reference): string {
     if (isReference(schema)) {
       return this.resolveReference(schema).name;
     }
-    if (isMap(schema)) {
-      return this.resolveMapType(schema);
+    if (Array.isArray(schema.type)) {
+      return schema.type
+        .map(type => {
+          const resolved = this.resolveType({ ...schema, type });
+          return /[|&]/.test(resolved) ? `(${resolved})` : resolved;
+        })
+        .join(' | ');
     }
-    if (schema.const) {
-      return `'${schema.const}'`;
+    if (isComposition(schema)) {
+      const compositions = (['allOf', 'oneOf', 'anyOf'] as const).flatMap(
+        keyword => {
+          const schemas = schema[keyword];
+          if (!schemas?.length) return [];
+          const types = schemas.map(member => {
+            const type = this.resolveType(member);
+            return type === 'any'
+              ? 'unknown'
+              : /[|&]/.test(type)
+                ? `(${type})`
+                : type;
+          });
+          return [`(${types.join(keyword === 'allOf' ? ' & ' : ' | ')})`];
+        },
+      );
+      const composed =
+        compositions.length === 1
+          ? compositions[0]
+          : `(${compositions.join(' & ')})`;
+      const base = {
+        ...schema,
+        oneOf: undefined,
+        anyOf: undefined,
+        allOf: undefined,
+      };
+      const baseType = this.resolveType(base);
+      const type =
+        baseType === 'any' ? composed : `(${composed} & (${baseType}))`;
+      const constraints = this.resolveCompositionConstraints(schema);
+      // Weak object types can otherwise admit non-object branches through intersections.
+      return constraints.objectConstrained
+        ? `globalThis.Exclude<${type}, string | number | boolean | readonly unknown[]> & ({ readonly [globalThis.Symbol.iterator]?: never } | null)`
+        : type;
+    }
+    if (schema.const !== undefined) {
+      if (!this.matchesLiteralType(schema.const, schema)) return 'never';
+      const literal = this.resolveLiteral(schema.const);
+      const baseType = this.resolveType({ ...schema, const: undefined });
+      return baseType === 'any' ? literal : `(${literal}) & (${baseType})`;
+    }
+    if (schema.nullable && schema.type && !isEnum(schema)) {
+      return `(${this.resolveType({ ...schema, nullable: false })}) | null`;
     }
     if (isEnum(schema)) {
-      return schema.enum.map(val => `\`${val}\``).join(' | ');
+      const literal =
+        schema.enum
+          .filter(value => this.matchesLiteralType(value, schema))
+          .map(value => this.resolveLiteral(value))
+          .join(' | ') || 'never';
+      const baseType = this.resolveType({ ...schema, enum: undefined });
+      return baseType === 'any' ? literal : `(${literal}) & (${baseType})`;
+    }
+    if (isMap(schema) && !schema.required?.length) {
+      return this.resolveMapType(schema);
     }
 
-    if (isComposition(schema)) {
-      const schemas = schema.oneOf || schema.anyOf || schema.allOf || [];
-      const types = schemas.map(s => this.resolveType(s));
-      const separator = isAllOf(schema) ? ' & ' : ' | ';
-      return `(${types.join(separator)})`;
-    }
-
-    if (isArray(schema)) {
-      const itemType = this.resolveType(schema.items);
+    if (schema.type === 'array') {
+      const itemType = this.resolveType(schema.items ?? {});
       return toArrayType(itemType);
     }
     if (schema.type === 'object') {
       return this.resolveObjectType(schema);
     }
     if (!schema.type) {
+      if (
+        schema.required?.length ||
+        Object.keys(schema.properties ?? {}).length > 0
+      ) {
+        // Object keywords constrain object instances without rejecting other JSON types.
+        const objectType = this.resolveObjectType({
+          ...schema,
+          type: 'object',
+          additionalProperties: schema.additionalProperties ?? true,
+        });
+        return `(${objectType} | null | string | number | boolean | readonly unknown[])`;
+      }
       return 'any';
     }
     return resolvePrimitiveType(schema.type);
+  }
+
+  private matchesLiteralType(value: unknown, schema: Schema): boolean {
+    if (schema.type === undefined) return true;
+    if (value === null && schema.nullable) return true;
+    return [schema.type].flat().some(type => {
+      if (type === 'null') return value === null;
+      if (type === 'array') return Array.isArray(value);
+      if (type === 'object') {
+        return (
+          value !== null && typeof value === 'object' && !Array.isArray(value)
+        );
+      }
+      if (type === 'integer')
+        return typeof value === 'number' && Number.isInteger(value);
+      return typeof value === type;
+    });
+  }
+
+  private resolveLiteral(value: unknown): string {
+    if (typeof value === 'string') {
+      return new CodeBlockWriter({ useSingleQuote: true })
+        .quote(value)
+        .toString();
+    }
+    if (Array.isArray(value)) {
+      return `[${value.map(item => this.resolveLiteral(item)).join(', ')}]`;
+    }
+    if (value !== null && typeof value === 'object') {
+      const properties = Object.entries(value).map(
+        ([name, item]) =>
+          `${resolvePropertyName(name)}: ${this.resolveLiteral(item)}`,
+      );
+      return properties.length
+        ? `{ ${properties.join('; ')}; readonly [globalThis.Symbol.iterator]?: never }`
+        : 'globalThis.Record<string, never>';
+    }
+    return JSON.stringify(value) ?? 'never';
   }
 
   private processEnum(schema: EnumSchema): JSDocableNode | undefined {
@@ -246,19 +454,53 @@ export class TypeGenerator implements Generator {
         members: Object.entries(enumText).map(([name, text]) => {
           return {
             name: resolveEnumMemberName(name),
-            initializer: `\`${text}\``,
+            initializer: this.resolveLiteral(text),
           };
         }),
       });
+    }
+    const stringValues = schema.enum.filter(
+      (value): value is string => typeof value === 'string',
+    );
+    if (
+      isComposition(schema) ||
+      schema.const !== undefined ||
+      (schema.type !== undefined && schema.type !== 'string') ||
+      stringValues.length !== schema.enum.length
+    ) {
+      if (stringValues.length) {
+        this.sourceFile.addVariableStatement({
+          declarationKind: VariableDeclarationKind.Const,
+          isExported: true,
+          declarations: [
+            {
+              name: this.modelInfo.name,
+              initializer: writer => {
+                writer.inlineBlock(() => {
+                  for (const value of stringValues) {
+                    writer
+                      .write(`${resolveEnumMemberName(value)}: `)
+                      .quote(value)
+                      .write(',')
+                      .newLine();
+                  }
+                });
+                writer.write(' as const');
+              },
+            },
+          ],
+        });
+      }
+      return this.processTypeAlias(schema);
     }
     return this.sourceFile.addEnum({
       name: this.modelInfo.name,
       isExported: true,
       members: schema.enum
-        .filter(value => typeof value === 'string' && value.length > 0)
+        .filter(value => typeof value === 'string')
         .map(value => ({
           name: resolveEnumMemberName(value),
-          initializer: `\`${value}\``,
+          initializer: this.resolveLiteral(value),
         })),
     });
   }
@@ -267,23 +509,29 @@ export class TypeGenerator implements Generator {
     interfaceDeclaration: InterfaceDeclaration,
     propName: string,
     propSchema: Schema | Reference,
+    required: boolean = true,
   ): void {
     const propType = this.resolveType(propSchema);
     const resolvedPropName = resolvePropertyName(propName);
     let propertySignature = interfaceDeclaration.getProperty(resolvedPropName);
     if (propertySignature) {
       propertySignature.setType(propType);
+      if (required) propertySignature.setHasQuestionToken(false);
     } else {
       propertySignature = interfaceDeclaration.addProperty({
         name: resolvedPropName,
         type: propType,
         isReadonly: isReadOnly(propSchema),
+        hasQuestionToken: !required,
       });
     }
     addSchemaJSDoc(propertySignature, propSchema);
   }
 
   private processInterface(schema: ObjectSchema): JSDocableNode | undefined {
+    if (this.requiresAdditionalPropertiesIntersection(schema)) {
+      return this.processTypeAlias(schema);
+    }
     const interfaceDeclaration = this.sourceFile.addInterface({
       name: this.modelInfo.name,
       isExported: true,
@@ -292,18 +540,28 @@ export class TypeGenerator implements Generator {
     const properties = schema.properties || {};
 
     Object.entries(properties).forEach(([propName, propSchema]) => {
-      this.addPropertyToInterface(interfaceDeclaration, propName, propSchema);
+      this.addPropertyToInterface(
+        interfaceDeclaration,
+        propName,
+        propSchema,
+        schema.required?.includes(propName) ?? false,
+      );
     });
 
-    if (schema.additionalProperties) {
+    for (const name of schema.required ?? []) {
+      if (!Object.hasOwn(properties, name)) {
+        interfaceDeclaration.addProperty({
+          name: resolvePropertyName(name),
+          type: this.resolveRequiredAdditionalPropertyType(schema),
+        });
+      }
+    }
+
+    if (this.resolveAdditionalProperties(schema)) {
       const indexSignature = interfaceDeclaration.addIndexSignature({
         keyName: 'key',
         keyType: 'string',
-        returnType: this.resolveType(
-          schema.additionalProperties === true
-            ? {}
-            : (schema.additionalProperties as Schema | Reference),
-        ),
+        returnType: this.resolveAdditionalPropertyType(schema),
       });
       indexSignature.addJsDoc('Additional properties');
     }
@@ -327,33 +585,6 @@ export class TypeGenerator implements Generator {
       type: this.resolveType(schema),
       isExported: true,
     });
-  }
-
-  private processIntersection(schema: AllOfSchema): JSDocableNode | undefined {
-    const interfaceDeclaration = this.sourceFile.addInterface({
-      name: this.modelInfo.name,
-      isExported: true,
-    });
-    schema.allOf.forEach(allOfSchema => {
-      if (isReference(allOfSchema)) {
-        const resolvedType = this.resolveType(allOfSchema);
-        interfaceDeclaration.addExtends(resolvedType);
-        return;
-      }
-      if (isObject(allOfSchema)) {
-        Object.entries(allOfSchema.properties).forEach(
-          ([propName, propSchema]) => {
-            this.addPropertyToInterface(
-              interfaceDeclaration,
-              propName,
-              propSchema,
-            );
-          },
-        );
-      }
-    });
-
-    return interfaceDeclaration;
   }
 
   private processTypeAlias(

--- a/packages/generator/src/utils/naming.ts
+++ b/packages/generator/src/utils/naming.ts
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 
+import { CodeBlockWriter } from 'ts-morph';
+
 const NAMING_SEPARATORS = /[-_'\s./?;:,()[\]{}|\\]+/;
 
 export function splitName(name: string) {
@@ -141,12 +143,12 @@ export function resolvePropertyName(name: string): string {
     return name;
   }
 
-  return `'${name}'`;
+  return new CodeBlockWriter({ useSingleQuote: true }).quote(name).toString();
 }
 
 export function resolveEnumMemberName(name: string): string {
   if (/^\d+$/.test(name)) {
     return `NUM_${name}`;
   }
-  return resolvePropertyName(upperSnakeCase(name));
+  return resolvePropertyName(upperSnakeCase(name) || name);
 }

--- a/packages/generator/test/compositionConstraints.test.ts
+++ b/packages/generator/test/compositionConstraints.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect, it } from 'vitest';
+import { Project } from 'ts-morph';
+import type { Components, Schema } from '@ahoo-wang/fetcher-openapi';
+import { TypeGenerator } from '../src/model';
+
+function model(schema: Schema, components?: Components) {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: {
+      strict: true,
+      skipLibCheck: true,
+      lib: ['lib.es2020.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+    },
+  });
+  const file = project.createSourceFile('/types.ts', '');
+  const generator = new TypeGenerator(
+    { name: 'Model', path: '/' },
+    file,
+    { key: 'Model', schema },
+    '/',
+    components,
+  );
+  return { project, file, generator };
+}
+
+it.each([
+  {
+    schema: {
+      type: ['object', 'null'],
+      oneOf: [
+        {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+        { type: 'null' },
+      ],
+    },
+    assignments: `
+      const valid: Model[] = [{name: 'value'}, null];
+      // @ts-expect-error a nullable object union does not admit booleans
+      const invalid: Model = false;
+      // @ts-expect-error object property constraints remain effective
+      const wrong: Model = {name: 1};
+    `,
+  },
+  {
+    schema: {
+      type: ['array', 'null'],
+      anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'null' }],
+    },
+    assignments: `
+      const valid: Model[] = [['value'], null];
+      // @ts-expect-error a nullable array union does not admit booleans
+      const invalid: Model = false;
+      // @ts-expect-error item constraints remain effective
+      const wrong: Model = [1];
+    `,
+  },
+] satisfies { schema: Schema; assignments: string }[])(
+  'does not let any erase type-array composition constraints: $schema.type',
+  ({ schema, assignments }) => {
+    const { generator, project, file } = model(schema);
+    generator.generate();
+    file.addStatements(assignments);
+    expect(
+      project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+    ).toEqual([]);
+  },
+);
+
+it('excludes primitive branches whenever an allOf member requires objects', () => {
+  const { generator, project, file } = model({
+    allOf: [
+      { type: 'object', properties: { id: { type: 'string' } } },
+      {
+        oneOf: [
+          { type: 'string' },
+          { type: 'object', properties: { name: { type: 'string' } } },
+        ],
+      },
+    ],
+  });
+  generator.generate();
+  file.addStatements(`
+    const valid: Model = {};
+    // @ts-expect-error an explicit object constraint excludes a string branch
+    const invalid: Model = 'text';
+  `);
+  expect(project.getPreEmitDiagnostics().map(d => d.getMessageText())).toEqual(
+    [],
+  );
+});
+
+it('excludes readonly arrays from object intersections', () => {
+  const { generator, project, file } = model({
+    allOf: [
+      { type: 'object', properties: { length: { type: 'number' } } },
+      { required: ['length'] },
+    ],
+  });
+  generator.generate();
+  file.addStatements(`
+    const valid: Model = {length: 0};
+    interface PlainObject { length: number }
+    const plain: PlainObject = {length: 0};
+    const fromInterface: Model = plain;
+    const readonlyTuple = [] as const;
+    // @ts-expect-error an array remains an array even when it is readonly
+    const invalid: Model = readonlyTuple;
+  `);
+  expect(project.getPreEmitDiagnostics().map(d => d.getMessageText())).toEqual(
+    [],
+  );
+});
+
+it.each([false, true])(
+  'visits shared composition DAG nodes a bounded number of times (recursive leaf: %s)',
+  recursiveLeaf => {
+    const depth = 12;
+    let reads = 0;
+    const schemas: NonNullable<Components['schemas']> = {
+      Layer0: recursiveLeaf
+        ? {
+            get allOf() {
+              reads++;
+              return [{ $ref: '#/components/schemas/Layer0' }];
+            },
+          }
+        : { type: 'object' },
+    };
+    for (let level = 1; level <= depth; level++) {
+      const reference = { $ref: `#/components/schemas/Layer${level - 1}` };
+      schemas[`Layer${level}`] = {
+        get allOf() {
+          reads++;
+          return [reference, reference];
+        },
+      };
+    }
+    const schema = schemas[`Layer${depth}`] as Schema;
+    const { generator } = model(schema, { schemas });
+    generator.resolveType(schema);
+    expect(reads).toBeLessThanOrEqual((depth + 1) * 4);
+  },
+);
+
+it('does not reuse a cycle-truncated constraint result on a different path', () => {
+  const schema: Schema = {
+    oneOf: [
+      { $ref: '#/components/schemas/A' },
+      { $ref: '#/components/schemas/B' },
+    ],
+  };
+  const { generator } = model(schema, {
+    schemas: {
+      A: { type: 'object', allOf: [{ $ref: '#/components/schemas/B' }] },
+      B: { allOf: [{ $ref: '#/components/schemas/A' }] },
+    },
+  });
+  expect(generator.resolveType(schema)).toMatch(/^globalThis\.Exclude</);
+});
+
+it.each(['anyOf', 'oneOf'] as const)(
+  'keeps a primitive alternative through mutually recursive %s constraints',
+  keyword => {
+    const schema: Schema = {
+      [keyword]: [
+        { $ref: '#/components/schemas/A' },
+        { $ref: '#/components/schemas/B' },
+      ],
+    };
+    const { generator } = model(schema, {
+      schemas: {
+        A: {
+          [keyword]: [{ $ref: '#/components/schemas/B' }, { type: 'string' }],
+        },
+        B: { allOf: [{ $ref: '#/components/schemas/A' }, { type: 'object' }] },
+      },
+    });
+    expect(generator.resolveType(schema)).not.toContain('globalThis.Exclude<');
+  },
+);
+
+it('keeps legal recursive properties in generated object compositions', () => {
+  const schema: Schema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      next: { $ref: '#/components/schemas/Model' },
+    },
+    allOf: [{ required: ['name'] }],
+  };
+  const { generator, project, file } = model(schema, {
+    schemas: { Model: schema },
+  });
+  generator.generate();
+  file.addStatements(`
+    const valid: Model = {name: 'one', next: {name: 'two'}};
+    // @ts-expect-error recursive object properties retain their constraint
+    const invalid: Model = {name: 'one', next: 1};
+  `);
+  expect(project.getPreEmitDiagnostics().map(d => d.getMessageText())).toEqual(
+    [],
+  );
+});

--- a/packages/generator/test/enumConstConstraints.test.ts
+++ b/packages/generator/test/enumConstConstraints.test.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import { runInNewContext } from 'node:vm';
+import { expect, it } from 'vitest';
+import { Project } from 'ts-morph';
+import type { Schema } from '@ahoo-wang/fetcher-openapi';
+import { TypeGenerator } from '../src/model/typeGenerator';
+
+function generate(schemas: Record<string, Schema>, consumer: string) {
+  const dir = mkdtempSync(join(tmpdir(), 'fetcher-enum-const-'));
+  try {
+    const project = new Project({ skipAddingFilesFromTsConfig: true });
+    const file = project.createSourceFile(join(dir, 'types.ts'), '');
+    for (const [name, schema] of Object.entries(schemas)) {
+      new TypeGenerator(
+        { name, path: '/' },
+        file,
+        { key: name, schema },
+        dir,
+      ).generate();
+    }
+    file.addStatements(consumer);
+    project.saveSync();
+    writeFileSync(
+      join(dir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          skipLibCheck: true,
+          module: 'CommonJS',
+          target: 'ES2020',
+          types: [],
+          outDir: 'dist',
+        },
+        include: ['types.ts'],
+      }),
+    );
+    const require = createRequire(import.meta.url);
+    const result = spawnSync(
+      process.execPath,
+      [
+        require.resolve('typescript/lib/tsc.js'),
+        '-p',
+        join(dir, 'tsconfig.json'),
+      ],
+      { encoding: 'utf8' },
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    const exports: Record<string, unknown> = {};
+    runInNewContext(readFileSync(join(dir, 'dist/types.js'), 'utf8'), {
+      exports,
+    });
+    return exports;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+it('keeps numeric and mixed EnumText exports and mixed runtime string members', () => {
+  const escaped = 'literal ` ${notInterpolation}';
+  const result = generate(
+    {
+      Numeric: {
+        type: 'integer',
+        enum: [0, 1],
+        'x-enum-text': { '0': escaped, '1': 'Enabled' },
+      },
+      EscapedString: { type: 'string', enum: [escaped] },
+      Mixed: {
+        enum: ['ON', 0, false],
+        'x-enum-text': { ON: escaped, '0': 'Disabled' },
+      },
+    },
+    `
+  const numeric: Numeric = 0;
+  const mixed: Mixed[] = [Mixed.ON,0,false];
+  export const labels = [NumericEnumText.NUM_0,MixedEnumText.ON];
+  export const member = Mixed.ON;
+  export const escapedValues = Object.values(EscapedString);
+  // @ts-expect-error Unknown numeric enum member.
+  const wrongNumeric: Numeric = 2;
+  // @ts-expect-error Unknown mixed enum string.
+  const wrongMixed: Mixed = 'OFF';
+  void numeric; void mixed; void wrongNumeric; void wrongMixed;
+ `,
+  );
+  expect(result.labels).toEqual([escaped, escaped]);
+  expect(result.escapedValues).toEqual([escaped]);
+  expect(result.member).toBe('ON');
+});
+
+it('keeps empty object enum and const values narrow, including nested literals', () => {
+  generate(
+    {
+      EmptyEnum: { enum: [{}, 'ON'] },
+      EmptyConst: { const: {} },
+      NestedConst: { const: { child: {}, values: [{}, 'ON'] } },
+      Record: { type: 'string' },
+    },
+    `
+  const enumValues: EmptyEnum[] = [{},EmptyEnum.ON];
+  const empty: EmptyConst = {};
+  const nested: NestedConst = {child:{},values:[{},'ON']};
+  // @ts-expect-error Empty object enum cannot accept a number.
+  const enumNumber: EmptyEnum = 42;
+  // @ts-expect-error Empty object enum cannot accept a boolean.
+  const enumBoolean: EmptyEnum = false;
+  // @ts-expect-error Empty object enum cannot accept an array.
+  const enumArray: EmptyEnum = [];
+  // @ts-expect-error Empty object constant cannot accept a number.
+  const constNumber: EmptyConst = 42;
+  // @ts-expect-error Empty object constant cannot accept arbitrary fields.
+  const constFields: EmptyConst = {x:1};
+  // @ts-expect-error Nested empty constants cannot become broad object types.
+  const nestedWrong: NestedConst = {child:42,values:[{},'ON']};
+  void enumValues; void empty; void nested;
+ `,
+  );
+});
+
+it('rejects arrays matching nonempty object literals without rejecting plain objects', () => {
+  generate(
+    {
+      LengthConst: { const: { length: 0 } },
+      TupleEnum: { enum: [{ 0: 'ON', length: 1 }] },
+      NestedConst: { const: { child: { length: 0 } } },
+      ArrayLiteral: { const: ['ON'] },
+    },
+    `
+  interface EmptyLength { length: 0 }
+  const shape: EmptyLength = {length: 0};
+  const plain: LengthConst = shape;
+  const tupleShape: TupleEnum = {0: 'ON', length: 1};
+  const nested: NestedConst = {child: {length: 0}};
+  const array: ArrayLiteral = ['ON'];
+  const mutableTuple: [] = [];
+  // @ts-expect-error Array length does not make an array an object constant.
+  const mutable: LengthConst = mutableTuple;
+  // @ts-expect-error Readonly arrays must not satisfy object constants either.
+  const readonlyArray: LengthConst = [] as const;
+  // @ts-expect-error Numeric object keys must not admit matching tuples.
+  const enumArray: TupleEnum = ['ON'] as const;
+  // @ts-expect-error Nested object literals preserve the same boundary.
+  const nestedArray: NestedConst = {child: [] as const};
+  void plain; void tupleShape; void nested; void array;
+ `,
+  );
+});
+
+it('applies declared types alongside enum and const constraints', () => {
+  generate(
+    {
+      TextEnum: { type: 'string', enum: ['ON', 0] },
+      ImpossibleEnum: { type: 'number', enum: ['ON'] },
+      NumberConst: { type: 'string', const: 1 },
+      BooleanConst: { type: 'number', const: true },
+      ObjectConst: { type: 'string', const: {} },
+      ArrayConst: { type: 'string', const: [] },
+      ObjectWithConst: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+        const: 1,
+      },
+      ValidConst: { type: 'number', const: 1 },
+      ArrayAsObject: { type: 'object', const: [] },
+      FractionConst: { type: 'integer', const: 1.5 },
+      IntegerEnum: { type: 'integer', enum: [1, 1.5] },
+      ObjectEnum: { type: 'object', enum: [[], {}] },
+      NullableEnum: { type: 'string', nullable: true, enum: ['ON', null] },
+    },
+    `
+  const text: TextEnum = TextEnum.ON;
+  const valid: ValidConst = 1;
+  const integer: IntegerEnum = 1;
+  const object: ObjectEnum = {};
+  const nullable: NullableEnum[] = ['ON', null];
+  // @ts-expect-error JSON objects exclude arrays even though arrays are TS objects.
+  const arrayAsObject: ArrayAsObject = [];
+  // @ts-expect-error Fractions do not satisfy an integer type.
+  const fractionConst: FractionConst = 1.5;
+  // @ts-expect-error Integer enums retain only integral values.
+  const fractionEnum: IntegerEnum = 1.5;
+  // @ts-expect-error Object enums do not admit array values.
+  const arrayEnum: ObjectEnum = [];
+  void integer; void object; void nullable;
+  // @ts-expect-error The number enum member fails the string type.
+  const numeric: TextEnum = 0;
+  // @ts-expect-error The only enum value fails the number type.
+  const impossible: ImpossibleEnum = ImpossibleEnum.ON;
+  // @ts-expect-error Number constant fails declared string type.
+  const numberConst: NumberConst = 1;
+  // @ts-expect-error Boolean constant fails declared number type.
+  const boolConst: BooleanConst = true;
+  // @ts-expect-error Object constant fails declared string type.
+  const objectConst: ObjectConst = {};
+  // @ts-expect-error Array constant fails declared string type.
+  const arrayConst: ArrayConst = [];
+  // @ts-expect-error Object generation must not bypass its constant.
+  const objectWithConst: ObjectWithConst = {id:'x'};
+  void text; void valid;
+ `,
+  );
+});

--- a/packages/generator/test/model/typeGenerator.test.ts
+++ b/packages/generator/test/model/typeGenerator.test.ts
@@ -90,7 +90,7 @@ describe('TypeGenerator', () => {
         type: 'string',
         enum: ['a', 'b', 'c'],
       });
-      expect(result).toBe('`a` | `b` | `c`');
+      expect(result).toBe("('a' | 'b' | 'c') & (string)");
     });
 
     it('should resolve array type', () => {
@@ -118,7 +118,7 @@ describe('TypeGenerator', () => {
         type: 'object',
         properties: { name: { type: 'string' }, age: { type: 'number' } },
       });
-      expect(result).toBe('{\n  name: string;\n  age: number; \n}');
+      expect(result).toBe('{\n  name?: string;\n  age?: number; \n}');
     });
 
     it('should resolve object type with additional properties', () => {
@@ -132,7 +132,7 @@ describe('TypeGenerator', () => {
         type: 'object',
         additionalProperties: { type: 'string' },
       });
-      expect(result).toBe('Record<string,string>');
+      expect(result).toBe('globalThis.Record<string,string>');
     });
 
     it('should resolve composition oneOf type', () => {
@@ -185,7 +185,7 @@ describe('TypeGenerator', () => {
         type: 'object',
         properties: { name: { type: 'string' } },
       });
-      expect(result).toBe('{\n  name: string; \n}');
+      expect(result).toBe('{\n  name?: string; \n}');
     });
 
     it('should resolve object with additional properties only', () => {
@@ -199,7 +199,7 @@ describe('TypeGenerator', () => {
         type: 'object',
         additionalProperties: { type: 'string' },
       });
-      expect(result).toBe('Record<string,string>');
+      expect(result).toBe('globalThis.Record<string,string>');
     });
 
     it('should resolve object with both properties and additional properties', () => {
@@ -214,10 +214,12 @@ describe('TypeGenerator', () => {
         properties: { name: { type: 'string' } },
         additionalProperties: { type: 'number' },
       });
-      expect(result).toBe('{\n  name: string;\n  [key: string]: number; \n}');
+      expect(result).toBe(
+        '({\n  name?: string; \n} & globalThis.Record<string, number>)',
+      );
     });
 
-    it('should return Record<string, any> for empty object', () => {
+    it('should return globalThis.Record<string, any> for empty object', () => {
       const generator = new TypeGenerator(
         modelInfo,
         {} as any,
@@ -225,7 +227,7 @@ describe('TypeGenerator', () => {
         outputDir,
       );
       const result = generator.resolveType({ type: 'object' });
-      expect(result).toBe('Record<string, any>');
+      expect(result).toBe('globalThis.Record<string, any>');
     });
   });
 
@@ -296,7 +298,7 @@ describe('TypeGenerator', () => {
           age: { type: 'number' },
         },
       });
-      expect(result).toEqual(['name: string', 'age: number']);
+      expect(result).toEqual(['name?: string', 'age?: number']);
     });
   });
 
@@ -320,8 +322,8 @@ describe('TypeGenerator', () => {
         name: 'TestModel',
         isExported: true,
         members: [
-          { name: 'VALUE1', initializer: '`value1`' },
-          { name: 'VALUE2', initializer: '`value2`' },
+          { name: 'VALUE1', initializer: "'value1'" },
+          { name: 'VALUE2', initializer: "'value2'" },
         ],
       });
       expect(result).toBeDefined();
@@ -403,11 +405,7 @@ describe('TypeGenerator', () => {
 
     it('should process allOf schema', () => {
       const mockSourceFile = {
-        addInterface: vi.fn().mockReturnValue({
-          addProperty: vi.fn(),
-          getProperty: vi.fn().mockReturnValue(null),
-          addExtends: vi.fn(),
-        }),
+        addTypeAlias: vi.fn().mockReturnValue({ addJsDoc: vi.fn() }),
         getDirectoryPath: vi.fn().mockReturnValue('/output'),
         getImportDeclaration: vi.fn().mockReturnValue(null),
         addImportDeclaration: vi.fn().mockReturnValue({
@@ -432,8 +430,9 @@ describe('TypeGenerator', () => {
       );
 
       const result = (generator as any).process();
-      expect(mockSourceFile.addInterface).toHaveBeenCalledWith({
+      expect(mockSourceFile.addTypeAlias).toHaveBeenCalledWith({
         name: 'TestModel',
+        type: 'globalThis.Exclude<(BaseModel & {\n  extra?: boolean; \n}), string | number | boolean | readonly unknown[]> & ({ readonly [globalThis.Symbol.iterator]?: never } | null)',
         isExported: true,
       });
       expect(result).toBeDefined();
@@ -459,7 +458,7 @@ describe('TypeGenerator', () => {
       const result = (generator as any).process();
       expect(mockSourceFile.addTypeAlias).toHaveBeenCalledWith({
         name: 'TestModel',
-        type: 'Record<string,string>',
+        type: 'globalThis.Record<string,string>',
         isExported: true,
       });
       expect(result).toBeDefined();
@@ -547,6 +546,7 @@ describe('TypeGenerator', () => {
     it('should update existing property type when property already exists', () => {
       const mockPropertySignature = {
         setType: vi.fn(),
+        setHasQuestionToken: vi.fn(),
       };
       const mockInterfaceDeclaration = {
         getProperty: vi.fn().mockReturnValue(mockPropertySignature),
@@ -617,7 +617,7 @@ describe('TypeGenerator', () => {
       expect(result).toBe(mockInterfaceDeclaration);
     });
 
-    it('should add index signature when additionalProperties is a schema', () => {
+    it('should add a strict index signature when declared properties are required', () => {
       const mockIndexSignature = {
         addJsDoc: vi.fn(),
       };
@@ -636,7 +636,8 @@ describe('TypeGenerator', () => {
           key: 'TestModel',
           schema: {
             type: 'object',
-            properties: { id: { type: 'string' } },
+            properties: { id: { type: 'number' } },
+            required: ['id'],
             additionalProperties: { type: 'number' },
           },
         },
@@ -645,7 +646,8 @@ describe('TypeGenerator', () => {
 
       const result = (generator as any).processInterface({
         type: 'object',
-        properties: { id: { type: 'string' } },
+        properties: { id: { type: 'number' } },
+        required: ['id'],
         additionalProperties: { type: 'number' },
       });
 

--- a/packages/generator/test/objectConstraintReview.test.ts
+++ b/packages/generator/test/objectConstraintReview.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Project } from 'ts-morph';
+import type { Schema } from '@ahoo-wang/fetcher-openapi';
+import { TypeGenerator } from '../src/model';
+
+function generate(schemas: Record<string, Schema>, assignments: string) {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: {
+      strict: true,
+      skipLibCheck: true,
+      lib: ['lib.es2020.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+    },
+  });
+  const file = project.createSourceFile('/models.ts', '');
+  for (const [name, schema] of Object.entries(schemas)) {
+    new TypeGenerator({ name, path: '/' }, file, { key: name, schema }, '/', {
+      schemas,
+    }).generate();
+  }
+  file.addStatements(assignments);
+  return project
+    .getPreEmitDiagnostics()
+    .map(diagnostic => diagnostic.getMessageText());
+}
+
+describe('reviewed object schema constraints', () => {
+  it('keeps typeless required objects open by default', () => {
+    expect(
+      generate(
+        {
+          Model: {
+            properties: { id: { type: 'string' } },
+            required: ['id'],
+          },
+        },
+        `
+      const valid: Model = { id: '1', extra: 2 };
+      const nonObjects: Model[] = [null, 'text', 1, true, []];
+      const tuple = [1, 'text'] as const;
+      const readonlyArray: Model = tuple;
+      void readonlyArray;
+      // @ts-expect-error object instances must supply id
+      const missing: Model = { extra: 2 };
+      // @ts-expect-error present id must match its schema
+      const wrong: Model = { id: 1 };
+    `,
+      ),
+    ).toEqual([]);
+  });
+
+  it('retains nonempty typeless root properties beside composition', () => {
+    expect(
+      generate(
+        {
+          Model: {
+            oneOf: [{ type: 'object', properties: {} }],
+            properties: { id: { type: 'string' } },
+          },
+        },
+        `
+      const valid: Model[] = [{}, { id: '1', extra: 2 }];
+      // @ts-expect-error root property constraints still apply
+      const wrong: Model = { id: 1 };
+    `,
+      ),
+    ).toEqual([]);
+  });
+
+  it('uses the global Record type when a component shadows its name', () => {
+    expect(
+      generate(
+        {
+          Record: { type: 'object', properties: { label: { type: 'string' } } },
+          Model: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            additionalProperties: { type: 'string' },
+          },
+          Empty: { type: 'object' },
+          Dictionary: {
+            type: 'object',
+            additionalProperties: { type: 'number' },
+          },
+        },
+        `
+      const valid: Model[] = [{}, { name: 'yes', extra: 'allowed' }];
+      const empty: Empty = {};
+      const dictionary: Dictionary = { count: 1 };
+      // @ts-expect-error additional properties retain their schema type
+      const wrong: Model = { extra: 2 };
+    `,
+      ),
+    ).toEqual([]);
+  });
+
+  it.each([undefined, true])(
+    'does not let prototype methods satisfy required JSON keys (additionalProperties: %s)',
+    additionalProperties => {
+      expect(
+        generate(
+          {
+            Model: {
+              type: 'object',
+              required: ['toString', 'constructor'],
+              additionalProperties,
+            },
+          },
+          `
+      const valid: Model[] = [
+        { toString: 'text', constructor: null },
+        { toString: {}, constructor: [] },
+        { toString: 1, constructor: false },
+      ];
+      // @ts-expect-error inherited functions cannot satisfy required JSON values
+      const missing: Model = {};
+      // @ts-expect-error inherited constructor is not a JSON value
+      const partial: Model = { toString: 'text' };
+      // @ts-expect-error a supplied function is not a JSON value either
+      const callable: Model = { toString: () => 'text', constructor: null };
+    `,
+        ),
+      ).toEqual([]);
+    },
+  );
+});

--- a/packages/generator/test/schemaConstraints.test.ts
+++ b/packages/generator/test/schemaConstraints.test.ts
@@ -1,0 +1,1018 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Project, ModuleKind } from 'ts-morph';
+import { runInNewContext } from 'node:vm';
+import type { Schema } from '@ahoo-wang/fetcher-openapi';
+import { TypeGenerator } from '../src/model';
+
+function generateModel(schema: Schema, assignments: string) {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: {
+      strict: true,
+      skipLibCheck: true,
+      lib: ['lib.es2020.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+    },
+  });
+  const file = project.createSourceFile('/types.ts', '');
+  new TypeGenerator(
+    { name: 'Model', path: '/' },
+    file,
+    { key: 'Model', schema },
+    '/',
+  ).generate();
+  file.addStatements(assignments);
+  return {
+    file,
+    diagnostics: project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+  };
+}
+
+describe('review regressions', () => {
+  it.each([false, true])(
+    'retains readonly properties in nullable object aliases (documented: %s)',
+    documented => {
+      expect(
+        generateModel(
+          {
+            type: 'object',
+            nullable: true,
+            required: ['id'],
+            properties: {
+              id: {
+                type: 'string',
+                readOnly: true,
+                ...(documented ? { description: 'Stable identifier' } : {}),
+              },
+              name: { type: 'string' },
+            },
+          },
+          `
+      let value: Model = { id: '1' };
+      value.name = 'updated';
+      // @ts-expect-error id is readonly even when the object can be null
+      value.id = '2';
+      value = null;
+    `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it.each([
+    [{ type: 'integer', enum: [0, 1] }, 'const value: Model = 0;'],
+    [
+      { enum: [0, 'one', false, null, ''] },
+      "const values: Model[] = [0, 'one', false, null, ''];",
+    ],
+    [
+      {
+        type: 'object',
+        required: ['status'],
+        properties: { status: { type: 'integer', enum: [0, 1] } },
+      },
+      'const value: Model = { status: 0 };',
+    ],
+  ] satisfies [Schema, string][])(
+    'preserves numeric and mixed enum values %#',
+    (schema, assignment) => {
+      const { diagnostics, file } = generateModel(schema, assignment);
+      expect(file.getText()).not.toMatch(/enum Model\s*\{\s*\}/);
+      expect(diagnostics).toEqual([]);
+    },
+  );
+
+  it('keeps string enum members available when an empty value is present', () => {
+    const { diagnostics, file } = generateModel(
+      { type: 'string', enum: ['', 'ON'] },
+      "const values: Model[] = [Model[''], Model.ON];",
+    );
+    expect(file.getEnum('Model')).toBeDefined();
+    expect(diagnostics).toEqual([]);
+  });
+
+  it.each(['allOf', 'oneOf', 'anyOf'] as const)(
+    'keeps string enum values and constraints with %s',
+    composition => {
+      const { diagnostics, file } = generateModel(
+        {
+          type: 'string',
+          enum: ['', 'ON', 'OFF'],
+          'x-enum-text': { ON: 'Enabled' },
+          [composition]: [{ type: 'string', enum: ['', 'ON'] }],
+        },
+        `
+          const valid: Model[] = [Model[''], Model.ON];
+          // @ts-expect-error OFF is excluded by the composition
+          const excluded: Model = Model.OFF;
+          // @ts-expect-error values outside the enum stay invalid
+          const unknown: Model = 'UNKNOWN';
+        `,
+      );
+      expect(diagnostics).toEqual([]);
+      file.getProject().compilerOptions.set({ module: ModuleKind.CommonJS });
+      const exports = {};
+      runInNewContext(file.getEmitOutput().getOutputFiles()[0].getText(), {
+        exports,
+      });
+      expect(exports).toMatchObject({
+        Model: { '': '', ON: 'ON', OFF: 'OFF' },
+        ModelEnumText: { ON: 'Enabled' },
+      });
+    },
+  );
+
+  it('keeps Model.ON available for a string enum with a string allOf member', () => {
+    const { diagnostics, file } = generateModel(
+      { type: 'string', enum: ['ON'], allOf: [{ type: 'string' }] },
+      'export const value: Model = Model.ON;',
+    );
+    expect(diagnostics).toEqual([]);
+    file.getProject().compilerOptions.set({ module: ModuleKind.CommonJS });
+    const exports = {};
+    runInNewContext(file.getEmitOutput().getOutputFiles()[0].getText(), {
+      exports,
+    });
+    expect(exports).toMatchObject({ Model: { ON: 'ON' }, value: 'ON' });
+  });
+
+  it('preserves optional properties in models and nested objects', () => {
+    const { diagnostics, file } = generateModel(
+      {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: { type: 'string' },
+          optional: { type: 'string' },
+          nested: {
+            type: 'object',
+            properties: { optional: { type: 'string' } },
+          },
+        },
+      },
+      "const value: Model = { id: '1', nested: {} };\n// @ts-expect-error id remains required\nconst invalid: Model = {};",
+    );
+    expect(diagnostics).toEqual([]);
+    expect(
+      file
+        .getInterfaceOrThrow('Model')
+        .getPropertyOrThrow('optional')
+        .hasQuestionToken(),
+    ).toBe(true);
+  });
+
+  it('allows optional properties alongside additional properties', () => {
+    const schema: Schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      additionalProperties: { type: 'string' },
+    };
+    expect(
+      generateModel(schema, 'const value: Model = {};').diagnostics,
+    ).toEqual([]);
+    expect(
+      generateModel(
+        { type: 'object', properties: { nested: schema } },
+        'const value: Model = { nested: {} };',
+      ).diagnostics,
+    ).toEqual([]);
+  });
+
+  it.each(['named', 'nested', 'allOf'] as const)(
+    'rejects undefined additional properties beside optional properties (%s)',
+    placement => {
+      const objectSchema: Schema = {
+        type: 'object',
+        properties: { name: { type: 'string', readOnly: true } },
+        additionalProperties: { type: 'string' },
+      };
+      const schema: Schema =
+        placement === 'nested'
+          ? {
+              type: 'object',
+              required: ['nested'],
+              properties: { nested: objectSchema },
+            }
+          : placement === 'allOf'
+            ? { allOf: [objectSchema] }
+            : objectSchema;
+      const value = (object: string) =>
+        placement === 'nested' ? `{ nested: ${object} }` : object;
+      expect(
+        generateModel(
+          schema,
+          `
+            const empty: Model = ${value('{}')};
+            const valid: Model = ${value("{ name: 'name', extra: 'value' }")};
+            // @ts-expect-error additional properties only accept string values
+            const undefinedExtra: Model = ${value('{ extra: undefined }')};
+            // @ts-expect-error additional properties still reject numbers
+            const numberExtra: Model = ${value('{ extra: 1 }')};
+            // @ts-expect-error declared properties keep their readonly modifier
+            valid${placement === 'nested' ? '.nested' : ''}.name = 'updated';
+          `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it('preserves OpenAPI 3.0 nullable on properties and named schemas', () => {
+    expect(
+      generateModel(
+        { type: 'string', nullable: true },
+        'const value: Model = null;',
+      ).diagnostics,
+    ).toEqual([]);
+    expect(
+      generateModel(
+        {
+          type: 'object',
+          required: ['value'],
+          properties: { value: { type: 'string', nullable: true } },
+        },
+        'const value: Model = { value: null };',
+      ).diagnostics,
+    ).toEqual([]);
+  });
+});
+
+describe('allOf required and nullable interactions', () => {
+  it.each([false, true])(
+    'retains nested allOf object constraints (referenced: %s)',
+    referenced => {
+      const project = new Project({
+        useInMemoryFileSystem: true,
+        compilerOptions: {
+          strict: true,
+          skipLibCheck: true,
+          lib: ['lib.es2020.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+        },
+      });
+      const file = project.createSourceFile('/types.ts', '');
+      const base: Schema = {
+        allOf: [{ type: 'object', properties: { id: { type: 'string' } } }],
+      };
+      const schemas: Record<string, Schema> = {
+        Base: base,
+        Model: {
+          allOf: [
+            referenced ? { $ref: '#/components/schemas/Base' } : base,
+            { required: ['id'] },
+          ],
+        },
+      };
+      for (const [name, schema] of Object.entries(schemas)) {
+        new TypeGenerator(
+          { name, path: '/' },
+          file,
+          { key: name, schema },
+          '/',
+          { schemas },
+        ).generate();
+      }
+      file.addStatements(`
+        const valid: Model = { id: '1' };
+        // @ts-expect-error nested object constraints still exclude strings
+        const text: Model = 'x';
+        // @ts-expect-error nested object constraints still exclude numbers
+        const number: Model = 1;
+        // @ts-expect-error nested object constraints still exclude booleans
+        const boolean: Model = true;
+        // @ts-expect-error nested object constraints still exclude arrays
+        const array: Model = [];
+        // @ts-expect-error required id must remain present
+        const missing: Model = {};
+      `);
+      expect(
+        project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+      ).toEqual([]);
+    },
+  );
+
+  it('retains object constraints when the required-only sibling is nested', () => {
+    expect(
+      generateModel(
+        {
+          allOf: [
+            { type: 'object', properties: { id: { type: 'string' } } },
+            { allOf: [{ required: ['id'] }] },
+          ],
+        },
+        `
+      const valid: Model = { id: '1' };
+      // @ts-expect-error the nested required-only union cannot admit strings
+      const text: Model = 'x';
+      // @ts-expect-error the nested required-only union cannot admit arrays
+      const array: Model = [];
+      // @ts-expect-error id must remain present
+      const missing: Model = {};
+    `,
+      ).diagnostics,
+    ).toEqual([]);
+  });
+
+  it.each(['oneOf', 'anyOf'] as const)(
+    'retains object constraints when %s allows only objects or null',
+    composition => {
+      expect(
+        generateModel(
+          {
+            allOf: [
+              {
+                [composition]: [
+                  { type: 'object', properties: { id: { type: 'string' } } },
+                  { type: 'object', properties: { id: { type: 'number' } } },
+                  { type: 'null' },
+                ],
+              },
+              { required: ['id'] },
+            ],
+          },
+          `
+        const valid: Model[] = [{ id: '1' }, { id: 1 }, null];
+        // @ts-expect-error no branch permits a string value
+        const text: Model = 'x';
+        // @ts-expect-error no branch permits an array value
+        const array: Model = [];
+        // @ts-expect-error an object still needs id
+        const missing: Model = {};
+      `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it.each(['oneOf', 'anyOf'] as const)(
+    'retains non-object alternatives allowed by nested %s',
+    composition => {
+      expect(
+        generateModel(
+          {
+            allOf: [
+              {
+                allOf: [
+                  {
+                    [composition]: [
+                      {
+                        type: 'object',
+                        properties: { id: { type: 'string' } },
+                      },
+                      { type: 'string' },
+                      { type: 'number' },
+                      { type: 'boolean' },
+                      { type: 'array', items: { type: 'string' } },
+                      { type: 'null' },
+                    ],
+                  },
+                ],
+              },
+              { required: ['id'] },
+            ],
+          },
+          `
+        const valid: Model[] = ['x', 1, true, [], null, { id: '1' }];
+        // @ts-expect-error an object still needs id
+        const missing: Model = {};
+      `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it('terminates constraint discovery through recursive allOf references', () => {
+    const project = new Project({ useInMemoryFileSystem: true });
+    const file = project.createSourceFile('/types.ts', '');
+    const schema: Schema = {
+      allOf: [{ $ref: '#/components/schemas/Recursive' }, { required: ['id'] }],
+    };
+    const generator = new TypeGenerator(
+      { name: 'Model', path: '/' },
+      file,
+      { key: 'Model', schema },
+      '/',
+      {
+        schemas: {
+          Recursive: { allOf: [{ $ref: '#/components/schemas/Recursive' }] },
+        },
+      },
+    );
+    expect(() => generator.generate()).not.toThrow();
+    expect(file.getTypeAlias('Model')).toBeDefined();
+  });
+
+  it.each([false, true])(
+    'keeps required-only allOf intersections object-constrained (nullable: %s)',
+    nullable => {
+      expect(
+        generateModel(
+          {
+            allOf: [
+              {
+                type: 'object',
+                nullable,
+                properties: { id: { type: 'string' } },
+              },
+              { required: ['id'] },
+            ],
+          },
+          `
+      const valid: Model = { id: '1' };
+      ${nullable ? '' : '// @ts-expect-error the object schema rejects null'}
+      const nullValue: Model = null;
+      // @ts-expect-error allOf still rejects primitives
+      const text: Model = 'x';
+      // @ts-expect-error allOf still rejects primitives
+      const number: Model = 1;
+      // @ts-expect-error allOf still rejects primitives
+      const boolean: Model = true;
+      // @ts-expect-error JSON arrays are not objects
+      const array: Model = [];
+      // @ts-expect-error id must still be present
+      const missing: Model = {};
+    `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it('allows non-object JSON values for standalone required-only schemas', () => {
+    expect(
+      generateModel(
+        { required: ['id'] },
+        `
+      const valid: Model[] = ['x', 1, true, null, [], { id: '1' }];
+      // @ts-expect-error required applies when the value is an object
+      const missing: Model = {};
+    `,
+      ).diagnostics,
+    ).toEqual([]);
+  });
+
+  it.each(['oneOf', 'anyOf', 'allOf'] as const)(
+    'preserves %s constraints with typeless root properties',
+    composition => {
+      expect(
+        generateModel(
+          {
+            [composition]:
+              composition === 'allOf'
+                ? [{ type: 'string' }]
+                : [{ type: 'string' }, { type: 'number' }],
+            properties: {},
+          },
+          `
+      const valid: Model = 'one';
+      // @ts-expect-error empty properties do not erase composition restrictions
+      const invalid: Model = true;
+    `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it.each(['fixed', '', 0, false])(
+    'does not widen const %j with nullable',
+    value => {
+      const type =
+        typeof value === 'boolean'
+          ? 'boolean'
+          : typeof value === 'number'
+            ? 'number'
+            : 'string';
+      expect(
+        generateModel(
+          { type, const: value, nullable: true },
+          `
+      const valid: Model = ${JSON.stringify(value)};
+      // @ts-expect-error const excludes null even when nullable expands the type
+      const invalid: Model = null;
+    `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it.each([false, true])(
+    'combines required fields across siblings (required-only: %s)',
+    requiredOnly => {
+      const schema: Schema = {
+        allOf: [
+          { type: 'object', properties: { id: { type: 'string' } } },
+          requiredOnly
+            ? { required: ['id'] }
+            : {
+                type: 'object',
+                required: ['id'],
+                properties: { id: { type: 'string' } },
+              },
+        ],
+      };
+      const { diagnostics } = generateModel(
+        schema,
+        "const valid: Model = { id: '1' };\n// @ts-expect-error allOf requires id\nconst invalid: Model = {};\n// @ts-expect-error the original string constraint remains\nconst wrong: Model = { id: 1 };\n// @ts-expect-error required string must not become undefined\nconst undefinedId: Model = { id: undefined };",
+      );
+      expect(diagnostics).toEqual([]);
+    },
+  );
+
+  it('intersects a nullable reference instead of extending its union', () => {
+    const project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        strict: true,
+        skipLibCheck: true,
+        lib: ['lib.es2020.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+      },
+    });
+    const file = project.createSourceFile('/types.ts', '');
+    const schemas: Record<string, Schema> = {
+      Base: {
+        type: 'object',
+        nullable: true,
+        properties: { id: { type: 'string' } },
+      },
+      Derived: {
+        allOf: [
+          { $ref: '#/components/schemas/Base' },
+          { type: 'object', properties: { name: { type: 'string' } } },
+        ],
+      },
+      Required: {
+        allOf: [{ $ref: '#/components/schemas/Base' }, { required: ['id'] }],
+      },
+    };
+    for (const [name, schema] of Object.entries(schemas)) {
+      new TypeGenerator({ name, path: '/' }, file, { key: name, schema }, '/', {
+        schemas,
+      }).generate();
+    }
+    file.addStatements(
+      "const valid: Derived = { id: '1', name: 'test' };\n// @ts-expect-error the non-null object sibling excludes null\nconst invalid: Derived = null;\nconst nullable: Required = null;\nconst required: Required = { id: '1' };\n// @ts-expect-error required-only sibling rejects an object missing id\nconst missing: Required = {};",
+    );
+    file.addStatements(`
+      // @ts-expect-error the referenced object still excludes primitives
+      const primitive: Required = 'x';
+      // @ts-expect-error the referenced object still excludes arrays
+      const array: Required = [];
+    `);
+    expect(
+      project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+    ).toEqual([]);
+  });
+
+  it('intersects nullable type with non-null allOf constraints', () => {
+    expect(
+      generateModel(
+        {
+          type: 'object',
+          nullable: true,
+          allOf: [{ type: 'object', properties: { id: { type: 'string' } } }],
+        },
+        'const valid: Model = {};\n// @ts-expect-error the allOf object constraint excludes null\nconst invalid: Model = null;',
+      ).diagnostics,
+    ).toEqual([]);
+  });
+
+  it('retains runtime members of a nullable string enum that excludes null', () => {
+    expect(
+      generateModel(
+        { type: 'string', enum: ['ON'], nullable: true },
+        'const valid: Model = Model.ON;\n// @ts-expect-error enum excludes null\nconst invalid: Model = null;',
+      ).diagnostics,
+    ).toEqual([]);
+  });
+
+  it('does not make null valid when enum excludes it', () => {
+    expect(
+      generateModel(
+        { type: 'integer', enum: [0, 1], nullable: true },
+        'const valid: Model = 0;\n// @ts-expect-error nullable does not remove enum restrictions\nconst invalid: Model = null;',
+      ).diagnostics,
+    ).toEqual([]);
+    expect(
+      generateModel(
+        { type: 'integer', enum: [0, 1, null], nullable: true },
+        'const valid: Model = null;',
+      ).diagnostics,
+    ).toEqual([]);
+  });
+});
+
+describe('allOf preserves every referenced and inline constraint', () => {
+  it.each([
+    [false, false],
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(
+    'retains inherited required properties (reverse: %s, two refs: %s)',
+    (reverse, twoReferences) => {
+      const project = new Project({
+        useInMemoryFileSystem: true,
+        compilerOptions: {
+          strict: true,
+          skipLibCheck: true,
+          lib: ['lib.es2020.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+        },
+      });
+      const file = project.createSourceFile('/types.ts', '');
+      const members: (Schema | { $ref: string })[] = [
+        { $ref: '#/components/schemas/Base' },
+        twoReferences
+          ? { $ref: '#/components/schemas/OptionalBase' }
+          : {
+              type: 'object',
+              properties: { id: { type: 'string' }, other: { type: 'string' } },
+            },
+      ];
+      const schemas: Record<string, Schema> = {
+        Base: {
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'string' } },
+        },
+        OptionalBase: {
+          type: 'object',
+          properties: { id: { type: 'string' }, other: { type: 'string' } },
+        },
+        Derived: { allOf: reverse ? [...members].reverse() : members },
+      };
+      for (const [name, schema] of Object.entries(schemas)) {
+        new TypeGenerator(
+          { name, path: '/' },
+          file,
+          { key: name, schema },
+          '/',
+          { schemas },
+        ).generate();
+      }
+      file.addStatements(
+        "const valid: Derived = { id: '1' };\n// @ts-expect-error inherited id remains required\nconst missing: Derived = {};\n// @ts-expect-error inherited id must be a string\nconst wrong: Derived = { id: 1 };\n// @ts-expect-error required does not permit undefined\nconst unset: Derived = { id: undefined };",
+      );
+      expect(
+        project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+      ).toEqual([]);
+    },
+  );
+
+  it.each([false, true])(
+    'intersects incompatible properties instead of taking the last type: %s',
+    reverse => {
+      const members: Schema[] = [
+        {
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'string' } },
+        },
+        {
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'number' } },
+        },
+      ];
+      expect(
+        generateModel(
+          { allOf: reverse ? [...members].reverse() : members },
+          "// @ts-expect-error string violates the number constraint\nconst stringId: Model = { id: '1' };\n// @ts-expect-error number violates the string constraint\nconst numberId: Model = { id: 1 };\n// @ts-expect-error id is still required\nconst missing: Model = {};",
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+});
+
+it('requires keys absent from an object schema properties map', () => {
+  expect(
+    generateModel(
+      {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['id'],
+      },
+      'const valid: Model = { id: 1 };\n// @ts-expect-error required is independent from properties\nconst missing: Model = {};',
+    ).diagnostics,
+  ).toEqual([]);
+});
+
+describe('required additional property constraints', () => {
+  it.each([false, true])(
+    'keeps required-only objects open by default (nested: %s)',
+    nested => {
+      const schema: Schema = {
+        type: 'object',
+        properties: {},
+        required: ['id'],
+      };
+      expect(
+        generateModel(
+          nested
+            ? {
+                type: 'object',
+                required: ['value'],
+                properties: { value: schema },
+              }
+            : schema,
+          nested
+            ? `
+      const valid: Model = { value: { id: 1, extra: 2 } };
+      // @ts-expect-error allowing extras does not make id optional
+      const missing: Model = { value: { extra: 2 } };
+    `
+            : `
+      const valid: Model = { id: 1, extra: 2 };
+      // @ts-expect-error allowing extras does not make id optional
+      const missing: Model = { extra: 2 };
+    `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it.each([false, true])(
+    'escapes required-only property names (nested: %s)',
+    nested => {
+      const schema: Schema = {
+        type: 'object',
+        properties: {},
+        required: ["owner's", 'path\\name', 'line\nbreak'],
+      };
+      expect(
+        generateModel(
+          nested
+            ? {
+                type: 'object',
+                required: ['value'],
+                properties: { value: schema },
+              }
+            : schema,
+          nested
+            ? `
+      const valid: Model = { value: { "owner's": 1, 'path\\\\name': 2, 'line\\nbreak': 3 } };
+      // @ts-expect-error the escaped keys remain required
+      const missing: Model = { value: {} };
+    `
+            : `
+      const valid: Model = { "owner's": 1, 'path\\\\name': 2, 'line\\nbreak': 3 };
+      // @ts-expect-error the escaped keys remain required
+      const missing: Model = {};
+    `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it.each([false, true])(
+    'emits own required declarations for prototype names (nested: %s)',
+    nested => {
+      const schema: Schema = {
+        type: 'object',
+        properties: {},
+        required: ['constructor', 'toString'],
+        additionalProperties: { type: 'string' },
+      };
+      expect(
+        generateModel(
+          nested
+            ? {
+                type: 'object',
+                required: ['value'],
+                properties: { value: schema },
+              }
+            : schema,
+          nested
+            ? `
+      const valid: Model = { value: { constructor: '1', toString: '2' } };
+      // @ts-expect-error inherited functions cannot satisfy required string values
+      const missing: Model = { value: {} };
+    `
+            : `
+      const valid: Model = { constructor: '1', toString: '2' };
+      // @ts-expect-error inherited functions cannot satisfy required string values
+      const missing: Model = {};
+    `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it.each([false, true])(
+    'preserves custom map keys when required keys exist (nested: %s)',
+    nested => {
+      const map: Schema = {
+        type: 'object',
+        required: ['id'],
+        additionalProperties: { type: 'string' },
+        'x-map-key-schema': { type: 'string', enum: ['id', 'name'] },
+      };
+      const { diagnostics } = generateModel(
+        nested
+          ? {
+              type: 'object',
+              required: ['map'],
+              properties: { map },
+            }
+          : map,
+        nested
+          ? `
+      const valid: Model = { map: { id: '1', name: 'one' } };
+      // @ts-expect-error unknown map keys remain invalid
+      const extra: Model = { map: { id: '1', name: 'one', other: 'two' } };
+      // @ts-expect-error the map still requires id
+      const missing: Model = { map: { name: 'one' } };
+    `
+          : `
+      const valid: Model = { id: '1', name: 'one' };
+      // @ts-expect-error unknown map keys remain invalid
+      const extra: Model = { id: '1', name: 'one', other: 'two' };
+      // @ts-expect-error the map still requires id
+      const missing: Model = { name: 'one' };
+      // @ts-expect-error values still follow additionalProperties
+      const wrong: Model = { id: 1, name: 'one' };
+    `,
+      );
+      expect(diagnostics).toEqual([]);
+    },
+  );
+
+  it.each([true, false])(
+    'uses the additional-property schema for required keys (properties present: %s)',
+    withProperties => {
+      const schema: Schema = {
+        type: 'object',
+        ...(withProperties
+          ? { properties: { name: { type: 'string' as const } } }
+          : {}),
+        required: ['id'],
+        additionalProperties: { type: 'string' },
+      };
+      const assignments =
+        "const valid: Model = { id: '1' };\n// @ts-expect-error id is required\nconst missing: Model = {};\n// @ts-expect-error undeclared required id obeys additionalProperties\nconst wrong: Model = { id: 1 };";
+      expect(generateModel(schema, assignments).diagnostics).toEqual([]);
+      expect(
+        generateModel(
+          {
+            type: 'object',
+            required: ['nested'],
+            properties: { nested: schema },
+          },
+          "const valid: Model = { nested: { id: '1' } };\n// @ts-expect-error nested id follows additionalProperties too\nconst wrong: Model = { nested: { id: 1 } };",
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it.each([false, true, undefined])(
+    'respects boolean/default additionalProperties: %s',
+    additionalProperties => {
+      const schema: Schema = {
+        type: 'object',
+        properties: {},
+        required: ['id'],
+        additionalProperties,
+      };
+      const assignments =
+        additionalProperties === false
+          ? "// @ts-expect-error a forbidden required field makes the schema impossible\nconst invalid: Model = { id: '1' };"
+          : "const valid: Model[] = [{ id: null }, { id: 1 }, { id: '1' }];\n// @ts-expect-error id cannot be missing\nconst missing: Model = {};";
+      expect(generateModel(schema, assignments).diagnostics).toEqual([]);
+    },
+  );
+});
+
+describe('simultaneous composition and declaration collisions', () => {
+  it.each(['oneOf', 'anyOf'] as const)(
+    'intersects allOf with the complete %s union',
+    composition => {
+      expect(
+        generateModel(
+          {
+            allOf: [
+              {
+                type: 'object',
+                required: ['id'],
+                properties: { id: { type: 'string' } },
+              },
+            ],
+            [composition]: ['a', 'b'].map(kind => ({
+              type: 'object',
+              required: ['kind'],
+              properties: { kind: { const: kind } },
+            })),
+          },
+          `
+            const valid: Model[] = [{ id: '1', kind: 'a' }, { id: '2', kind: 'b' }];
+            // @ts-expect-error allOf still requires id
+            const missingId: Model = { kind: 'a' };
+            // @ts-expect-error the union still requires kind
+            const missingKind: Model = { id: '1' };
+            // @ts-expect-error allOf still constrains the id type
+            const wrongId: Model = { id: 1, kind: 'a' };
+          `,
+        ).diagnostics,
+      ).toEqual([]);
+    },
+  );
+
+  it('intersects simultaneous oneOf and anyOf unions', () => {
+    expect(
+      generateModel(
+        {
+          oneOf: [{ const: 'a' }, { const: 'b' }],
+          anyOf: [{ const: 'b' }, { const: 'c' }],
+        },
+        `
+          const valid: Model = 'b';
+          // @ts-expect-error a does not satisfy anyOf
+          const excludedByAnyOf: Model = 'a';
+          // @ts-expect-error c does not satisfy oneOf
+          const excludedByOneOf: Model = 'c';
+        `,
+      ).diagnostics,
+    ).toEqual([]);
+  });
+
+  it('keeps the global Exclude available beside a model of the same name', () => {
+    const project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        strict: true,
+        skipLibCheck: true,
+        lib: ['lib.es2020.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+      },
+    });
+    const file = project.createSourceFile('/types.ts', '');
+    const schemas: Record<string, Schema> = {
+      Exclude: { type: 'string' },
+      Model: {
+        allOf: [
+          { type: 'object', properties: { id: { type: 'string' } } },
+          { required: ['id'] },
+        ],
+      },
+    };
+    for (const [name, schema] of Object.entries(schemas)) {
+      new TypeGenerator({ name, path: '/' }, file, { key: name, schema }, '/', {
+        schemas,
+      }).generate();
+    }
+    file.addStatements(`
+      const component: Exclude = 'local model';
+      const valid: Model = { id: '1' };
+      // @ts-expect-error id remains required
+      const missing: Model = {};
+      // @ts-expect-error required-only branches cannot admit a string
+      const primitive: Model = 'x';
+      // @ts-expect-error required-only branches cannot admit an array
+      const array: Model = [];
+    `);
+    expect(
+      project.getPreEmitDiagnostics().map(d => d.getMessageText()),
+    ).toEqual([]);
+  });
+
+  it.each([false, true])(
+    'keeps empty and separator enum members distinct (composed: %s)',
+    composed => {
+      const { diagnostics, file } = generateModel(
+        {
+          type: 'string',
+          enum: ['', '-', '_', 'ON'],
+          'x-enum-text': {
+            '': 'Empty',
+            '-': 'Dash',
+            _: 'Underscore',
+            ON: 'On',
+          },
+          ...(composed ? { allOf: [{ type: 'string' as const }] } : {}),
+        },
+        `
+          export const values: Model[] = [Model[''], Model['-'], Model['_'], Model.ON];
+          export const labels = [ModelEnumText[''], ModelEnumText['-'], ModelEnumText['_'], ModelEnumText.ON];
+        `,
+      );
+      expect(diagnostics).toEqual([]);
+      file.getProject().compilerOptions.set({ module: ModuleKind.CommonJS });
+      const exports = {};
+      runInNewContext(file.getEmitOutput().getOutputFiles()[0].getText(), {
+        exports,
+      });
+      expect(exports).toMatchObject({
+        Model: { '': '', '-': '-', _: '_', ON: 'ON' },
+        ModelEnumText: { '': 'Empty', '-': 'Dash', _: 'Underscore', ON: 'On' },
+        values: ['', '-', '_', 'ON'],
+        labels: ['Empty', 'Dash', 'Underscore', 'On'],
+      });
+    },
+  );
+});

--- a/skills/fetcher-openapi-generator/references/api.md
+++ b/skills/fetcher-openapi-generator/references/api.md
@@ -119,6 +119,64 @@ parseOpenAPI(inputPath) → AggregateResolver(openAPI).resolve()
 5. **Index Generator** - Creates `index.ts` barrel exports at every directory level
 6. **Post-processing** - `formatText()`, `organizeImports()`, `fixMissingImports()` on all files
 
+Generated object properties follow each schema's `required` list, including nested
+objects and `allOf` siblings. Read-only properties retain `readonly` in nullable
+and inline object aliases. Required keys absent from `properties` follow
+`additionalProperties`, remain open to extra keys when that option is omitted,
+and preserve custom `x-map-key-schema` constraints. Forbidden required keys have
+type `never`; required names use own-property checks and escaped property names.
+For undeclared required keys with default or `true` additional properties, the
+fallback accepts primitive/null values, dictionaries, and readonly arrays while
+rejecting function values, so inherited prototype methods do not satisfy them.
+TypeScript cannot prove arbitrary properties are own properties or recursively
+validate JSON values through these structural types.
+OpenAPI 3.0 `nullable: true` permits `null` only when enum, const, and composition
+constraints also allow it. A standalone `required` list only constrains objects.
+Without `type`, nonempty `properties` still constrain object instances, including
+beside compositions; these object branches remain open when
+`additionalProperties` is omitted. The unconstrained non-object branch includes
+mutable and readonly arrays.
+Object constraints in `allOf`, including nested compositions and references,
+exclude primitive and array branches. Object-constrained compositions and nonempty
+enum/const object literals, including nested literals, also add an
+optional `globalThis.Symbol.iterator` property of type `never`, so readonly arrays
+cannot satisfy a weak object shape. This boundary requires `ES2015.Iterable` or a
+higher standard library, such as the repository's ES2020 library. Custom iterable
+objects must first be converted to plain JSON objects; this is not a general
+TypeScript representation of every JavaScript object that is not an array.
+Mixed `oneOf` and `anyOf` branches retain their allowed non-object values.
+Empty root properties do not erase composition constraints. When multiple
+composition keywords occur together, each `allOf` intersection and `oneOf` or
+`anyOf` union is retained, then their results are intersected. A `type` array
+applies the same schema constraints to each listed type before forming its union,
+so object/array alternatives do not introduce an unconstrained `any`. Repeated
+composition nodes and edges are collected once, then object constraints propagate
+until stable. Recursive references do not produce path-dependent partial cache
+entries, and repeated DAG branches reuse the same collected nodes. A component named
+`Exclude` remains usable alongside composed object schemas. Generated `Record`
+references use `globalThis.Record` so a component named `Record` cannot shadow
+the utility type.
+
+All `allOf` schemas generate TypeScript intersection aliases so required,
+optional, and conflicting property types retain every member constraint. Object
+schemas with optional properties and schema-valued `additionalProperties` also
+use an intersection alias: the declared properties retain their modifiers while
+the string index keeps the additional-property type without adding `undefined`.
+Other plain object schemas continue generating interfaces. TypeScript string
+indexes also constrain declared keys; they cannot express the JSON Schema case
+where declared properties have types incompatible with `additionalProperties`.
+Generated types do not perform runtime JSON validation.
+
+String-only enums with no const or composition constraints, and with `type` omitted or set to `'string'`, remain TypeScript enums (including empty-string members).
+Separator-only values whose normalized name is empty retain their original key,
+so `Model['']` and `Model['-']` are distinct; the same keys apply to `EnumText` and
+composed enum value objects. When a string enum also has `allOf`, `oneOf`, or `anyOf`, it generates a constrained type
+alias and a same-name `const` object, preserving runtime access such as
+`Model.ON`. The object retains every declared enum value; the type alias rejects
+values excluded by the composition. Use `typeof Model.ON` for a member's type in
+this form. `ModelEnumText` remains available when `x-enum-text` is supplied.
+Numeric and mixed enums use literal unions that preserve the JSON value types and keep `ModelEnumText` when supplied. Mixed enums also export a same-name `const` object for their existing string members. Enum and const literals are intersected with supported type, object, and composition constraints; contradictory literal and type constraints reject every value. Known literals are checked against JSON type categories, so arrays do not satisfy `object` and fractional numbers do not satisfy `integer`. Empty object literals, including nested enum/const objects, use `globalThis.Record<string, never>` rather than the broad TypeScript `{}` type.
+
 ## Generated Output Structure
 
 ```


### PR DESCRIPTION
## Description

Generated types preserve type unions, object requirements, enum/const literals and simultaneous composition constraints without widening them to `any`. Object branches retain typeless property constraints, reject inherited function values for undeclared required keys, and exclude mutable and readonly arrays when an object type is required. Typeless schemas continue to permit both mutable and readonly arrays outside the object branch. Repeated composition nodes are collected once and their object constraints propagate until stable, including graphs with recursive leaves.

Numeric and mixed enums retain `EnumText` exports; mixed and constrained string enums retain runtime string members. Pure non-string enums have type-only model exports in 5.0.0; their former empty runtime placeholders are intentionally removed. Literal rendering preserves empty-object constraints, excludes arrays from nonempty object literals (including nested values), and safely escapes enum values and labels. Known literals are filtered by JSON type categories before intersection, excluding arrays from object literals and fractions from integer literals. Global utility types cannot be shadowed by component names. Generated snapshot changes were reviewed: enum member names/values and interface property flags remain unchanged.

## Release and type-library scope

This is part of the unreleased **4.0.1 → 5.0.0** series. Prerequisite #1400 already applied the major version bump; npm and GitHub still publish 4.0.1. Optional fields, allOf intersection aliases and constrained enum type aliases are intentional 5.0.0 output changes, documented in the API reference.

Non-array object-composition and object-literal types require `ES2015.Iterable` or higher type libraries (this repository uses ES2020+). They describe plain JSON objects; custom iterable objects must first be converted. Generated structural types do not perform runtime JSON validation or prove arbitrary own-property membership.

## Validation

The combined stack passed before this scoped fix was inserted into the owning layer; every later source tree was replayed and verified against the tested tree:

- `pnpm build`
- `pnpm test:unit` — 280 files, 3764 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .` — no errors
- `git diff --check`

Node.js 24.11.0, pnpm 10.34.5. Regressions compile generated consumers with valid and invalid assignments, check runtime enum values, and use deterministic visit counts for DAG performance. Snapshot baselines were regenerated through the existing test harness and then checked in an ordinary full test run. No dependencies, root/package tsconfig, or build configuration changed.

## Review and CI

Ready for review. Merge requires a completed GitHub Codex review, no unresolved review threads, and five successful CI workflows for the current head. Codacy quality-rule findings remain separately documented with source evidence.

Native GitHub stack #1418, layer 11 of 16. Squash this layer separately and verify rewritten heads before advancing. No release or tag is published.

Split index: #1399.
