### PR TITLE
fix(generator): refresh generated output and remove stale owned files

### DIFF
--- a/packages/generator/expected/compensation-spec/.fetcher-generator.json
+++ b/packages/generator/expected/compensation-spec/.fetcher-generator.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "files": {
+    "compensation/boundedContext.ts": "c8224683408336b206d4685a045f6db9322a9f13c75786bc13301b8b44f6b86c",
+    "compensation/execution_failed/commandClient.ts": "25bf14d00089968ccd3e564fc0bee159035b85b5233352e277e1ae2a59cc283c",
+    "compensation/execution_failed/index.ts": "bd180919586fd2d243b06ff644f6f51ed8919242c58f155e284a2833be3229c6",
+    "compensation/execution_failed/queryClient.ts": "c430f1e23d57c244939b435aacb233f6f7e97b1e42d53761af04b557efa4dadb",
+    "compensation/execution_failed/types.ts": "b2cc3a874ba70a934c461efd575d0647adbfc92cc09c034aba808977bfc0e8a3",
+    "compensation/index.ts": "911a07ee6fcb51649feec772deea9a98e82822ff0992aea7d8c2f9feb3e4483e",
+    "compensation/types.ts": "3e184243fc8e20c22116d147441cb287728e3faa3a17a6fdbd9d39ec5e335930",
+    "index.ts": "84d2d07747b82299f979c66971e9a695c5441340e71d12433eb09f73649055a9"
+  }
+}

--- a/packages/generator/expected/demo-spec/.fetcher-generator.json
+++ b/packages/generator/expected/demo-spec/.fetcher-generator.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "files": {
+    "example/CartApiClient.ts": "c445ce05fc5511dc74b9b6e442cc6562c30dffbe8e90192a56c127e86ae6fc5c",
+    "example/OrderApiClient.ts": "07c1917f4fa81f3f30420693d0695051a3debc604ff9bc11ac1668863b51480c",
+    "example/boundedContext.ts": "c0ee8a415fb0edfd13151bac02cdb821faa644b62bb8ecaf5f01777f23ca4fb9",
+    "example/cart/commandClient.ts": "45c5433243673b5621ec35918abff9463e3954a6687f5b5d06fc5e28adb21042",
+    "example/cart/index.ts": "bd180919586fd2d243b06ff644f6f51ed8919242c58f155e284a2833be3229c6",
+    "example/cart/queryClient.ts": "8cd084c1c9b0bf5dbc597a463900df49bd64103ee39eadc6d121ab141e9d13bd",
+    "example/cart/types.ts": "f6936fe373407c5909c7ef51cef28286d8ae8701069e7b825808a6ddc2886340",
+    "example/index.ts": "958816b9ed6d0ed9e6700f94bd414bdf17e60b4983c885ed6e87cca8f3085e5b",
+    "example/order/commandClient.ts": "b6509a0692d511df4711d8c1d938cd349391499f4499ac4544b3c8693c8c5946",
+    "example/order/index.ts": "bd180919586fd2d243b06ff644f6f51ed8919242c58f155e284a2833be3229c6",
+    "example/order/queryClient.ts": "3d8bd01008655b5c60dbf5f5e1f64d75a94c7e64344ab35c098e9ccf7ff28832",
+    "example/order/types.ts": "093cd06009ef13571062c9b81a13eb3dc302aaca05d2f13ccac76ce37bb32421",
+    "example/types.ts": "6c5251435bd5c66925d335b810899d77db182a31ee31bb066891296ff7ec4eab",
+    "index.ts": "15abd9254fef79efb01578428672cc77b7b8640c0cad2006411af396681e32a0"
+  }
+}

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -18,7 +18,15 @@ import { ClientGenerator } from './client';
 import { GenerateContext } from './generateContext';
 import { ModelGenerator } from './model';
 import type { GeneratorConfiguration, GeneratorOptions } from './types';
-import { parseConfiguration, parseOpenAPI } from './utils';
+import {
+  beginGeneration,
+  forgetStaleGeneratedFiles,
+  getGeneratedFilePaths,
+  getOrCreateSourceFile,
+  parseConfiguration,
+  parseOpenAPI,
+  saveGeneration,
+} from './utils';
 
 /**
  * Default path to the generator configuration file.
@@ -105,6 +113,8 @@ export class CodeGenerator {
       this.options.logger.info(`Configuration file parsing failed: ${e}`);
     }
 
+    beginGeneration(this.project, this.options.outputDir);
+
     const context: GenerateContext = new GenerateContext({
       openAPI: openAPI,
       project: this.project,
@@ -123,9 +133,11 @@ export class CodeGenerator {
     const clientGenerator = new ClientGenerator(context);
     clientGenerator.generate();
     this.options.logger.info('Clients generated successfully');
+    forgetStaleGeneratedFiles(this.project, this.options.outputDir);
     const outputDir = this.project.getDirectory(this.options.outputDir);
     if (!outputDir) {
       this.options.logger.info('Output directory not found.');
+      await saveGeneration(this.project, this.options.outputDir);
       return;
     }
     this.options.logger.info('Generating index files');
@@ -137,7 +149,7 @@ export class CodeGenerator {
     this.options.logger.info('Source files optimized successfully');
 
     this.options.logger.info('Saving project to disk');
-    await this.project.save();
+    await saveGeneration(this.project, this.options.outputDir);
     this.options.logger.info('Code generation completed successfully');
   }
 
@@ -159,7 +171,6 @@ export class CodeGenerator {
       `Generating index files for output directory: ${this.options.outputDir}`,
     );
     this.processDirectory(outputDir);
-    this.generateIndexForDirectory(outputDir);
     this.options.logger.info('Index file generation completed');
   }
 
@@ -167,14 +178,12 @@ export class CodeGenerator {
    * Recursively processes all subdirectories to generate index files.
    * @param dir - The directory to process.
    */
-  private processDirectory(dir: Directory) {
-    const subDirs = dir.getDirectories();
+  private processDirectory(dir: Directory): boolean {
+    const subDirs = dir
+      .getDirectories()
+      .filter(subDir => this.processDirectory(subDir));
     this.options.logger.info(`Processing ${subDirs.length} subdirectories`);
-    for (const subDir of subDirs) {
-      this.options.logger.info(`Processing subdirectory: ${subDir.getPath()}`);
-      this.generateIndexForDirectory(subDir);
-      this.processDirectory(subDir);
-    }
+    return this.generateIndexForDirectory(dir, subDirs);
   }
 
   /**
@@ -184,7 +193,10 @@ export class CodeGenerator {
    *
    * @param dir - The directory to generate the index file for.
    */
-  private generateIndexForDirectory(dir: Directory) {
+  private generateIndexForDirectory(
+    dir: Directory,
+    subDirs = dir.getDirectories(),
+  ): boolean {
     const dirPath = dir.getPath();
     this.options.logger.info(`Generating index for directory: ${dirPath}`);
 
@@ -196,8 +208,6 @@ export class CodeGenerator {
           file.getBaseName() !== 'index.ts',
       );
 
-    const subDirs: Directory[] = dir.getDirectories();
-
     this.options.logger.info(
       `Found ${tsFiles.length} TypeScript files and ${subDirs.length} subdirectories in ${dirPath}`,
     );
@@ -206,13 +216,10 @@ export class CodeGenerator {
       this.options.logger.info(
         `No files or subdirectories to export in ${dirPath}, skipping index generation`,
       );
-      return;
+      return this.project.getSourceFile(`${dirPath}/index.ts`) !== undefined;
     }
 
-    const indexFilePath = `${dirPath}/index.ts`;
-    const indexFile =
-      this.project.getSourceFile(indexFilePath) ||
-      this.project.createSourceFile(indexFilePath, '', { overwrite: true });
+    const indexFile = getOrCreateSourceFile(this.project, dirPath, 'index.ts');
 
     indexFile.removeText();
 
@@ -237,6 +244,7 @@ export class CodeGenerator {
     this.options.logger.info(
       `Index file generated for ${dirPath} with ${tsFiles.length + subDirs.length} exports`,
     );
+    return true;
   }
 
   /**
@@ -246,7 +254,10 @@ export class CodeGenerator {
    * @param outputDir - The root output directory containing source files to optimize.
    */
   optimizeSourceFiles(outputDir: Directory) {
-    const sourceFiles = outputDir.getDescendantSourceFiles();
+    const written = getGeneratedFilePaths(this.project);
+    const sourceFiles = outputDir
+      .getDescendantSourceFiles()
+      .filter(file => !written || written.has(file.getFilePath()));
     this.options.logger.info(
       `Optimizing ${sourceFiles.length} source files in ${outputDir.getPath()}`,
     );

--- a/packages/generator/src/utils/sourceFiles.ts
+++ b/packages/generator/src/utils/sourceFiles.ts
@@ -14,6 +14,7 @@
 import { combineURLs } from '@ahoo-wang/fetcher';
 import { isAbsolute, join, relative, resolve, sep } from 'path';
 import type { JSDocableNode, Project, SourceFile } from 'ts-morph';
+import { ts } from 'ts-morph';
 import type { ModelInfo } from '../model';
 import type { Reference, Schema } from '@ahoo-wang/fetcher-openapi';
 
@@ -21,6 +22,149 @@ import type { Reference, Schema } from '@ahoo-wang/fetcher-openapi';
 const MODEL_FILE_NAME = 'types.ts';
 /** Alias for import paths */
 const IMPORT_ALIAS = '@';
+
+const GENERATION_MANIFEST = '.fetcher-generator.json';
+const generatedFiles = new WeakMap<
+  Project,
+  { written: Set<string>; previous: Map<string, string>; stale: Set<string> }
+>();
+
+/** Load only explicitly recorded ownership; discard drafts from the last run. */
+export function beginGeneration(project: Project, outputDir: string): void {
+  const fs = project.getFileSystem();
+  outputDir = resolve(fs.getCurrentDirectory(), outputDir);
+  const manifestPath = join(outputDir, GENERATION_MANIFEST);
+  const previous = new Map<string, string>();
+  if (fs.fileExistsSync(manifestPath)) {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath));
+    if (
+      manifest?.version !== 1 ||
+      !manifest.files ||
+      typeof manifest.files !== 'object' ||
+      Array.isArray(manifest.files)
+    ) {
+      throw new Error(`Invalid generation manifest: ${manifestPath}`);
+    }
+    for (const [path, hash] of Object.entries(manifest.files)) {
+      const fileName = resolve(outputDir, path);
+      assertWithinOutputDir(outputDir, fileName);
+      if (
+        isAbsolute(path) ||
+        !path.endsWith('.ts') ||
+        typeof hash !== 'string' ||
+        !/^[a-f0-9]{64}$/.test(hash)
+      ) {
+        throw new Error(`Invalid generated file entry: ${path}`);
+      }
+      previous.set(fileName, hash);
+    }
+  }
+  for (const path of generatedFiles.get(project)?.written ?? []) {
+    project.getSourceFile(path)?.forget();
+  }
+  for (const path of previous.keys()) {
+    project.getSourceFile(path)?.forget();
+  }
+  generatedFiles.set(project, {
+    written: new Set(),
+    previous,
+    stale: new Set(),
+  });
+}
+
+function fileHash(text: string): string {
+  if (!ts.sys.createSHA256Hash) {
+    throw new Error('SHA-256 hashing is unavailable in this environment.');
+  }
+  return ts.sys.createSHA256Hash(text);
+}
+
+function isUnchangedGeneratedFile(
+  project: Project,
+  outputDir: string,
+  path: string,
+  hash: string,
+): boolean {
+  const fs = project.getFileSystem();
+  if (!fs.fileExistsSync(path)) return false;
+  assertWithinOutputDir(fs.realpathSync(outputDir), fs.realpathSync(path));
+  return fileHash(fs.readFileSync(path)) === hash;
+}
+
+/** Exclude stale owned files from indexes without deleting anything on disk. */
+export function forgetStaleGeneratedFiles(
+  project: Project,
+  outputDir: string,
+): void {
+  const run = generatedFiles.get(project);
+  if (!run) return;
+  outputDir = resolve(project.getFileSystem().getCurrentDirectory(), outputDir);
+  for (const [path, hash] of run.previous) {
+    if (
+      !run.written.has(path) &&
+      isUnchangedGeneratedFile(project, outputDir, path, hash)
+    ) {
+      project.getSourceFile(path)?.forget();
+      run.stale.add(path);
+    }
+  }
+}
+
+export function getGeneratedFilePaths(
+  project: Project,
+): ReadonlySet<string> | undefined {
+  return generatedFiles.get(project)?.written;
+}
+
+/** Save current output before removing unchanged stale files and recording ownership. */
+export async function saveGeneration(
+  project: Project,
+  outputDir: string,
+): Promise<void> {
+  const run = generatedFiles.get(project);
+  if (!run) return;
+  outputDir = resolve(project.getFileSystem().getCurrentDirectory(), outputDir);
+  const files = [...run.written]
+    .sort()
+    .map(path => project.getSourceFileOrThrow(path));
+  const saved = await Promise.allSettled(files.map(file => file.save()));
+  for (const result of saved) {
+    if (result.status === 'rejected') throw result.reason;
+  }
+  const fs = project.getFileSystem();
+  for (const path of run.stale) {
+    if (
+      !run.written.has(path) &&
+      isUnchangedGeneratedFile(
+        project,
+        outputDir,
+        path,
+        run.previous.get(path)!,
+      )
+    ) {
+      await fs.delete(path);
+    }
+  }
+  fs.mkdirSync(outputDir);
+  await fs.writeFile(
+    join(outputDir, GENERATION_MANIFEST),
+    JSON.stringify(
+      {
+        version: 1,
+        files: Object.fromEntries(
+          files.map(file => [
+            relative(resolve(outputDir), file.getFilePath())
+              .split(sep)
+              .join('/'),
+            fileHash(fs.readFileSync(file.getFilePath())),
+          ]),
+        ),
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+}
 
 /**
  * Generates the file path for a model file.
@@ -79,13 +223,20 @@ export function getOrCreateSourceFile(
 ): SourceFile {
   const fileName = combineURLs(outputDir, filePath);
   assertWithinOutputDir(outputDir, fileName);
-  const file = project.getSourceFile(fileName);
-  if (file) {
-    return file;
+  const file =
+    project.getSourceFile(fileName) ??
+    project.createSourceFile(fileName, '', {
+      overwrite: true,
+    });
+  const written = generatedFiles.get(project)?.written;
+  if (written) {
+    const path = file.getFilePath();
+    if (!written.has(path)) {
+      file.removeText();
+      written.add(path);
+    }
   }
-  return project.createSourceFile(fileName, '', {
-    overwrite: true,
-  });
+  return file;
 }
 
 /**

--- a/packages/generator/test/index.test.ts
+++ b/packages/generator/test/index.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CodeGenerator } from '../src';
-import { GeneratorOptions } from '../src/types';
+import type { GeneratorOptions } from '../src/types';
 
 // Mock dependencies
 vi.mock('ts-morph', () => ({
@@ -32,6 +32,14 @@ vi.mock('ts-morph', () => ({
 }));
 
 vi.mock('../src/utils', () => ({
+  beginGeneration: vi.fn(),
+  forgetStaleGeneratedFiles: vi.fn(),
+  getGeneratedFilePaths: vi.fn(),
+  getOrCreateSourceFile: vi.fn().mockReturnValue({
+    removeText: vi.fn(),
+    addExportDeclaration: vi.fn(),
+  }),
+  saveGeneration: vi.fn(),
   parseOpenAPI: vi.fn(),
   parseConfiguration: vi.fn(),
 }));
@@ -58,17 +66,12 @@ vi.mock('../src/client', () => ({
 }));
 
 // Import after mocking
-import { Project } from 'ts-morph';
 import { parseOpenAPI, parseConfiguration } from '../src/utils';
-import { AggregateResolver } from '../src/aggregate';
-import { ModelGenerator } from '../src/model';
-import { ClientGenerator } from '../src/client';
 
 describe('CodeGenerator', () => {
   let mockProject: any;
   let mockLogger: any;
   let mockOpenAPI: any;
-  let mockContextAggregates: any;
   let options: GeneratorOptions;
 
   beforeEach(() => {
@@ -93,10 +96,6 @@ describe('CodeGenerator', () => {
       openapi: '3.0.0',
       info: { title: 'Test API', version: '1.0.0' },
       paths: {},
-    };
-
-    mockContextAggregates = {
-      size: 2,
     };
 
     (parseOpenAPI as any).mockResolvedValue(mockOpenAPI);

--- a/packages/generator/test/regeneration.test.ts
+++ b/packages/generator/test/regeneration.test.ts
@@ -1,0 +1,386 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CodeGenerator } from '../src';
+import type { OpenAPI } from '@ahoo-wang/fetcher-openapi';
+
+const directories: string[] = [];
+afterEach(() =>
+  directories
+    .splice(0)
+    .forEach(dir => rmSync(dir, { recursive: true, force: true })),
+);
+const logger = {
+  info() {},
+  success() {},
+  error() {},
+  progress() {},
+  progressWithCount() {},
+};
+
+describe('review regressions', () => {
+  it('regenerates included output without accumulating declarations', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'fetcher-regeneration-'));
+    directories.push(dir);
+    const inputPath = join(dir, 'openapi.json');
+    const tsConfigFilePath = join(dir, 'tsconfig.json');
+    const outputDir = join(dir, 'out');
+    writeFileSync(
+      tsConfigFilePath,
+      JSON.stringify({
+        compilerOptions: { experimentalDecorators: true },
+        include: ['out/**/*.ts'],
+      }),
+    );
+    writeFileSync(
+      inputPath,
+      JSON.stringify({
+        openapi: '3.0.4',
+        info: {},
+        paths: {
+          '/message': {
+            get: {
+              tags: ['Messages'],
+              operationId: 'message',
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': { schema: { type: 'string' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    const options = { inputPath, outputDir, tsConfigFilePath, logger };
+    await new CodeGenerator(options).generate();
+    const first = readFileSync(join(outputDir, 'MessagesApiClient.ts'), 'utf8');
+    writeFileSync(join(outputDir, 'custom.ts'), 'export const custom = 1;');
+    await new CodeGenerator(options).generate();
+    expect(readFileSync(join(outputDir, 'custom.ts'), 'utf8')).toBe(
+      'export const custom = 1;',
+    );
+    expect(readFileSync(join(outputDir, 'MessagesApiClient.ts'), 'utf8')).toBe(
+      first,
+    );
+  });
+});
+
+function regenerationFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'fetcher-owned-output-'));
+  directories.push(dir);
+  const inputPath = join(dir, 'openapi.json');
+  const outputDir = join(dir, 'out');
+  const options = {
+    inputPath,
+    outputDir,
+    logger,
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { experimentalDecorators: true },
+  };
+  return {
+    options,
+    path: (...parts: string[]) => join(outputDir, ...parts),
+    write: (spec: object) => writeFileSync(inputPath, JSON.stringify(spec)),
+  };
+}
+
+function namespaceSpec(namespace: string): OpenAPI {
+  return {
+    openapi: '3.0.4',
+    info: {},
+    paths: {
+      '/item': {
+        get: {
+          tags: [`${namespace}.Items`],
+          operationId: 'getItem',
+          responses: {
+            '200': {
+              content: {
+                'application/json': {
+                  schema: { $ref: `#/components/schemas/${namespace}.User` },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        [`${namespace}.User`]: {
+          type: 'object',
+          properties: { id: { type: 'string' } },
+          required: ['id'],
+        },
+      },
+    },
+  };
+}
+
+it.each(['same', 'new'] as const)(
+  'removes renamed schema/tag files across %s generator instances without tsconfig output discovery',
+  async instance => {
+    const fixture = regenerationFixture();
+    fixture.write(namespaceSpec('old'));
+    const generator = new CodeGenerator(fixture.options);
+    await generator.generate();
+    for (const file of ['types.ts', 'ItemsApiClient.ts', 'index.ts']) {
+      expect(existsSync(fixture.path('old', file))).toBe(true);
+    }
+    fixture.write(namespaceSpec('next'));
+    await (
+      instance === 'same' ? generator : new CodeGenerator(fixture.options)
+    ).generate();
+    for (const file of ['types.ts', 'ItemsApiClient.ts', 'index.ts']) {
+      expect(existsSync(fixture.path('old', file))).toBe(false);
+      expect(existsSync(fixture.path('next', file))).toBe(true);
+    }
+    const barrel = readFileSync(fixture.path('index.ts'), 'utf8');
+    expect(barrel).toContain('./next');
+    expect(barrel).not.toContain('./old');
+  },
+);
+
+it('cleans empty output barrels while preserving handwritten and edited generated bytes', async () => {
+  const fixture = regenerationFixture();
+  const initial = namespaceSpec('old');
+  initial.components!.schemas!['gone.Item'] = { type: 'string' };
+  fixture.write(initial);
+  await new CodeGenerator(fixture.options).generate();
+  const custom =
+    '// Handwritten file. Keep spacing.\nexport const custom   = 1;';
+  writeFileSync(fixture.path('old', 'custom.ts'), custom);
+  const edited =
+    '// Handwritten addition.\n' +
+    readFileSync(fixture.path('old', 'types.ts'), 'utf8');
+  writeFileSync(fixture.path('old', 'types.ts'), edited);
+  fixture.write({
+    openapi: '3.0.4',
+    info: {},
+    paths: {},
+    components: { schemas: {} },
+  });
+  await new CodeGenerator(fixture.options).generate();
+  expect(readFileSync(fixture.path('old', 'custom.ts'), 'utf8')).toBe(custom);
+  expect(readFileSync(fixture.path('old', 'types.ts'), 'utf8')).toBe(edited);
+  expect(existsSync(fixture.path('old', 'ItemsApiClient.ts'))).toBe(false);
+  expect(existsSync(fixture.path('gone', 'types.ts'))).toBe(false);
+  for (const path of [
+    fixture.path('index.ts'),
+    fixture.path('old', 'index.ts'),
+    fixture.path('gone', 'index.ts'),
+  ]) {
+    expect(existsSync(path)).toBe(false);
+  }
+});
+
+it('keeps disk output and manifest on partial failure and discards drafts before same-instance retry', async () => {
+  const fixture = regenerationFixture();
+  fixture.write(namespaceSpec('old'));
+  const generator = new CodeGenerator(fixture.options);
+  await generator.generate();
+  const files = [
+    'index.ts',
+    'old/types.ts',
+    'old/ItemsApiClient.ts',
+    'old/index.ts',
+  ];
+  const before = files.map(path => readFileSync(fixture.path(path), 'utf8'));
+  const manifestPath = fixture.path('.fetcher-generator.json');
+  const manifestBefore = existsSync(manifestPath)
+    ? readFileSync(manifestPath, 'utf8')
+    : undefined;
+  fixture.write({
+    openapi: '3.0.4',
+    info: {},
+    paths: {},
+    components: {
+      schemas: {
+        'draft.Temporary': { type: 'string' },
+        'bad.Cycle': { $ref: '#/components/schemas/bad.Cycle' },
+      },
+    },
+  });
+  await expect(generator.generate()).rejects.toThrow(/cyclic/i);
+  expect(files.map(path => readFileSync(fixture.path(path), 'utf8'))).toEqual(
+    before,
+  );
+  expect(
+    existsSync(manifestPath) ? readFileSync(manifestPath, 'utf8') : undefined,
+  ).toBe(manifestBefore);
+  expect(existsSync(fixture.path('draft', 'types.ts'))).toBe(false);
+  expect(existsSync(fixture.path('bad', 'types.ts'))).toBe(false);
+  fixture.write(namespaceSpec('next'));
+  await generator.generate();
+  expect(existsSync(fixture.path('next', 'types.ts'))).toBe(true);
+  expect(existsSync(fixture.path('draft', 'types.ts'))).toBe(false);
+  expect(existsSync(fixture.path('bad', 'types.ts'))).toBe(false);
+  const barrel = readFileSync(fixture.path('index.ts'), 'utf8');
+  expect(barrel).not.toContain('./draft');
+  expect(barrel).not.toContain('./bad');
+});
+
+it('rejects manifest paths outside output before deleting existing files', async () => {
+  const fixture = regenerationFixture();
+  fixture.write(namespaceSpec('old'));
+  await new CodeGenerator(fixture.options).generate();
+  const manifestPath = fixture.path('.fetcher-generator.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const original = readFileSync(fixture.path('old', 'types.ts'), 'utf8');
+  writeFileSync(fixture.path('..', 'outside.ts'), original);
+  manifest.files['../outside.ts'] = manifest.files['old/types.ts'];
+  writeFileSync(manifestPath, JSON.stringify(manifest));
+  fixture.write({ openapi: '3.0.4', info: {}, paths: {} });
+  await expect(new CodeGenerator(fixture.options).generate()).rejects.toThrow(
+    /outside the output directory/,
+  );
+  expect(readFileSync(fixture.path('..', 'outside.ts'), 'utf8')).toBe(original);
+  expect(readFileSync(fixture.path('old', 'types.ts'), 'utf8')).toBe(original);
+});
+
+it('does not delete an owned path redirected outside output by a directory symlink', async () => {
+  const fixture = regenerationFixture();
+  fixture.write(namespaceSpec('old'));
+  await new CodeGenerator(fixture.options).generate();
+  const original = readFileSync(fixture.path('old', 'types.ts'), 'utf8');
+  const moved = fixture.path('..', 'moved');
+  renameSync(fixture.path('old'), moved);
+  symlinkSync(moved, fixture.path('old'), 'junction');
+  fixture.write({ openapi: '3.0.4', info: {}, paths: {} });
+  await expect(new CodeGenerator(fixture.options).generate()).rejects.toThrow(
+    /outside the output directory/,
+  );
+  expect(readFileSync(join(moved, 'types.ts'), 'utf8')).toBe(original);
+});
+
+it('tracks saved BOM bytes using the project filesystem and its relative output directory', async () => {
+  const fixture = regenerationFixture();
+  fixture.write(namespaceSpec('old'));
+  const generator = new CodeGenerator({
+    ...fixture.options,
+    outputDir: 'out',
+    useInMemoryFileSystem: true,
+  });
+  const project = generator['project'];
+  project.createSourceFile('/out/old/types.ts', '\uFEFFexport const old = 1;');
+  await project.save();
+  await generator.generate();
+  const fs = project.getFileSystem();
+  expect(fs.readFileSync('/out/old/types.ts').charCodeAt(0)).toBe(0xfeff);
+  fixture.write({ openapi: '3.0.4', info: {}, paths: {} });
+  await generator.generate();
+  expect(fs.fileExistsSync('/out/old/types.ts')).toBe(false);
+  expect(fs.fileExistsSync('/out/index.ts')).toBe(false);
+  expect(fs.fileExistsSync('/out/.fetcher-generator.json')).toBe(true);
+});
+
+it('waits for every file write before rejecting a failed save', async () => {
+  const fixture = regenerationFixture();
+  fixture.write(namespaceSpec('old'));
+  const generator = new CodeGenerator(fixture.options);
+  await generator.generate();
+  const oldPaths = ['old/types.ts', 'old/ItemsApiClient.ts', 'old/index.ts'];
+  const oldBytes = oldPaths.map(path =>
+    readFileSync(fixture.path(path), 'utf8'),
+  );
+  const manifest = readFileSync(
+    fixture.path('.fetcher-generator.json'),
+    'utf8',
+  );
+  const fileSystem = generator['project'].getFileSystem();
+  const writeFile = fileSystem.writeFile.bind(fileSystem);
+  const failure = new Error('injected write failure');
+  let releaseDelayed!: () => void;
+  const delayed = new Promise<void>(resolve => {
+    releaseDelayed = resolve;
+  });
+  let reportStarted!: () => void;
+  const started = new Promise<void>(resolve => {
+    reportStarted = resolve;
+  });
+  let reportFailed!: () => void;
+  const failed = new Promise<void>(resolve => {
+    reportFailed = resolve;
+  });
+  let reportFinished!: () => void;
+  const finished = new Promise<void>(resolve => {
+    reportFinished = resolve;
+  });
+  let delayedFinished = false;
+  let rejectionObserved = false;
+  const write = vi
+    .spyOn(fileSystem, 'writeFile')
+    .mockImplementation(async (path, text) => {
+      if (path.endsWith('/next/types.ts')) {
+        reportFailed();
+        throw failure;
+      }
+      if (path.endsWith('/next/ItemsApiClient.ts')) {
+        reportStarted();
+        try {
+          await delayed;
+          await writeFile(path, text);
+          delayedFinished = true;
+        } finally {
+          reportFinished();
+        }
+        return;
+      }
+      await writeFile(path, text);
+    });
+  fixture.write(namespaceSpec('next'));
+  const generation = generator.generate().then(
+    () => {
+      throw new Error('Expected the injected write failure');
+    },
+    error => {
+      rejectionObserved = true;
+      return error;
+    },
+  );
+  try {
+    await Promise.all([started, failed]);
+    // Let the failing write's rejection propagate without releasing the other write.
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(rejectionObserved).toBe(false);
+    expect(delayedFinished).toBe(false);
+    releaseDelayed();
+    await expect(generation).resolves.toBe(failure);
+    expect(delayedFinished).toBe(true);
+    expect(
+      oldPaths.map(path => readFileSync(fixture.path(path), 'utf8')),
+    ).toEqual(oldBytes);
+    expect(readFileSync(fixture.path('.fetcher-generator.json'), 'utf8')).toBe(
+      manifest,
+    );
+  } finally {
+    releaseDelayed();
+    await Promise.allSettled([generation, finished]);
+    write.mockRestore();
+  }
+});

--- a/skills/fetcher-openapi-generator/references/api.md
+++ b/skills/fetcher-openapi-generator/references/api.md
@@ -80,6 +80,19 @@ const generator = new CodeGenerator({
 await generator.generate();
 ```
 
+Re-running generation with the output included in the supplied tsconfig
+rebuilds the generated declarations instead of appending duplicates.
+Each successful run records generated files and their content hashes in
+`<outputDir>/.fetcher-generator.json`, including barrel indexes. Later runs remove
+files no longer generated only when they remain unchanged, then rebuild indexes
+without exports for removed output. This also works across generator instances
+when the output is not included in tsconfig. Handwritten files, modified stale
+files, and legacy output without an ownership record are preserved; keep the
+manifest with the generated output to enable cleanup. Only current generated
+files are formatted and saved. Rendering failures leave existing output intact,
+and retrying the same instance discards drafts from the failed run. Filesystem
+save failures can leave partial output; generation is not a directory transaction.
+
 ### Key Exports
 
 `CodeGenerator`, `DEFAULT_CONFIG_PATH` (`./fetcher-generator.config.json`) — that is the complete public surface; option and config interfaces (`GeneratorOptions`, `GeneratorConfiguration`) are not re-exported from the package entry.


### PR DESCRIPTION
## Description

Removing or renaming an OpenAPI schema or tag now removes its unchanged generated files and stale barrel exports on the next successful run. Generation records relative output paths and saved-content hashes in `.fetcher-generator.json`, including barrel indexes, so cleanup also works across generator instances without tsconfig output discovery.

Only files recorded by an earlier run with matching content hashes are removed. Handwritten files, edited stale files, and legacy output without ownership records remain on disk. Manifest paths and physical cleanup targets must stay inside the output directory. Indexes are rebuilt from the current project tree without exports for empty removed subtrees; only current generated files are formatted and saved.

A new run discards earlier in-memory drafts. Rendering failures preserve existing output, and file-save failures wait for outstanding writes before reporting failure. Cleanup follows successful writes; general filesystem failures may still leave partial output because generation is not a directory transaction. Content hashes include saved BOM bytes and use the configured project filesystem.

## Validation

The combined stack is validated before this fix is inserted into its owning layer; later source deltas are replayed and checked against the tested tree.

- `pnpm build`, `pnpm test:unit` (3772 passed, 1 skipped; 280 files), package TypeScript checks, read-only ESLint, and `git diff --check`.
- Actual filesystem regressions cover same/new instances, renamed schema/tag output, empty contracts, preserved handwritten/edited files, failed-run retry, and path/symlink boundaries.
- An in-memory filesystem regression covers relative output paths and BOM-preserving saves. Built CLI checks in two separate Node.js processes also verify stale-file removal and recorded SHA-256 hashes.
- End-to-end snapshots add only two ownership manifests. Existing generated TypeScript snapshots are unchanged; all 22 recorded output hashes were checked.

No dependencies, root/package tsconfig, or build configuration changed. This remains part of the pending 5.0.0 series; no release or tag is published.

## Review and CI

Ready for review. Merge requires completed GitHub Codex review, no unresolved review threads, and five successful CI workflows on the current head. Codacy quality findings remain separately documented with source evidence.

Native GitHub stack #1418, layer 12 of 16. Squash this layer separately, then verify rebased upper heads before advancing. Split index: #1399.
