### PR TITLE
fix(react): preserve async hook lifecycles and API method semantics

### DIFF
--- a/packages/react/src/api/apiHooks.ts
+++ b/packages/react/src/api/apiHooks.ts
@@ -38,10 +38,16 @@ export function methodNameToHookName(methodName: string): string {
 /**
  * Collects all function methods from an object and its prototype chain.
  * @param obj - The object to collect methods from.
+ * @param onAccessor - Receives accessors lazily and the methods collected before them; otherwise getters are evaluated to collect their returned methods.
  * @returns A map of method names to bound methods.
  */
 export function collectMethods<T extends (...args: any[]) => Promise<any>>(
   obj: Record<string, any>,
+  onAccessor?: (
+    name: string,
+    get: () => unknown,
+    methods: ReadonlyMap<string, T>,
+  ) => void,
 ): Map<string, T> {
   const methods = new Map<string, T>();
   const processedKeys = new Set<string>();
@@ -51,7 +57,12 @@ export function collectMethods<T extends (...args: any[]) => Promise<any>>(
     Object.getOwnPropertyNames(target).forEach(key => {
       if (!processedKeys.has(key) && key !== 'constructor') {
         processedKeys.add(key);
-        const value = target[key];
+        const descriptor = Object.getOwnPropertyDescriptor(target, key);
+        if (descriptor?.get && onAccessor) {
+          onAccessor(key, () => obj[key], methods);
+          return;
+        }
+        const value = obj[key];
         if (typeof value === 'function') {
           // Bind method to the original object to preserve 'this' context
           methods.set(key, value.bind(obj) as T);
@@ -161,7 +172,7 @@ export type ApiHooksMapping<
   MethodType extends (...args: any[]) => Promise<any>,
   HookType,
 > = {
-  [K in keyof API as API[K] extends MethodType
-    ? HookName<string & K>
-    : never]: API[K] extends MethodType ? HookType : never;
+  [
+    K in keyof API as API[K] extends MethodType ? HookName<string & K> : never
+  ]: API[K] extends MethodType ? HookType : never;
 };

--- a/packages/react/src/api/createExecuteApiHooks.ts
+++ b/packages/react/src/api/createExecuteApiHooks.ts
@@ -26,7 +26,7 @@ import type {
   FunctionReturnType,
   OnBeforeExecuteCallback,
 } from './apiHooks';
-import { collectMethods, methodNameToHookName } from './apiHooks';
+import { mapApiHooks } from './mapApiHooks';
 
 /**
  * Configuration options for createExecuteApiHooks.
@@ -76,9 +76,9 @@ export interface UseApiMethodExecuteOptions<
  * @template E - The error type for all hooks (defaults to FetcherError).
  */
 export type APIHooks<API extends Record<string, any>, E = FetcherError> = {
-  [K in keyof API as API[K] extends ApiMethod
-    ? HookName<string & K>
-    : never]: API[K] extends ApiMethod
+  [
+    K in keyof API as API[K] extends ApiMethod ? HookName<string & K> : never
+  ]: API[K] extends ApiMethod
     ? (
         options?: UseApiMethodExecuteOptions<
           FunctionParameters<API[K]>,
@@ -202,16 +202,5 @@ export function createExecuteApiHooks<
   API extends Record<string, any>,
   E = FetcherError,
 >(options: CreateExecuteApiHooksOptions<API>): APIHooks<API, E> {
-  const { api } = options;
-
-  const result = {} as any;
-  const methods = collectMethods<(...args: any[]) => Promise<any>>(api);
-
-  // Create hooks for each collected method
-  methods.forEach((boundMethod, methodName) => {
-    const hookName = methodNameToHookName(methodName);
-    result[hookName] = createHookForMethod<E>(boundMethod);
-  });
-
-  return result;
+  return mapApiHooks(options.api, createHookForMethod<E>) as APIHooks<API, E>;
 }

--- a/packages/react/src/api/createQueryApiHooks.ts
+++ b/packages/react/src/api/createQueryApiHooks.ts
@@ -21,7 +21,7 @@ import type {
   QueryMethod,
   OnBeforeExecuteCallback,
 } from './apiHooks';
-import { collectMethods, methodNameToHookName } from './apiHooks';
+import { mapApiHooks } from './mapApiHooks';
 
 /**
  * Configuration options for createQueryApiHooks.
@@ -68,9 +68,9 @@ export interface UseApiMethodQueryOptions<
  * @template E - The error type for all hooks (defaults to FetcherError).
  */
 export type QueryAPIHooks<API extends Record<string, any>, E = FetcherError> = {
-  [K in keyof API as API[K] extends QueryMethod
-    ? HookName<string & K>
-    : never]: API[K] extends QueryMethod<infer Q, infer R>
+  [
+    K in keyof API as API[K] extends QueryMethod ? HookName<string & K> : never
+  ]: API[K] extends QueryMethod<infer Q, infer R>
     ? (options?: UseApiMethodQueryOptions<Q, R, E>) => UseQueryReturn<Q, R, E>
     : never;
 };
@@ -175,23 +175,8 @@ export function createQueryApiHooks<
   API extends Record<string, any>,
   E = FetcherError,
 >(options: CreateQueryApiHooksOptions<API>): QueryAPIHooks<API, E> {
-  const { api } = options;
-
-  const result = {} as any;
-  const methods =
-    collectMethods<
-      (
-        query: any,
-        attributes?: Record<string, any>,
-        abortController?: AbortController,
-      ) => Promise<any>
-    >(api);
-
-  // Create hooks for each collected method
-  methods.forEach((boundMethod, methodName) => {
-    const hookName = methodNameToHookName(methodName);
-    result[hookName] = createQueryHookForMethod<E>(boundMethod);
-  });
-
-  return result;
+  return mapApiHooks(options.api, createQueryHookForMethod<E>) as QueryAPIHooks<
+    API,
+    E
+  >;
 }

--- a/packages/react/src/api/mapApiHooks.ts
+++ b/packages/react/src/api/mapApiHooks.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { collectMethods, methodNameToHookName } from './apiHooks';
+import type { ApiMethod } from './apiHooks';
+
+/** Maps API methods to hooks, resolving accessors on access or enumeration. */
+export function mapApiHooks<Method extends ApiMethod, Hook>(
+  api: Record<string, unknown>,
+  createHook: (method: Method) => Hook,
+): Record<string, Hook> {
+  const hooks: Record<string, Hook> = {};
+  const mappedMethods = new Set<string>();
+  // ponytail: O(methods * accessors); add a per-method callback only
+  // if profiling large APIs shows a bottleneck.
+  const mapMethods = (methods: ReadonlyMap<string, Method>) => {
+    methods.forEach((method, name) => {
+      if (mappedMethods.has(name)) return;
+      mappedMethods.add(name);
+      Object.defineProperty(hooks, methodNameToHookName(name), {
+        value: createHook(method),
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    });
+  };
+  const methods = collectMethods<Method>(api, (name, get, priorMethods) => {
+    mapMethods(priorMethods);
+    const hookName = methodNameToHookName(name);
+    const previous = Object.getOwnPropertyDescriptor(hooks, hookName);
+    Object.defineProperty(hooks, hookName, {
+      configurable: true,
+      get() {
+        const method = get();
+        if (typeof method !== 'function') {
+          if (previous?.get) return previous.get();
+          if (previous) {
+            hooks[hookName] = previous.value;
+            return previous.value;
+          }
+          delete hooks[hookName];
+          return undefined;
+        }
+        const hook = createHook(method.bind(api) as Method);
+        hooks[hookName] = hook;
+        return hook;
+      },
+      set(hook: Hook) {
+        Object.defineProperty(hooks, hookName, {
+          value: hook,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
+      },
+    });
+  });
+  mapMethods(methods);
+  return new Proxy(hooks, {
+    has(target, key) {
+      if (Reflect.getOwnPropertyDescriptor(target, key)?.get) {
+        Reflect.get(target, key);
+      }
+      return Reflect.has(target, key);
+    },
+    getOwnPropertyDescriptor(target, key) {
+      if (Reflect.getOwnPropertyDescriptor(target, key)?.get) {
+        Reflect.get(target, key);
+      }
+      return Reflect.getOwnPropertyDescriptor(target, key);
+    },
+    ownKeys(target) {
+      for (const key of Reflect.ownKeys(target)) {
+        if (Reflect.getOwnPropertyDescriptor(target, key)?.get) {
+          Reflect.get(target, key);
+        }
+      }
+      return Reflect.ownKeys(target);
+    },
+  });
+}

--- a/packages/react/src/core/debounced/index.ts
+++ b/packages/react/src/core/debounced/index.ts
@@ -11,6 +11,10 @@
  * limitations under the License.
  */
 
-export * from './useDebouncedCallback';
+export { useDebouncedCallback } from './useDebouncedCallback';
+export type {
+  UseDebouncedCallbackOptions,
+  UseDebouncedCallbackReturn,
+} from './useDebouncedCallback';
 export * from './useDebouncedExecutePromise';
 export * from './useDebouncedQuery';

--- a/packages/react/src/core/debounced/useDebouncedCallback.ts
+++ b/packages/react/src/core/debounced/useDebouncedCallback.ts
@@ -88,6 +88,22 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
   callback: T,
   options: UseDebouncedCallbackOptions,
 ): UseDebouncedCallbackReturn<T> {
+  const {
+    run,
+    cancel: cancelInternal,
+    isPending,
+  } = useDebouncedCallbackInternal(callback, options);
+  const cancel = useCallback(() => cancelInternal(), [cancelInternal]);
+  return useMemo(() => ({ run, cancel, isPending }), [run, cancel, isPending]);
+}
+
+/** @internal Automatic query cancellation can also reset the leading window. */
+export function useDebouncedCallbackInternal<T extends (...args: any[]) => any>(
+  callback: T,
+  options: UseDebouncedCallbackOptions,
+): Omit<UseDebouncedCallbackReturn<T>, 'cancel'> & {
+  readonly cancel: (resetLeading?: boolean) => void;
+} {
   if (options.leading === false && options.trailing === false) {
     throw new Error(
       'useDebouncedCallback: at least one of leading or trailing must be true',
@@ -167,16 +183,20 @@ export function useDebouncedCallback<T extends (...args: any[]) => any>(
       scheduleTrailing,
     ],
   );
-  const cancel = useCallback(() => {
-    cleanTimeout();
-    lastArgsRef.current = null;
-  }, [cleanTimeout]);
+  const cancel = useCallback(
+    (resetLeading = false) => {
+      cleanTimeout();
+      lastArgsRef.current = null;
+      if (resetLeading) lastInvokeTimeRef.current = null;
+    },
+    [cleanTimeout],
+  );
   const isPending = useCallback(() => {
     return timeoutRef.current !== undefined;
   }, []);
   useEffect(() => {
     return () => {
-      cancel();
+      cancel(true);
     };
   }, [cancel]);
 

--- a/packages/react/src/core/debounced/useDebouncedQuery.ts
+++ b/packages/react/src/core/debounced/useDebouncedQuery.ts
@@ -15,8 +15,9 @@ import type { FetcherError } from '@ahoo-wang/fetcher';
 import type { UseQueryOptions, UseQueryReturn } from '../index';
 import { useQuery } from '../index';
 import type { DebounceCapable, UseDebouncedCallbackReturn } from '../index';
-import { useDebouncedCallback } from '../index';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useDebouncedCallbackInternal } from './useDebouncedCallback';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { dequal } from 'dequal';
 
 /**
  * Configuration options for the useDebouncedQuery hook
@@ -140,6 +141,8 @@ export function useDebouncedQuery<Q, R, E = FetcherError>(
   options: UseDebouncedQueryOptions<Q, R, E>,
 ): UseDebouncedQueryReturn<Q, R, E> {
   const originalAutoExecute = options.autoExecute;
+  const hasQuery = 'query' in options;
+  const hasQueryToExecute = options.query !== undefined || !hasQuery;
   const debouncedExecuteOptions = {
     ...options,
     autoExecute: false,
@@ -155,24 +158,111 @@ export function useDebouncedQuery<Q, R, E = FetcherError>(
     getQuery,
     setQuery,
   } = useQuery(debouncedExecuteOptions);
-  const { run, cancel, isPending } = useDebouncedCallback(
-    execute,
-    options.debounce,
+  type AutomaticQuery = { query: Q | undefined; invoked: boolean };
+  const automaticallyScheduled = useRef<AutomaticQuery | undefined>(undefined);
+  const invokeScheduled = useCallback(
+    (automatic?: AutomaticQuery) => {
+      if (automatic) automatic.invoked = true;
+      return execute();
+    },
+    [execute],
   );
+  const {
+    run: schedule,
+    cancel: cancelScheduled,
+    isPending,
+  } = useDebouncedCallbackInternal(invokeScheduled, options.debounce);
+  const cancel = useCallback(() => {
+    automaticallyScheduled.current = undefined;
+    cancelScheduled();
+  }, [cancelScheduled]);
+  const cancelAutomatic = useCallback(() => {
+    automaticallyScheduled.current = undefined;
+    cancelScheduled(true);
+  }, [cancelScheduled]);
+  const scheduleAutomatically = useCallback(
+    (query: Q | undefined) => {
+      const previous = automaticallyScheduled.current;
+      const automatic = { query, invoked: false };
+      automaticallyScheduled.current = automatic;
+      schedule(automatic);
+      if (
+        automaticallyScheduled.current === automatic &&
+        !automatic.invoked &&
+        !isPending()
+      ) {
+        // A suppressed call owns no timer; retain only an already invoked automatic call.
+        automaticallyScheduled.current = previous?.invoked
+          ? previous
+          : undefined;
+      }
+    },
+    [schedule, isPending],
+  );
+  const run = useCallback(() => {
+    automaticallyScheduled.current = undefined;
+    schedule();
+  }, [schedule]);
   const setQueryFn = useCallback(
     (query: Q) => {
       setQuery(query);
       if (originalAutoExecute) {
-        run();
+        scheduleAutomatically(query);
       }
     },
-    [setQuery, run, originalAutoExecute],
+    [setQuery, scheduleAutomatically, originalAutoExecute],
+  );
+  const lastExecution = useRef({
+    autoExecute: false,
+    hasQuery,
+    query: options.query,
+  });
+  useEffect(
+    () => () => {
+      // The debounce cleanup cancels pending work, including StrictMode replay.
+      lastExecution.current.autoExecute = false;
+      automaticallyScheduled.current = undefined;
+    },
+    [],
   );
   useEffect(() => {
-    if (originalAutoExecute) {
-      run();
+    const previous = lastExecution.current;
+    lastExecution.current = {
+      autoExecute: !!originalAutoExecute,
+      hasQuery,
+      query: options.query,
+    };
+    if (
+      (!originalAutoExecute && previous.autoExecute) ||
+      (originalAutoExecute && !hasQueryToExecute)
+    ) {
+      if (automaticallyScheduled.current) cancelAutomatic();
+    } else if (
+      originalAutoExecute &&
+      hasQueryToExecute &&
+      (!previous.autoExecute ||
+        previous.hasQuery !== hasQuery ||
+        !dequal(previous.query, options.query))
+    ) {
+      if (
+        previous.autoExecute &&
+        previous.hasQuery === hasQuery &&
+        automaticallyScheduled.current &&
+        dequal(automaticallyScheduled.current.query, options.query)
+      ) {
+        return;
+      }
+      scheduleAutomatically(getQuery());
     }
-  }, [run, originalAutoExecute]);
+  }, [
+    scheduleAutomatically,
+    cancelAutomatic,
+    originalAutoExecute,
+    hasQuery,
+    hasQueryToExecute,
+    options.query,
+    getQuery,
+  ]);
   return useMemo(
     () => ({
       loading,

--- a/packages/react/src/core/index.ts
+++ b/packages/react/src/core/index.ts
@@ -21,4 +21,9 @@ export * from './useMounted';
 export * from './useRefs';
 export * from './useForceUpdate';
 export * from './useQuery';
-export * from './useQueryState';
+export { useQueryState, isValidateQuery } from './useQueryState';
+export type {
+  QueryOptions,
+  UseQueryStateOptions,
+  UseQueryStateReturn,
+} from './useQueryState';

--- a/packages/react/src/core/useExecutePromise.ts
+++ b/packages/react/src/core/useExecutePromise.ts
@@ -223,6 +223,7 @@ export function useExecutePromise<R = unknown, E = FetcherError>(
   const isMounted = useMounted();
   const requestId = useRequestId();
   const abortControllerRef = useRef<AbortController | undefined>(undefined);
+  const resetOnMountRequestIdRef = useRef<number | undefined>(undefined);
   const propagateError = options?.propagateError;
   const onAbortRef = useLatest(options?.onAbort);
   const handleOnAbort = useCallback(async () => {
@@ -243,19 +244,23 @@ export function useExecutePromise<R = unknown, E = FetcherError>(
    */
   const execute = useCallback(
     async (input: PromiseSupplier<R>): Promise<void> => {
+      const currentRequestId = requestId.generate();
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
         await handleOnAbort();
+        if (!requestId.isLatest(currentRequestId)) {
+          return;
+        }
       }
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
-      const currentRequestId = requestId.generate();
       setLoading();
       try {
         const data = await input(abortController);
 
         if (isMounted() && requestId.isLatest(currentRequestId)) {
-          await setSuccess(data);
+          if (abortController.signal.aborted) setIdle();
+          else await setSuccess(data);
         }
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') {
@@ -265,12 +270,20 @@ export function useExecutePromise<R = unknown, E = FetcherError>(
           return;
         }
         if (isMounted() && requestId.isLatest(currentRequestId)) {
-          await setError(err as E);
+          if (abortController.signal.aborted) setIdle();
+          else await setError(err as E);
         }
         if (propagateError) {
           throw err;
         }
       } finally {
+        if (
+          isMounted() &&
+          requestId.isLatest(currentRequestId) &&
+          abortController.signal.aborted
+        ) {
+          setIdle();
+        }
         if (abortControllerRef.current === abortController) {
           abortControllerRef.current = undefined;
         }
@@ -305,6 +318,15 @@ export function useExecutePromise<R = unknown, E = FetcherError>(
    * Safe to call even when no operation is currently running.
    */
   const abort = useCallback(async () => {
+    const previousRequestId = requestId.current();
+    requestId.invalidate();
+    if (
+      !isMounted() &&
+      (abortControllerRef.current ||
+        resetOnMountRequestIdRef.current === previousRequestId)
+    ) {
+      resetOnMountRequestIdRef.current = requestId.current();
+    }
     reset();
     if (!abortControllerRef.current) {
       return;
@@ -312,13 +334,21 @@ export function useExecutePromise<R = unknown, E = FetcherError>(
     abortControllerRef.current.abort();
     abortControllerRef.current = undefined;
     await handleOnAbort();
-  }, [reset, handleOnAbort]);
+  }, [reset, handleOnAbort, requestId, isMounted]);
 
   useEffect(() => {
+    const cancelledRequestId = resetOnMountRequestIdRef.current;
+    resetOnMountRequestIdRef.current = undefined;
+    if (
+      cancelledRequestId !== undefined &&
+      requestId.isLatest(cancelledRequestId)
+    ) {
+      reset();
+    }
     return () => {
       abort();
     };
-  }, [abort]);
+  }, [abort, requestId, reset]);
   return useMemo(
     () => ({
       loading,

--- a/packages/react/src/core/useQuery.ts
+++ b/packages/react/src/core/useQuery.ts
@@ -21,7 +21,7 @@ import { useExecutePromise, useLatest, isValidateQuery } from './index';
 import { useCallback, useMemo } from 'react';
 import type { AttributesCapable, FetcherError } from '@ahoo-wang/fetcher';
 import type { UseQueryStateReturn } from './useQueryState';
-import { useQueryState } from './useQueryState';
+import { useCancellableQueryState } from './useQueryState';
 import type { AutoExecuteCapable } from '../types';
 
 /**
@@ -132,7 +132,7 @@ export function useQuery<Q, R, E = FetcherError>(
     [promiseExecutor, latestOptionsRef],
   );
 
-  const { getQuery, setQuery } = useQueryState({
+  const { getQuery, setQuery } = useCancellableQueryState({
     initialQuery: options.initialQuery,
     query: options.query,
     autoExecute: options.autoExecute,

--- a/packages/react/src/core/useQueryState.ts
+++ b/packages/react/src/core/useQueryState.ts
@@ -113,6 +113,20 @@ export interface UseQueryStateReturn<Q> {
 export function useQueryState<Q>(
   options: UseQueryStateOptions<Q>,
 ): UseQueryStateReturn<Q> {
+  return useQueryStateInternal(options, false);
+}
+
+/** @internal Query state for hooks that cancel executions during cleanup. */
+export function useCancellableQueryState<Q>(
+  options: UseQueryStateOptions<Q>,
+): UseQueryStateReturn<Q> {
+  return useQueryStateInternal(options, true);
+}
+
+function useQueryStateInternal<Q>(
+  options: UseQueryStateOptions<Q>,
+  resetOnCleanup: boolean,
+): UseQueryStateReturn<Q> {
   const { initialQuery, query, autoExecute = true, execute } = options;
   const queryOptions = query ?? initialQuery;
   const queryRef = useRef<Q>(queryOptions);
@@ -148,6 +162,15 @@ export function useQueryState<Q>(
   // autoExecute false→true flip (case b) still issues a request even when the
   // query content is unchanged.
   const lastExecuteWrapperRef = useRef(executeWrapper);
+
+  useEffect(
+    () => () => {
+      if (resetOnCleanup) {
+        lastCommittedQueryRef.current = undefined;
+      }
+    },
+    [resetOnCleanup],
+  );
 
   useEffect(() => {
     const configChanged = lastExecuteWrapperRef.current !== executeWrapper;

--- a/packages/react/src/fetcher/debounced/useDebouncedFetcherQuery.ts
+++ b/packages/react/src/fetcher/debounced/useDebouncedFetcherQuery.ts
@@ -13,8 +13,9 @@
 
 import type { FetcherError } from '@ahoo-wang/fetcher';
 import type { DebounceCapable, UseDebouncedCallbackReturn } from '../../core';
-import { useDebouncedCallback } from '../../core';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useDebouncedCallbackInternal } from '../../core/debounced/useDebouncedCallback';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { dequal } from 'dequal';
 import type { UseFetcherQueryOptions, UseFetcherQueryReturn } from '../index';
 import { useFetcherQuery } from '../index';
 
@@ -145,6 +146,8 @@ export function useDebouncedFetcherQuery<Q, R, E = FetcherError>(
   options: UseDebouncedFetcherQueryOptions<Q, R, E>,
 ): UseDebouncedFetcherQueryReturn<Q, R, E> {
   const originalAutoExecute = options.autoExecute;
+  const hasQuery = 'query' in options;
+  const hasQueryToExecute = options.query !== undefined || !hasQuery;
   const debouncedExecuteOptions = {
     ...options,
     autoExecute: false,
@@ -160,24 +163,111 @@ export function useDebouncedFetcherQuery<Q, R, E = FetcherError>(
     getQuery,
     setQuery,
   } = useFetcherQuery(debouncedExecuteOptions);
-  const { run, cancel, isPending } = useDebouncedCallback(
-    execute,
-    options.debounce,
+  type AutomaticQuery = { query: Q | undefined; invoked: boolean };
+  const automaticallyScheduled = useRef<AutomaticQuery | undefined>(undefined);
+  const invokeScheduled = useCallback(
+    (automatic?: AutomaticQuery) => {
+      if (automatic) automatic.invoked = true;
+      return execute();
+    },
+    [execute],
   );
+  const {
+    run: schedule,
+    cancel: cancelScheduled,
+    isPending,
+  } = useDebouncedCallbackInternal(invokeScheduled, options.debounce);
+  const cancel = useCallback(() => {
+    automaticallyScheduled.current = undefined;
+    cancelScheduled();
+  }, [cancelScheduled]);
+  const cancelAutomatic = useCallback(() => {
+    automaticallyScheduled.current = undefined;
+    cancelScheduled(true);
+  }, [cancelScheduled]);
+  const scheduleAutomatically = useCallback(
+    (query: Q | undefined) => {
+      const previous = automaticallyScheduled.current;
+      const automatic = { query, invoked: false };
+      automaticallyScheduled.current = automatic;
+      schedule(automatic);
+      if (
+        automaticallyScheduled.current === automatic &&
+        !automatic.invoked &&
+        !isPending()
+      ) {
+        // A suppressed call owns no timer; retain only an already invoked automatic call.
+        automaticallyScheduled.current = previous?.invoked
+          ? previous
+          : undefined;
+      }
+    },
+    [schedule, isPending],
+  );
+  const run = useCallback(() => {
+    automaticallyScheduled.current = undefined;
+    schedule();
+  }, [schedule]);
   const setQueryFn = useCallback(
     (query: Q) => {
       setQuery(query);
       if (originalAutoExecute) {
-        run();
+        scheduleAutomatically(query);
       }
     },
-    [setQuery, run, originalAutoExecute],
+    [setQuery, scheduleAutomatically, originalAutoExecute],
+  );
+  const lastExecution = useRef({
+    autoExecute: false,
+    hasQuery,
+    query: options.query,
+  });
+  useEffect(
+    () => () => {
+      // The debounce cleanup cancels pending work, including StrictMode replay.
+      lastExecution.current.autoExecute = false;
+      automaticallyScheduled.current = undefined;
+    },
+    [],
   );
   useEffect(() => {
-    if (originalAutoExecute) {
-      run();
+    const previous = lastExecution.current;
+    lastExecution.current = {
+      autoExecute: !!originalAutoExecute,
+      hasQuery,
+      query: options.query,
+    };
+    if (
+      (!originalAutoExecute && previous.autoExecute) ||
+      (originalAutoExecute && !hasQueryToExecute)
+    ) {
+      if (automaticallyScheduled.current) cancelAutomatic();
+    } else if (
+      originalAutoExecute &&
+      hasQueryToExecute &&
+      (!previous.autoExecute ||
+        previous.hasQuery !== hasQuery ||
+        !dequal(previous.query, options.query))
+    ) {
+      if (
+        previous.autoExecute &&
+        previous.hasQuery === hasQuery &&
+        automaticallyScheduled.current &&
+        dequal(automaticallyScheduled.current.query, options.query)
+      ) {
+        return;
+      }
+      scheduleAutomatically(getQuery());
     }
-  }, [run, originalAutoExecute]);
+  }, [
+    scheduleAutomatically,
+    cancelAutomatic,
+    originalAutoExecute,
+    hasQuery,
+    hasQueryToExecute,
+    options.query,
+    getQuery,
+  ]);
   return useMemo(
     () => ({
       loading,

--- a/packages/react/src/fetcher/useFetcher.ts
+++ b/packages/react/src/fetcher/useFetcher.ts
@@ -25,7 +25,7 @@ import type {
 } from '../core';
 import { useExecutePromise } from '../core';
 import { useCallback, useState, useMemo } from 'react';
-import { useLatest } from '../core';
+import { useLatest, useMounted, useRequestId } from '../core';
 
 /**
  * Configuration options for the useFetcher hook.
@@ -176,6 +176,8 @@ export function useFetcher<R, E = FetcherError>(
     undefined,
   );
   const latestOptions = useLatest(options);
+  const requestId = useRequestId();
+  const isMounted = useMounted();
   const currentFetcher = getFetcher(fetcher);
   /**
    * Execute the fetch operation with automatic abort support.
@@ -184,22 +186,45 @@ export function useFetcher<R, E = FetcherError>(
    */
   const execute = useCallback(
     async (request: FetchRequest) => {
+      const currentRequestId = requestId.generate();
+      let signal: AbortSignal | undefined;
       try {
         await promiseExecutor(async abortController => {
+          signal = abortController.signal;
           request.abortController = abortController;
           const exchange = await currentFetcher.exchange(
             request,
             latestOptions.current,
           );
-          setExchange(exchange);
+          if (
+            isMounted() &&
+            !abortController.signal.aborted &&
+            requestId.isLatest(currentRequestId)
+          ) {
+            setExchange(exchange);
+          }
           return await exchange.extractResult<R>();
         });
       } catch (error) {
-        setExchange(undefined);
+        if (
+          isMounted() &&
+          !signal?.aborted &&
+          requestId.isLatest(currentRequestId)
+        ) {
+          setExchange(undefined);
+        }
         throw error;
+      } finally {
+        if (
+          isMounted() &&
+          requestId.isLatest(currentRequestId) &&
+          signal?.aborted
+        ) {
+          setExchange(undefined);
+        }
       }
     },
-    [promiseExecutor, currentFetcher, latestOptions],
+    [promiseExecutor, currentFetcher, latestOptions, requestId, isMounted],
   );
 
   const resetFn = useCallback(() => {
@@ -207,9 +232,10 @@ export function useFetcher<R, E = FetcherError>(
     setExchange(undefined);
   }, [reset]);
   const abortFn = useCallback(() => {
+    requestId.invalidate();
     abort();
     setExchange(undefined);
-  }, [abort]);
+  }, [abort, requestId]);
   return useMemo(
     () => ({
       loading,

--- a/packages/react/src/fetcher/useFetcherQuery.ts
+++ b/packages/react/src/fetcher/useFetcherQuery.ts
@@ -16,7 +16,8 @@ import { useFetcher } from './index';
 import type { FetcherError, FetchRequest } from '@ahoo-wang/fetcher';
 import { JsonResultExtractor } from '@ahoo-wang/fetcher';
 import type { QueryOptions, UseQueryStateReturn } from '../core';
-import { isValidateQuery, useLatest, useQueryState } from '../core';
+import { isValidateQuery, useLatest } from '../core';
+import { useCancellableQueryState } from '../core/useQueryState';
 import { useCallback, useMemo } from 'react';
 import type { AutoExecuteCapable } from '../types';
 
@@ -151,7 +152,7 @@ export function useFetcherQuery<Q, R, E = FetcherError>(
     [fetcherExecute, latestOptionsRef],
   );
 
-  const { getQuery, setQuery } = useQueryState({
+  const { getQuery, setQuery } = useCancellableQueryState({
     initialQuery: useFetcherQueryOptions.initialQuery,
     query: useFetcherQueryOptions.query,
     autoExecute: useFetcherQueryOptions.autoExecute,

--- a/packages/react/src/storage/useImmerKeyStorage.ts
+++ b/packages/react/src/storage/useImmerKeyStorage.ts
@@ -11,10 +11,14 @@
  * limitations under the License.
  */
 
-import { useCallback } from 'react';
+import { createRef, useCallback, useInsertionEffect, useMemo } from 'react';
 import type { KeyStorage } from '@ahoo-wang/fetcher-storage';
 import { useKeyStorage } from './useKeyStorage';
 import { produce } from 'immer';
+
+function createStorageDefaults<T>(storage: KeyStorage<T>) {
+  return { storage, defaultValueRef: createRef<T | undefined>() };
+}
 
 export function useImmerKeyStorage<T>(
   keyStorage: KeyStorage<T>,
@@ -136,16 +140,28 @@ export function useImmerKeyStorage<T>(
     keyStorage,
     defaultValue as T,
   );
+  // Retained updaters keep the defaults committed for their own storage.
+  const { storage, defaultValueRef } = useMemo(
+    () => createStorageDefaults(keyStorage),
+    [keyStorage],
+  );
+  // Publish committed defaults before any descendant layout effect can update.
+  useInsertionEffect(() => {
+    defaultValueRef.current = defaultValue;
+  }, [defaultValueRef, defaultValue]);
   const updateImmer = useCallback(
     (updater: (draft: T | null) => T | null | void) => {
-      const nextValue = produce(value, updater);
+      const storedValue = storage.get();
+      const currentValue =
+        storedValue === null ? (defaultValueRef.current ?? null) : storedValue;
+      const nextValue = produce(currentValue, updater);
       if (nextValue === null) {
         remove();
         return;
       }
       return setValue(nextValue);
     },
-    [value, setValue, remove],
+    [storage, defaultValueRef, setValue, remove],
   );
 
   return [value, updateImmer, remove];

--- a/packages/react/test/api/apiHooks.test.ts
+++ b/packages/react/test/api/apiHooks.test.ts
@@ -95,3 +95,130 @@ describe('apiHooks utilities', () => {
     });
   });
 });
+
+it('collects function-valued getters with the public single-argument utility', async () => {
+  class Api {
+    prefix = 'instance';
+    get load() {
+      return async function (this: Api, id: string) {
+        return `${this.prefix}:${id}`;
+      };
+    }
+    get ready() {
+      return true;
+    }
+  }
+  const methods = collectMethods(new Api());
+  expect([...methods.keys()]).toEqual(['load']);
+  await expect(methods.get('load')?.('direct')).resolves.toBe(
+    'instance:direct',
+  );
+});
+
+it('collects ordinary properties through a Proxy get trap', async () => {
+  const api = new Proxy(
+    { prefix: 'instance', load: undefined },
+    {
+      get(target, key, receiver) {
+        if (key === 'load') {
+          return async function (this: { prefix: string }, id: string) {
+            return `${this.prefix}:${id}`;
+          };
+        }
+        return Reflect.get(target, key, receiver);
+      },
+    },
+  );
+  const methods = collectMethods(api);
+  expect([...methods.keys()]).toEqual(['load']);
+  await expect(methods.get('load')?.('proxy')).resolves.toBe('instance:proxy');
+});
+
+it('keeps two-argument accessor callbacks lazy and separate from ordinary methods', () => {
+  let reads = 0;
+  const lazyMethods = new Map<string, () => unknown>();
+  const methods = collectMethods(
+    {
+      async first() {
+        return 'first';
+      },
+      get load() {
+        reads++;
+        return async () => 'loaded';
+      },
+      async last() {
+        return 'last';
+      },
+    },
+    (name, get) => lazyMethods.set(name, get),
+  );
+  expect(reads).toBe(0);
+  expect([...methods.keys()]).toEqual(['first', 'last']);
+  expect([...lazyMethods.keys()]).toEqual(['load']);
+  expect(lazyMethods.get('load')?.()).toBeTypeOf('function');
+  expect(reads).toBe(1);
+});
+
+it.each(['own', 'inherited'])(
+  'collects %s accessors through a Proxy get trap',
+  async placement => {
+    const reads = { getter: 0, proxy: 0 };
+    class Api {
+      prefix = 'instance';
+      get load() {
+        reads.getter++;
+        return undefined;
+      }
+    }
+    const target = new Api();
+    if (placement === 'own') {
+      Object.defineProperty(
+        target,
+        'load',
+        Object.getOwnPropertyDescriptor(Api.prototype, 'load')!,
+      );
+    }
+    const api = new Proxy(target, {
+      get(target, key, receiver) {
+        if (key === 'load') {
+          reads.proxy++;
+          return async function (this: Api, id: string) {
+            return `${this.prefix}:${id}`;
+          };
+        }
+        return Reflect.get(target, key, receiver);
+      },
+    });
+    const methods = collectMethods(api);
+    expect([...methods.keys()]).toEqual(['load']);
+    await expect(methods.get('load')?.('proxy')).resolves.toBe(
+      'instance:proxy',
+    );
+    expect(reads).toEqual({ getter: 0, proxy: 1 });
+  },
+);
+
+it('collects inherited ordinary properties through the original Proxy', async () => {
+  let reads = 0;
+  class Api {
+    prefix = 'instance';
+    async load() {
+      return 'prototype';
+    }
+  }
+  const api = new Proxy(new Api(), {
+    get(target, key, receiver) {
+      if (key === 'load') {
+        reads++;
+        return async function (this: Api, id: string) {
+          return `${this.prefix}:${id}`;
+        };
+      }
+      return Reflect.get(target, key, receiver);
+    },
+  });
+  const methods = collectMethods(api);
+  expect([...methods.keys()]).toEqual(['load']);
+  await expect(methods.get('load')?.('proxy')).resolves.toBe('instance:proxy');
+  expect(reads).toBe(1);
+});

--- a/packages/react/test/api/mapApiHooks.test.ts
+++ b/packages/react/test/api/mapApiHooks.test.ts
@@ -1,0 +1,425 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { createExecuteApiHooks, createQueryApiHooks } from '../../src/api';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+it.each([
+  [createExecuteApiHooks, 'in'],
+  [createQueryApiHooks, 'in'],
+  [createExecuteApiHooks, 'own'],
+  [createQueryApiHooks, 'own'],
+  [createExecuteApiHooks, 'descriptor'],
+  [createQueryApiHooks, 'descriptor'],
+] as const)(
+  'reports only real getter hooks at the first reflection lookup %#',
+  (createHooks, reflection) => {
+    const reads = { ready: 0, load: 0 };
+    const hooks = createHooks({
+      api: {
+        get ready() {
+          reads.ready++;
+          return true;
+        },
+        get load() {
+          reads.load++;
+          return async () => 'loaded';
+        },
+        async other() {
+          return 'other';
+        },
+      },
+    });
+    const exists = (key: string) =>
+      reflection === 'in'
+        ? key in hooks
+        : reflection === 'own'
+          ? Object.hasOwn(hooks, key)
+          : Object.getOwnPropertyDescriptor(hooks, key) !== undefined;
+    expect(reads).toEqual({ ready: 0, load: 0 });
+    expect(exists('useReady')).toBe(false);
+    expect(exists('useReady')).toBe(false);
+    expect(reads).toEqual({ ready: 1, load: 0 });
+    expect(exists('useLoad')).toBe(true);
+    expect(exists('useLoad')).toBe(true);
+    const load = hooks.useLoad;
+    expect(load).toBeTypeOf('function');
+    expect(hooks.useLoad).toBe(load);
+    expect(exists('useOther')).toBe(true);
+    expect(Object.keys(hooks)).toEqual(['useLoad', 'useOther']);
+    expect(reads).toEqual({ ready: 1, load: 1 });
+  },
+);
+
+it.each([createExecuteApiHooks, createQueryApiHooks])(
+  'collects API methods without evaluating accessors',
+  createHooks => {
+    class Api {
+      state = { ready: true };
+      get ready() {
+        return this.state.ready;
+      }
+      async list() {
+        return [];
+      }
+    }
+    const hooks = createHooks({ api: new Api() });
+    expect(Object.keys(hooks)).toEqual(['useList']);
+    expect(hooks.useList).toBeTypeOf('function');
+  },
+);
+
+it.each([createExecuteApiHooks, createQueryApiHooks])(
+  'keeps a method hook when a non-function getter maps to the same name',
+  createHooks => {
+    const hooks = createHooks({
+      api: {
+        async load() {
+          return 'loaded';
+        },
+        get Load() {
+          return false;
+        },
+      },
+    });
+    expect(Object.keys(hooks)).toEqual(['useLoad']);
+    expect(hooks.useLoad).toBeTypeOf('function');
+  },
+);
+
+it.each([createExecuteApiHooks, createQueryApiHooks])(
+  'includes function-valued getters when enumerating or copying generated hooks',
+  createHooks => {
+    let reads = 0;
+    class Api {
+      get load() {
+        reads++;
+        return async () => 'loaded';
+      }
+      get ready() {
+        return true;
+      }
+    }
+    const hooks = createHooks({ api: new Api() });
+    expect(reads).toBe(0);
+    expect(Object.keys(hooks)).toEqual(['useLoad']);
+    expect({ ...hooks }).toEqual({ useLoad: hooks.useLoad });
+    expect(Object.assign({}, hooks)).toEqual({ useLoad: hooks.useLoad });
+    expect(reads).toBe(1);
+  },
+);
+
+it.each([
+  [createExecuteApiHooks, false],
+  [createQueryApiHooks, false],
+  [createExecuteApiHooks, true],
+  [createQueryApiHooks, true],
+] as const)(
+  'allows replacing getter hooks before and after lazy resolution %#',
+  (createHooks, cached) => {
+    let reads = 0;
+    const hooks = createHooks({
+      api: {
+        get load() {
+          reads++;
+          return async () => 'loaded';
+        },
+        async other() {
+          return 'other';
+        },
+      },
+    });
+    if (cached) expect(hooks.useLoad).toBeTypeOf('function');
+    const replacement = createHooks({
+      api: {
+        async other() {
+          return 'replacement';
+        },
+      },
+    }).useOther;
+    hooks.useLoad = replacement;
+    hooks.useOther = replacement;
+    expect(reads).toBe(cached ? 1 : 0);
+    expect(hooks.useLoad).toBe(replacement);
+    expect(hooks.useOther).toBe(replacement);
+    expect({ ...hooks }).toEqual({
+      useLoad: replacement,
+      useOther: replacement,
+    });
+    expect(reads).toBe(cached ? 1 : 0);
+  },
+);
+
+it('lazily exposes function-valued API getters bound to the API instance', async () => {
+  let getterReads = 0;
+  class BaseApi {
+    prefix = 'base';
+    get load() {
+      getterReads++;
+      return async function (this: BaseApi, id: string) {
+        return `${this.prefix}:${id}`;
+      };
+    }
+  }
+  class Api extends BaseApi {
+    prefix = 'instance';
+    get ready(): boolean {
+      throw new Error('Ordinary getters must not run during hook creation');
+    }
+  }
+  const api = new Api();
+  const executeHooks = createExecuteApiHooks({ api });
+  const queryHooks = createQueryApiHooks({ api });
+  expect(getterReads).toBe(0);
+
+  const executor = renderHook(() => executeHooks.useLoad());
+  const query = renderHook(() =>
+    queryHooks.useLoad({ initialQuery: 'query', autoExecute: false }),
+  );
+  await act(async () => {
+    await executor.result.current.execute('execute');
+    await query.result.current.execute();
+  });
+  expect(executor.result.current.result).toBe('instance:execute');
+  expect(query.result.current.result).toBe('instance:query');
+  const executeHook = executeHooks.useLoad;
+  const queryHook = queryHooks.useLoad;
+  expect(executeHooks.useLoad).toBe(executeHook);
+  expect(queryHooks.useLoad).toBe(queryHook);
+  expect(getterReads).toBe(2);
+});
+
+describe.each([createExecuteApiHooks, createQueryApiHooks])(
+  'API hook name collisions %#',
+  createHooks => {
+    it.each([false, true])(
+      'uses the last function when the later getter returns a function: %s',
+      async laterIsFunction => {
+        let reads = 0;
+        const hooks = createHooks({
+          api: {
+            get load() {
+              reads++;
+              return async () => 'first';
+            },
+            get Load() {
+              reads++;
+              return laterIsFunction ? async () => 'last' : false;
+            },
+          },
+        });
+        expect(reads).toBe(0);
+        expect(Object.keys(hooks)).toEqual(['useLoad']);
+        const hook = hooks.useLoad;
+        expect({ ...hooks }).toEqual({ useLoad: hook });
+        expect(Object.assign({}, hooks)).toEqual({ useLoad: hook });
+        const resolvedReads = reads;
+        const { result } = renderHook(() =>
+          hook({ initialQuery: 'query', autoExecute: false }),
+        );
+        await act(async () => {
+          await result.current.execute();
+        });
+        expect(result.current.result).toBe(laterIsFunction ? 'last' : 'first');
+        expect(reads).toBe(resolvedReads);
+      },
+    );
+
+    it('ignores an earlier non-function getter when a later getter returns a method', async () => {
+      let reads = 0;
+      const hooks = createHooks({
+        api: {
+          get load() {
+            reads++;
+            return false;
+          },
+          get Load() {
+            reads++;
+            return async () => 'last';
+          },
+        },
+      });
+      expect(reads).toBe(0);
+      const { result } = renderHook(() =>
+        hooks.useLoad({ initialQuery: 'query', autoExecute: false }),
+      );
+      await act(async () => {
+        await result.current.execute();
+      });
+      expect(result.current.result).toBe('last');
+      expect(Object.keys(hooks)).toEqual(['useLoad']);
+    });
+
+    it.each([false, true])(
+      'preserves method order when an ordinary method precedes a getter returning a function: %s',
+      async laterIsFunction => {
+        let reads = 0;
+        const hooks = createHooks({
+          api: {
+            async load() {
+              return 'first';
+            },
+            get Load() {
+              reads++;
+              return laterIsFunction ? async () => 'last' : false;
+            },
+          },
+        });
+        expect(reads).toBe(0);
+        const { result } = renderHook(() =>
+          hooks.useLoad({ initialQuery: 'query', autoExecute: false }),
+        );
+        await act(async () => {
+          await result.current.execute();
+        });
+        expect(result.current.result).toBe(laterIsFunction ? 'last' : 'first');
+        expect(reads).toBe(1);
+        expect(Object.keys(hooks)).toEqual(['useLoad']);
+      },
+    );
+
+    it('preserves method order when a getter precedes an ordinary method', async () => {
+      let reads = 0;
+      const hooks = createHooks({
+        api: {
+          get load() {
+            reads++;
+            return async () => 'first';
+          },
+          async Load() {
+            return 'last';
+          },
+        },
+      });
+      expect(reads).toBe(0);
+      const { result } = renderHook(() =>
+        hooks.useLoad({ initialQuery: 'query', autoExecute: false }),
+      );
+      await act(async () => {
+        await result.current.execute();
+      });
+      expect(result.current.result).toBe('last');
+      expect(Object.keys(hooks)).toEqual(['useLoad']);
+    });
+
+    it.each(['own', 'inherited'])(
+      'lazily creates hooks for %s accessors through a Proxy get trap',
+      async placement => {
+        const reads = { getter: 0, proxy: 0 };
+        class Api {
+          prefix = 'instance';
+          get load() {
+            reads.getter++;
+            return undefined;
+          }
+        }
+        const target = new Api();
+        if (placement === 'own') {
+          Object.defineProperty(
+            target,
+            'load',
+            Object.getOwnPropertyDescriptor(Api.prototype, 'load')!,
+          );
+        }
+        const api = new Proxy(target, {
+          get(target, key, receiver) {
+            if (key === 'load') {
+              reads.proxy++;
+              return async function (this: Api) {
+                return `${this.prefix}:proxy`;
+              };
+            }
+            return Reflect.get(target, key, receiver);
+          },
+        });
+        const hooks = createHooks({ api });
+        expect(reads).toEqual({ getter: 0, proxy: 0 });
+        expect('useLoad' in hooks).toBe(true);
+        const hook = Reflect.get(hooks, 'useLoad');
+        const { result } = renderHook(() =>
+          hook({ initialQuery: 'query', autoExecute: false }),
+        );
+        await act(async () => {
+          await result.current.execute();
+        });
+        expect(result.current.result).toBe('instance:proxy');
+        expect(Object.keys(hooks)).toEqual(['useLoad']);
+        expect(Reflect.get(hooks, 'useLoad')).toBe(hook);
+        expect(reads).toEqual({ getter: 0, proxy: 1 });
+      },
+    );
+
+    it('creates hooks for inherited ordinary properties through the original Proxy', async () => {
+      let reads = 0;
+      class Api {
+        prefix = 'instance';
+        async load() {
+          return 'prototype';
+        }
+      }
+      const api = new Proxy(new Api(), {
+        get(target, key, receiver) {
+          if (key === 'load') {
+            reads++;
+            return async function (this: Api) {
+              return `${this.prefix}:proxy`;
+            };
+          }
+          return Reflect.get(target, key, receiver);
+        },
+      });
+      const hooks = createHooks({ api });
+      const hook = hooks.useLoad;
+      const { result } = renderHook(() =>
+        hook({ initialQuery: 'query', autoExecute: false }),
+      );
+      await act(async () => {
+        await result.current.execute();
+      });
+      expect(result.current.result).toBe('instance:proxy');
+      expect(Object.keys(hooks)).toEqual(['useLoad']);
+      expect(hooks.useLoad).toBe(hook);
+      expect(reads).toBe(1);
+    });
+
+    it('creates hooks for ordinary API properties supplied by a Proxy get trap', async () => {
+      const api = new Proxy(
+        { prefix: 'instance', load: async () => 'placeholder' },
+        {
+          get(target, key, receiver) {
+            if (key === 'load') {
+              return async function (this: { prefix: string }) {
+                return `${this.prefix}:proxy`;
+              };
+            }
+            return Reflect.get(target, key, receiver);
+          },
+        },
+      );
+      const hooks = createHooks({ api });
+      expect(Object.keys(hooks)).toEqual(['useLoad']);
+      const { result } = renderHook(() =>
+        hooks.useLoad({ initialQuery: 'query', autoExecute: false }),
+      );
+      await act(async () => {
+        await result.current.execute();
+      });
+      expect(result.current.result).toBe('instance:proxy');
+    });
+  },
+);

--- a/packages/react/test/core/debounced/useDebouncedCallback.test.ts
+++ b/packages/react/test/core/debounced/useDebouncedCallback.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useDebouncedCallback } from '../../../src';
+import { useDebouncedCallbackInternal } from '../../../src/core/debounced/useDebouncedCallback';
 
 describe('useDebouncedCallback', () => {
   beforeEach(() => {
@@ -352,4 +353,75 @@ describe('useDebouncedCallback', () => {
       'useDebouncedCallback: at least one of leading or trailing must be true',
     );
   });
+  it.each([false, true])(
+    'keeps the leading window across explicit cancel and rerender (trailing: %s)',
+    trailing => {
+      vi.setSystemTime(1000);
+      const callback = vi.fn();
+      const { result, rerender } = renderHook(() =>
+        useDebouncedCallback(callback, { delay: 100, leading: true, trailing }),
+      );
+      act(() => result.current.run('first'));
+      act(() => result.current.cancel());
+      rerender();
+      act(() => result.current.run('second'));
+      expect(callback).toHaveBeenCalledExactlyOnceWith('first');
+      expect(result.current.isPending()).toBe(trailing);
+      act(() => vi.advanceTimersByTime(100));
+      expect(callback).toHaveBeenCalledTimes(trailing ? 2 : 1);
+      expect(result.current.isPending()).toBe(false);
+    },
+  );
+});
+
+it.each([true, 'event'] as const)(
+  'preserves the public cancel cooldown when used as a callback receiving %s',
+  argument => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const callback = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useDebouncedCallback(callback, {
+        delay: 100,
+        leading: true,
+        trailing: false,
+      }),
+    );
+    try {
+      const cancelHandler: (value: unknown) => void = result.current.cancel;
+      act(() => {
+        result.current.run('first');
+        cancelHandler(argument === true ? true : new Event('click'));
+        result.current.run('second');
+      });
+      expect(callback).toHaveBeenCalledExactlyOnceWith('first');
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
+  },
+);
+
+it('internal cancellation starts a fresh leading window and keeps the run return value unchanged', () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1000);
+  const callback = vi.fn();
+  const { result, unmount } = renderHook(() =>
+    useDebouncedCallbackInternal(callback, {
+      delay: 100,
+      leading: true,
+      trailing: false,
+    }),
+  );
+  try {
+    act(() => {
+      expect(result.current.run('first')).toBeUndefined();
+      result.current.cancel(true);
+      expect(result.current.run('second')).toBeUndefined();
+    });
+    expect(callback.mock.calls).toEqual([['first'], ['second']]);
+  } finally {
+    unmount();
+    vi.useRealTimers();
+  }
 });

--- a/packages/react/test/core/debounced/useDebouncedQuery.regression.test.ts
+++ b/packages/react/test/core/debounced/useDebouncedQuery.regression.test.ts
@@ -1,0 +1,466 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StrictMode, useState } from 'react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { useDebouncedQuery } from '../../../src/core/debounced/useDebouncedQuery';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+it.each([
+  ['query', false],
+  ['query', true],
+] as const)(
+  'tracks %s query mode when both values are undefined (starts controlled: %s)',
+  async (kind, startsControlled) => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const initialQuery = { search: 'initial' };
+    const { result, rerender } = renderHook(
+      ({ controlled }) => {
+        const options = {
+          initialQuery,
+          ...(controlled ? { query: undefined } : {}),
+          autoExecute: true,
+          debounce: { delay: 10 },
+        };
+        return useDebouncedQuery({ ...options, execute });
+      },
+      { initialProps: { controlled: startsControlled } },
+    );
+    expect(result.current.isPending()).toBe(!startsControlled);
+    rerender({ controlled: !startsControlled });
+    expect(result.current.isPending()).toBe(startsControlled);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual(startsControlled ? [{ search: 'initial' }] : []);
+    rerender({ controlled: startsControlled });
+    expect(result.current.isPending()).toBe(!startsControlled);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'initial' }]);
+  },
+);
+
+it.each(['query'] as const)(
+  'does not restart a cleared controlled %s query when auto execution is re-enabled',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const { result, rerender } = renderHook(
+      ({
+        query,
+        enabled,
+      }: {
+        query:
+          | {
+              search: string;
+            }
+          | undefined;
+        enabled: boolean;
+      }) =>
+        useDebouncedQuery({
+          query,
+          execute,
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      {
+        initialProps: {
+          query: { search: 'previous' } as { search: string } | undefined,
+          enabled: false,
+        },
+      },
+    );
+    rerender({ query: undefined, enabled: false });
+    rerender({ query: undefined, enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([]);
+    expect(result.current.isPending()).toBe(false);
+    act(() => result.current.run());
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'previous' }]);
+    rerender({ query: { search: 'current' }, enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'previous' }, { search: 'current' }]);
+  },
+);
+
+it.each(['query'] as const)(
+  'keeps uncontrolled %s initialQuery execution across automatic toggles',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const initialQuery = { search: 'initial' };
+    const { rerender } = renderHook(
+      ({ enabled }) =>
+        useDebouncedQuery({
+          initialQuery,
+          execute,
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      { initialProps: { enabled: false } },
+    );
+    rerender({ enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'initial' }]);
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'initial' }, { search: 'initial' }]);
+  },
+);
+
+it.each(['query'] as const)(
+  'debounces controlled %s changes and ignores equal values',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const useSelectedQuery = (query: { search: string }) =>
+      useDebouncedQuery({
+        query,
+        execute,
+        autoExecute: true,
+        debounce: { delay: 10 },
+      });
+    const { rerender } = renderHook(({ query }) => useSelectedQuery(query), {
+      initialProps: { query: { search: 'a' } },
+    });
+    await act(() => vi.advanceTimersByTimeAsync(10));
+    rerender({ query: { search: 'b' } });
+    await act(() => vi.advanceTimersByTimeAsync(10));
+    expect(queries).toEqual([{ search: 'a' }, { search: 'b' }]);
+    rerender({ query: { search: 'b' } });
+    await act(() => vi.advanceTimersByTimeAsync(10));
+    expect(queries).toHaveLength(2);
+  },
+);
+
+it.each(['query'] as const)(
+  'cancels stale debounced %s work when the controlled query is cleared',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const { result, rerender } = renderHook(
+      ({
+        query,
+      }: {
+        query:
+          | {
+              search: string;
+            }
+          | undefined;
+      }) =>
+        useDebouncedQuery({
+          query,
+          execute,
+          autoExecute: true,
+          debounce: { delay: 10 },
+        }),
+      {
+        initialProps: {
+          query: { search: 'pending' } as { search: string } | undefined,
+        },
+      },
+    );
+    rerender({ query: undefined });
+    expect(result.current.isPending()).toBe(false);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([]);
+    rerender({ query: { search: 'current' } });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'current' }]);
+    rerender({ query: undefined });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'current' }]);
+  },
+);
+
+it.each(['query'] as const)(
+  'cancels automatic %s work created by setQuery after a manual run',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const initialQuery = { search: 'initial' };
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useDebouncedQuery({
+          initialQuery,
+          execute,
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      { initialProps: { enabled: true } },
+    );
+    act(() => {
+      result.current.run();
+      result.current.setQuery({ search: 'automatic' });
+    });
+    rerender({ enabled: false });
+    expect(result.current.isPending()).toBe(false);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([]);
+  },
+);
+
+it.each(['query'] as const)(
+  'runs the initial debounced %s once under StrictMode',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const { rerender } = renderHook(
+      ({ query }) =>
+        useDebouncedQuery({
+          query,
+          execute,
+          autoExecute: true,
+          debounce: { delay: 10 },
+        }),
+      { initialProps: { query: { search: 'a' } }, wrapper: StrictMode },
+    );
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'a' }]);
+    rerender({ query: { search: 'a' } });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toHaveLength(1);
+  },
+);
+
+it.each(['query'] as const)(
+  'cancels automatic %s scheduling while preserving manual runs and re-enabling',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const { result, rerender } = renderHook(
+      ({ query, enabled }) =>
+        useDebouncedQuery({
+          query,
+          execute,
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      { initialProps: { query: { search: 'a' }, enabled: true } },
+    );
+    expect(result.current.isPending()).toBe(true);
+    rerender({ query: { search: 'a' }, enabled: false });
+    expect(result.current.isPending()).toBe(false);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([]);
+    act(() => result.current.run());
+    rerender({ query: { search: 'a' }, enabled: false });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'a' }]);
+    rerender({ query: { search: 'b' }, enabled: false });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toHaveLength(1);
+    rerender({ query: { search: 'b' }, enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'a' }, { search: 'b' }]);
+  },
+);
+
+it.each([
+  ['query', 'disable'],
+  ['query', 'clear'],
+] as const)(
+  'preserves a pending manual %s run when automatic scheduling changes: %s',
+  async (kind, change) => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: unknown) => {
+      queries.push(query);
+      return query;
+    };
+    const query = { search: 'manual' };
+    const { result, rerender } = renderHook(
+      ({
+        query,
+        enabled,
+      }: {
+        query:
+          | {
+              search: string;
+            }
+          | undefined;
+        enabled: boolean;
+      }) =>
+        useDebouncedQuery({
+          query,
+          execute,
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      {
+        initialProps: {
+          query: query as { search: string } | undefined,
+          enabled: true,
+        },
+      },
+    );
+    const run = result.current.run;
+    act(() => run());
+    rerender({
+      query: change === 'clear' ? undefined : query,
+      enabled: change !== 'disable',
+    });
+    expect(result.current.run).toBe(run);
+    expect(result.current.isPending()).toBe(true);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'manual' }]);
+  },
+);
+
+it.each([false, true])(
+  'does not repeat a controlled setQuery on the trailing edge (StrictMode: %s)',
+  async strict => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const execute = async (query: { search: string }) => {
+      queries.push(query);
+      return query;
+    };
+    const { result } = renderHook(
+      () => {
+        const [query, setControlledQuery] = useState({ search: 'initial' });
+        const hook = useDebouncedQuery({
+          query,
+          execute,
+          autoExecute: true,
+          debounce: { delay: 10, leading: true, trailing: true },
+        });
+        return { ...hook, setControlledQuery };
+      },
+      { wrapper: strict ? StrictMode : undefined },
+    );
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    queries.length = 0;
+    await act(async () => {
+      result.current.setQuery({ search: 'updated' });
+      result.current.setControlledQuery({ search: 'updated' });
+    });
+    expect(queries).toEqual([{ search: 'updated' }]);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'updated' }]);
+    await act(async () => {
+      result.current.setControlledQuery({ search: 'external' });
+    });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'updated' }, { search: 'external' }]);
+  },
+);
+
+it.each([
+  'public cancel',
+  'controlled clear',
+  'suppressed leading',
+  'auto toggle',
+  'suppressed then toggle',
+] as const)(
+  'restores cancelled or suppressed automatic scheduling: %s',
+  async scenario => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const queries: string[] = [];
+    const execute = async (query: { search: string }) => {
+      queries.push(query.search);
+      return query;
+    };
+    const leading =
+      scenario === 'suppressed leading' ||
+      scenario === 'auto toggle' ||
+      scenario === 'suppressed then toggle';
+    const debounce = { delay: 100, leading, trailing: !leading };
+    const { result, rerender } = renderHook(
+      ({
+        query,
+        enabled,
+      }: {
+        query: { search: string } | undefined;
+        enabled: boolean;
+      }) =>
+        useDebouncedQuery({ query, execute, autoExecute: enabled, debounce }),
+      {
+        initialProps: {
+          query: { search: 'A' } as { search: string } | undefined,
+          enabled: true,
+        },
+      },
+    );
+    await act(async () => {});
+    if (scenario === 'public cancel') {
+      act(() => {
+        result.current.setQuery({ search: 'B' });
+        result.current.cancel();
+      });
+      rerender({ query: { search: 'B' }, enabled: true });
+    } else if (scenario === 'controlled clear') {
+      rerender({ query: undefined, enabled: true });
+      rerender({ query: { search: 'A' }, enabled: true });
+    } else if (scenario === 'suppressed leading') {
+      act(() => result.current.setQuery({ search: 'B' }));
+      expect(result.current.isPending()).toBe(false);
+      await act(() => vi.advanceTimersByTimeAsync(101));
+      rerender({ query: { search: 'B' }, enabled: true });
+    } else {
+      if (scenario === 'suppressed then toggle') {
+        act(() => result.current.setQuery({ search: 'B' }));
+      }
+      rerender({ query: { search: 'A' }, enabled: false });
+      rerender({ query: { search: 'A' }, enabled: true });
+    }
+    await act(() => vi.advanceTimersByTimeAsync(101));
+    expect(queries).toEqual(
+      scenario === 'public cancel'
+        ? ['B']
+        : scenario === 'controlled clear'
+          ? ['A']
+          : scenario === 'auto toggle'
+            ? ['A', 'A']
+            : ['A', 'B'],
+    );
+  },
+);

--- a/packages/react/test/core/debounced/useDebouncedQuery.strictMode.test.ts
+++ b/packages/react/test/core/debounced/useDebouncedQuery.strictMode.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StrictMode } from 'react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { useDebouncedQuery } from '../../../src/core/debounced/useDebouncedQuery';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+it.each([false, true])(
+  'restarts leading query immediately after StrictMode cleanup (trailing: %s)',
+  async trailing => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const requests: {
+      signal: AbortSignal;
+      resolve: (value: string) => void;
+    }[] = [];
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const onAbort = vi.fn();
+    const execute = (
+      _query: { id: number },
+      _attributes: unknown,
+      controller?: AbortController,
+    ) =>
+      new Promise<string>(resolve =>
+        requests.push({ signal: controller!.signal, resolve }),
+      );
+    const { result, rerender } = renderHook(
+      ({ query }) =>
+        useDebouncedQuery({
+          query,
+          execute,
+          autoExecute: true,
+          debounce: { delay: 100, leading: true, trailing },
+          onSuccess,
+          onError,
+          onAbort,
+        }),
+      { initialProps: { query: { id: 1 } }, wrapper: StrictMode },
+    );
+    await act(async () => {});
+    expect(requests).toHaveLength(2);
+    expect(requests[0].signal.aborted).toBe(true);
+    expect(requests[1].signal.aborted).toBe(false);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.isPending()).toBe(false);
+    await act(async () => requests[1].resolve('current'));
+    expect(result.current.result).toBe('current');
+    expect(result.current.loading).toBe(false);
+    rerender({ query: { id: 1 } });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+    expect(requests).toHaveLength(2);
+    await act(async () => requests[0].resolve('obsolete'));
+    expect(result.current.result).toBe('current');
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.status).toBe('success');
+    expect(onSuccess).toHaveBeenCalledExactlyOnceWith('current');
+    expect(onError).not.toHaveBeenCalled();
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  },
+);

--- a/packages/react/test/core/debounced/useDebouncedQuery.test.ts
+++ b/packages/react/test/core/debounced/useDebouncedQuery.test.ts
@@ -21,11 +21,11 @@ vi.mock('../../../src/core/useQuery', () => ({
 }));
 
 vi.mock('../../../src/core/debounced/useDebouncedCallback', () => ({
-  useDebouncedCallback: vi.fn(),
+  useDebouncedCallbackInternal: vi.fn(),
 }));
 
 import { useQuery } from '../../../src/core/useQuery';
-import { useDebouncedCallback } from '../../../src/core/debounced/useDebouncedCallback';
+import { useDebouncedCallbackInternal as useDebouncedCallback } from '../../../src/core/debounced/useDebouncedCallback';
 
 describe('useDebouncedQuery', () => {
   const mockResult = { id: 1, name: 'Test Item' };
@@ -81,8 +81,10 @@ describe('useDebouncedQuery', () => {
     expect(result.current).toHaveProperty('abort', expect.any(Function)); // abort function from useExecutePromise
     expect(result.current).toHaveProperty('getQuery', mockGetQuery);
     expect(result.current).toHaveProperty('setQuery', expect.any(Function)); // setQuery function from useQueryState
-    expect(result.current).toHaveProperty('run', mockDebouncedReturn.run);
-    expect(result.current).toHaveProperty('cancel', mockDebouncedReturn.cancel);
+    expect(result.current).toHaveProperty('run', expect.any(Function));
+    expect(result.current).toHaveProperty('cancel', expect.any(Function));
+    act(() => result.current.cancel());
+    expect(mockDebouncedReturn.cancel).toHaveBeenCalledExactlyOnceWith();
     expect(result.current).toHaveProperty(
       'isPending',
       mockDebouncedReturn.isPending,
@@ -107,9 +109,11 @@ describe('useDebouncedQuery', () => {
       }),
     );
     expect(useDebouncedCallback).toHaveBeenCalledWith(
-      mockExecute,
+      expect.any(Function),
       options.debounce,
     );
+    vi.mocked(useDebouncedCallback).mock.lastCall![0]();
+    expect(mockExecute).toHaveBeenCalledExactlyOnceWith();
   });
 
   it('should expose debounced run method for executing queries', () => {

--- a/packages/react/test/core/useExecutePromise.strictMode.test.ts
+++ b/packages/react/test/core/useExecutePromise.strictMode.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { StrictMode, useEffect, useRef } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { useExecutePromise } from '../../src/core/useExecutePromise';
+import { PromiseStatus } from '../../src/core/usePromiseState';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+it.each([
+  ['success', false],
+  ['success', true],
+  ['error', false],
+  ['error', true],
+  ['AbortError', false],
+  ['AbortError', true],
+] as const)(
+  'keeps externally aborted %s out of state with propagateError=%s',
+  async (outcome, propagateError) => {
+    const pending = deferred<string>();
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const onAbort = vi.fn();
+    const { result } = renderHook(
+      () =>
+        useExecutePromise<string>({
+          propagateError,
+          onSuccess,
+          onError,
+          onAbort,
+        }),
+      { wrapper: StrictMode },
+    );
+    let controller!: AbortController;
+    let execution!: Promise<void | Error>;
+    act(() => {
+      execution = result.current
+        .execute(current => {
+          controller = current;
+          return pending.promise;
+        })
+        .catch((error: Error) => error);
+      controller.abort();
+    });
+    const failure = new Error('cancelled supplier failure');
+    if (outcome === 'AbortError') failure.name = 'AbortError';
+    await act(async () => {
+      if (outcome === 'success') pending.resolve('cancelled value');
+      else pending.reject(failure);
+      expect(await execution).toBe(
+        outcome === 'error' && propagateError ? failure : undefined,
+      );
+    });
+    expect(result.current.status).toBe(PromiseStatus.IDLE);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(onAbort).not.toHaveBeenCalled();
+  },
+);
+
+it.each(['success', 'failure'] as const)(
+  'returns to idle after StrictMode cancellation and ignores late %s',
+  async outcome => {
+    const pending = deferred<string>();
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    let signal!: AbortSignal;
+    let execution!: Promise<void>;
+    const { result } = renderHook(
+      () => {
+        const hook = useExecutePromise<string>({ onSuccess, onError });
+        const started = useRef(false);
+        useEffect(() => {
+          if (started.current) return;
+          started.current = true;
+          execution = hook.execute(controller => {
+            signal = controller.signal;
+            return pending.promise;
+          });
+        }, [hook.execute]);
+        return hook;
+      },
+      { wrapper: StrictMode },
+    );
+    expect(signal.aborted).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe(PromiseStatus.IDLE);
+    await act(async () => {
+      if (outcome === 'success') pending.resolve('stale');
+      else pending.reject(new Error('stale'));
+      await execution;
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe(PromiseStatus.IDLE);
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  },
+);
+
+it('preserves the initial status when StrictMode has no request to cancel', () => {
+  const onAbort = vi.fn();
+  const { result } = renderHook(
+    () => useExecutePromise({ initialStatus: PromiseStatus.SUCCESS, onAbort }),
+    { wrapper: StrictMode },
+  );
+  expect(result.current.status).toBe(PromiseStatus.SUCCESS);
+  expect(result.current.loading).toBe(false);
+  expect(onAbort).not.toHaveBeenCalled();
+});
+
+it('keeps the request started by a reentrant onAbort while its callback is pending', async () => {
+  const stale = deferred<string>();
+  const current = deferred<string>();
+  const callback = deferred<void>();
+  let execute!: ReturnType<typeof useExecutePromise<string>>['execute'];
+  let staleExecution!: Promise<void>;
+  let currentExecution!: Promise<void>;
+  const onSuccess = vi.fn();
+  const onAbort = vi.fn(() => {
+    currentExecution = execute(() => current.promise);
+    return callback.promise;
+  });
+  const { result } = renderHook(
+    () => {
+      const hook = useExecutePromise<string>({ onSuccess, onAbort });
+      const started = useRef(false);
+      useEffect(() => {
+        execute = hook.execute;
+        if (started.current) return;
+        started.current = true;
+        staleExecution = hook.execute(() => stale.promise);
+      }, [hook.execute]);
+      return hook;
+    },
+    { wrapper: StrictMode },
+  );
+  expect(onAbort).toHaveBeenCalledTimes(1);
+  expect(result.current.loading).toBe(true);
+  await act(async () => {
+    current.resolve('current');
+    await currentExecution;
+  });
+  expect(result.current.status).toBe(PromiseStatus.SUCCESS);
+  expect(result.current.result).toBe('current');
+  await act(async () => {
+    callback.resolve();
+    stale.resolve('stale');
+    await staleExecution;
+  });
+  expect(result.current.loading).toBe(false);
+  expect(result.current.status).toBe(PromiseStatus.SUCCESS);
+  expect(result.current.result).toBe('current');
+  expect(onSuccess).toHaveBeenCalledExactlyOnceWith('current');
+});
+
+it.each([
+  ['success', false],
+  ['success', true],
+  ['error', false],
+  ['error', true],
+] as const)(
+  'settles externally aborted async %s callbacks as idle with propagateError=%s',
+  async (outcome, propagateError) => {
+    const callbackStarted = deferred<void>();
+    const callbackFinished = deferred<void>();
+    const callback = vi.fn(async () => {
+      callbackStarted.resolve();
+      await callbackFinished.promise;
+    });
+    const onSuccess = outcome === 'success' ? callback : vi.fn();
+    const onError = outcome === 'error' ? callback : vi.fn();
+    const onAbort = vi.fn();
+    const { result } = renderHook(
+      () =>
+        useExecutePromise<string, Error>({
+          propagateError,
+          onSuccess,
+          onError,
+          onAbort,
+        }),
+      { wrapper: StrictMode },
+    );
+    const failure = new Error('supplier failed');
+    let controller!: AbortController;
+    let execution!: Promise<void | Error>;
+    await act(async () => {
+      execution = result.current
+        .execute(async current => {
+          controller = current;
+          if (outcome === 'error') throw failure;
+          return 'completed';
+        })
+        .catch((error: Error) => error);
+      await callbackStarted.promise;
+    });
+    expect(result.current.status).toBe(outcome);
+    act(() => controller.abort());
+    await act(async () => {
+      callbackFinished.resolve();
+      expect(await execution).toBe(
+        outcome === 'error' && propagateError ? failure : undefined,
+      );
+    });
+    expect(result.current.status).toBe(PromiseStatus.IDLE);
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(onAbort).not.toHaveBeenCalled();
+  },
+);

--- a/packages/react/test/core/useExecutePromise.test.ts
+++ b/packages/react/test/core/useExecutePromise.test.ts
@@ -373,3 +373,33 @@ describe('useExecutePromise', () => {
     consoleWarnSpy.mockRestore();
   });
 });
+
+it.each(['success', 'failure'] as const)(
+  'ignores late %s after manual abort',
+  async outcome => {
+    let resolve!: (value: string) => void;
+    let reject!: (error: Error) => void;
+    let execution!: Promise<void>;
+    const { result } = renderHook(() => useExecutePromise<string>());
+    act(() => {
+      execution = result.current.execute(
+        () =>
+          new Promise((yes, no) => {
+            resolve = yes;
+            reject = no;
+          }),
+      );
+    });
+    await act(async () => {
+      await result.current.abort();
+    });
+    await act(async () => {
+      if (outcome === 'success') resolve('obsolete');
+      else reject(new Error('obsolete'));
+      await execution;
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+  },
+);

--- a/packages/react/test/core/useQuery.strictMode.test.ts
+++ b/packages/react/test/core/useQuery.strictMode.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { StrictMode } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { useQuery } from '../../src/core/useQuery';
+
+it.each(['success', 'abort'] as const)(
+  'finishes automatic useQuery after StrictMode replay and ignores late %s',
+  async outcome => {
+    const requests: {
+      signal: AbortSignal;
+      resolve: (value: string) => void;
+      reject: (reason: Error) => void;
+    }[] = [];
+    const successes: string[] = [];
+    const errors: unknown[] = [];
+    const execute = (
+      _query: { id: number },
+      _attributes?: Record<string, unknown>,
+      controller?: AbortController,
+    ) =>
+      new Promise<string>((resolve, reject) => {
+        requests.push({ signal: controller!.signal, resolve, reject });
+      });
+    const { result, rerender } = renderHook(
+      () =>
+        useQuery({
+          query: { id: 1 },
+          autoExecute: true,
+          execute,
+          onSuccess: value => {
+            successes.push(value);
+          },
+          onError: error => {
+            errors.push(error);
+          },
+        }),
+      { wrapper: StrictMode },
+    );
+    await act(async () => {});
+    expect(result.current.loading).toBe(true);
+    await act(async () => {
+      requests[requests.length - 1].resolve('current');
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe('success');
+    expect(result.current.result).toBe('current');
+    expect(requests).toHaveLength(2);
+    expect(requests[0].signal.aborted).toBe(true);
+    await act(async () => {
+      if (outcome === 'success') requests[0].resolve('obsolete');
+      else
+        requests[0].reject(
+          Object.assign(new Error('obsolete'), { name: 'AbortError' }),
+        );
+    });
+    rerender();
+    expect(requests).toHaveLength(2);
+    expect(result.current.result).toBe('current');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+    expect(successes).toEqual(['current']);
+    expect(errors).toEqual([]);
+  },
+);

--- a/packages/react/test/core/useQueryState.test.ts
+++ b/packages/react/test/core/useQueryState.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { renderHook, act } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { useQueryState } from '../../src';
 
@@ -626,4 +627,30 @@ describe('useQueryState', () => {
       });
     });
   });
+});
+
+it('does not replay an uncancelled standalone query under StrictMode', async () => {
+  const pending: (() => void)[] = [];
+  const completed: string[] = [];
+  const execute = vi.fn(async (query: { id: string }) => {
+    await new Promise<void>(resolve => pending.push(resolve));
+    completed.push(query.id);
+  });
+  const { rerender } = renderHook(
+    ({ query }) => useQueryState({ query, autoExecute: true, execute }),
+    { initialProps: { query: { id: 'first' } }, wrapper: StrictMode },
+  );
+  expect(execute).toHaveBeenCalledTimes(1);
+  rerender({ query: { id: 'first' } });
+  expect(execute).toHaveBeenCalledTimes(1);
+  await act(async () => {
+    pending[0]();
+  });
+  expect(completed).toEqual(['first']);
+  rerender({ query: { id: 'next' } });
+  expect(execute).toHaveBeenCalledTimes(2);
+  await act(async () => {
+    pending[1]();
+  });
+  expect(completed).toEqual(['first', 'next']);
 });

--- a/packages/react/test/fetcher/debounced/useDebouncedFetcherQuery.regression.test.ts
+++ b/packages/react/test/fetcher/debounced/useDebouncedFetcherQuery.regression.test.ts
@@ -1,0 +1,507 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StrictMode, useState } from 'react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { Fetcher } from '@ahoo-wang/fetcher';
+import { useDebouncedFetcherQuery } from '../../../src/fetcher/debounced/useDebouncedFetcherQuery';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+it.each([
+  ['fetcher', false],
+  ['fetcher', true],
+] as const)(
+  'tracks %s query mode when both values are undefined (starts controlled: %s)',
+  async (kind, startsControlled) => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const initialQuery = { search: 'initial' };
+    const { result, rerender } = renderHook(
+      ({ controlled }) => {
+        const options = {
+          initialQuery,
+          ...(controlled ? { query: undefined } : {}),
+          autoExecute: true,
+          debounce: { delay: 10 },
+        };
+        return useDebouncedFetcherQuery({
+          ...options,
+          fetcher: client,
+          url: '/search',
+        });
+      },
+      { initialProps: { controlled: startsControlled } },
+    );
+    expect(result.current.isPending()).toBe(!startsControlled);
+    rerender({ controlled: !startsControlled });
+    expect(result.current.isPending()).toBe(startsControlled);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual(startsControlled ? [{ search: 'initial' }] : []);
+    rerender({ controlled: startsControlled });
+    expect(result.current.isPending()).toBe(!startsControlled);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'initial' }]);
+  },
+);
+
+it.each(['fetcher'] as const)(
+  'does not restart a cleared controlled %s query when auto execution is re-enabled',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const { result, rerender } = renderHook(
+      ({
+        query,
+        enabled,
+      }: {
+        query:
+          | {
+              search: string;
+            }
+          | undefined;
+        enabled: boolean;
+      }) =>
+        useDebouncedFetcherQuery({
+          query,
+          fetcher: client,
+          url: '/search',
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      {
+        initialProps: {
+          query: { search: 'previous' } as { search: string } | undefined,
+          enabled: false,
+        },
+      },
+    );
+    rerender({ query: undefined, enabled: false });
+    rerender({ query: undefined, enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([]);
+    expect(result.current.isPending()).toBe(false);
+    act(() => result.current.run());
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'previous' }]);
+    rerender({ query: { search: 'current' }, enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'previous' }, { search: 'current' }]);
+  },
+);
+
+it.each(['fetcher'] as const)(
+  'keeps uncontrolled %s initialQuery execution across automatic toggles',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const initialQuery = { search: 'initial' };
+    const { rerender } = renderHook(
+      ({ enabled }) =>
+        useDebouncedFetcherQuery({
+          initialQuery,
+          fetcher: client,
+          url: '/search',
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      { initialProps: { enabled: false } },
+    );
+    rerender({ enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'initial' }]);
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'initial' }, { search: 'initial' }]);
+  },
+);
+
+it.each(['fetcher'] as const)(
+  'debounces controlled %s changes and ignores equal values',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const useSelectedQuery = (query: { search: string }) =>
+      useDebouncedFetcherQuery({
+        query,
+        fetcher: client,
+        url: '/search',
+        autoExecute: true,
+        debounce: { delay: 10 },
+      });
+    const { rerender } = renderHook(({ query }) => useSelectedQuery(query), {
+      initialProps: { query: { search: 'a' } },
+    });
+    await act(() => vi.advanceTimersByTimeAsync(10));
+    rerender({ query: { search: 'b' } });
+    await act(() => vi.advanceTimersByTimeAsync(10));
+    expect(queries).toEqual([{ search: 'a' }, { search: 'b' }]);
+    rerender({ query: { search: 'b' } });
+    await act(() => vi.advanceTimersByTimeAsync(10));
+    expect(queries).toHaveLength(2);
+  },
+);
+
+it.each(['fetcher'] as const)(
+  'cancels stale debounced %s work when the controlled query is cleared',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const { result, rerender } = renderHook(
+      ({
+        query,
+      }: {
+        query:
+          | {
+              search: string;
+            }
+          | undefined;
+      }) =>
+        useDebouncedFetcherQuery({
+          query,
+          fetcher: client,
+          url: '/search',
+          autoExecute: true,
+          debounce: { delay: 10 },
+        }),
+      {
+        initialProps: {
+          query: { search: 'pending' } as { search: string } | undefined,
+        },
+      },
+    );
+    rerender({ query: undefined });
+    expect(result.current.isPending()).toBe(false);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([]);
+    rerender({ query: { search: 'current' } });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'current' }]);
+    rerender({ query: undefined });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'current' }]);
+  },
+);
+
+it.each(['fetcher'] as const)(
+  'cancels automatic %s work created by setQuery after a manual run',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      queries.push(JSON.parse(init.body as string));
+      return Response.json({});
+    });
+    const initialQuery = { search: 'initial' };
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useDebouncedFetcherQuery({
+          initialQuery,
+          fetcher: client,
+          url: '/search',
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      { initialProps: { enabled: true } },
+    );
+    act(() => {
+      result.current.run();
+      result.current.setQuery({ search: 'automatic' });
+    });
+    rerender({ enabled: false });
+    expect(result.current.isPending()).toBe(false);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([]);
+  },
+);
+
+it.each(['fetcher'] as const)(
+  'runs the initial debounced %s once under StrictMode',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const { rerender } = renderHook(
+      ({ query }) =>
+        useDebouncedFetcherQuery({
+          query,
+          fetcher: client,
+          url: '/search',
+          autoExecute: true,
+          debounce: { delay: 10 },
+        }),
+      { initialProps: { query: { search: 'a' } }, wrapper: StrictMode },
+    );
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'a' }]);
+    rerender({ query: { search: 'a' } });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toHaveLength(1);
+  },
+);
+
+it.each(['fetcher'] as const)(
+  'cancels automatic %s scheduling while preserving manual runs and re-enabling',
+  async () => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const { result, rerender } = renderHook(
+      ({ query, enabled }) =>
+        useDebouncedFetcherQuery({
+          query,
+          fetcher: client,
+          url: '/search',
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      { initialProps: { query: { search: 'a' }, enabled: true } },
+    );
+    expect(result.current.isPending()).toBe(true);
+    rerender({ query: { search: 'a' }, enabled: false });
+    expect(result.current.isPending()).toBe(false);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([]);
+    act(() => result.current.run());
+    rerender({ query: { search: 'a' }, enabled: false });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'a' }]);
+    rerender({ query: { search: 'b' }, enabled: false });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toHaveLength(1);
+    rerender({ query: { search: 'b' }, enabled: true });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'a' }, { search: 'b' }]);
+  },
+);
+
+it.each([
+  ['fetcher', 'disable'],
+  ['fetcher', 'clear'],
+] as const)(
+  'preserves a pending manual %s run when automatic scheduling changes: %s',
+  async (kind, change) => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const query = { search: 'manual' };
+    const { result, rerender } = renderHook(
+      ({
+        query,
+        enabled,
+      }: {
+        query:
+          | {
+              search: string;
+            }
+          | undefined;
+        enabled: boolean;
+      }) =>
+        useDebouncedFetcherQuery({
+          query,
+          fetcher: client,
+          url: '/search',
+          autoExecute: enabled,
+          debounce: { delay: 10 },
+        }),
+      {
+        initialProps: {
+          query: query as { search: string } | undefined,
+          enabled: true,
+        },
+      },
+    );
+    const run = result.current.run;
+    act(() => run());
+    rerender({
+      query: change === 'clear' ? undefined : query,
+      enabled: change !== 'disable',
+    });
+    expect(result.current.run).toBe(run);
+    expect(result.current.isPending()).toBe(true);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'manual' }]);
+  },
+);
+
+it.each([false, true])(
+  'does not repeat a controlled setQuery on the trailing edge (StrictMode: %s)',
+  async strict => {
+    vi.useFakeTimers();
+    const queries: unknown[] = [];
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string);
+      queries.push(query);
+      return Response.json(query);
+    });
+    const { result } = renderHook(
+      () => {
+        const [query, setControlledQuery] = useState({ search: 'initial' });
+        const hook = useDebouncedFetcherQuery({
+          query,
+          fetcher: client,
+          url: '/search',
+          autoExecute: true,
+          debounce: { delay: 10, leading: true, trailing: true },
+        });
+        return { ...hook, setControlledQuery };
+      },
+      { wrapper: strict ? StrictMode : undefined },
+    );
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    queries.length = 0;
+    await act(async () => {
+      result.current.setQuery({ search: 'updated' });
+      result.current.setControlledQuery({ search: 'updated' });
+    });
+    expect(queries).toEqual([{ search: 'updated' }]);
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'updated' }]);
+    await act(async () => {
+      result.current.setControlledQuery({ search: 'external' });
+    });
+    await act(() => vi.advanceTimersByTimeAsync(20));
+    expect(queries).toEqual([{ search: 'updated' }, { search: 'external' }]);
+  },
+);
+
+it.each([
+  'public cancel',
+  'controlled clear',
+  'suppressed leading',
+  'auto toggle',
+  'suppressed then toggle',
+] as const)(
+  'restores cancelled or suppressed automatic scheduling: %s',
+  async scenario => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const queries: string[] = [];
+    const fetcher = new Fetcher({ baseURL: 'https://example.test' });
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      const query = JSON.parse(init.body as string) as { search: string };
+      queries.push(query.search);
+      return Response.json(query);
+    });
+    const leading =
+      scenario === 'suppressed leading' ||
+      scenario === 'auto toggle' ||
+      scenario === 'suppressed then toggle';
+    const debounce = { delay: 100, leading, trailing: !leading };
+    const { result, rerender } = renderHook(
+      ({
+        query,
+        enabled,
+      }: {
+        query: { search: string } | undefined;
+        enabled: boolean;
+      }) =>
+        useDebouncedFetcherQuery<{ search: string }, { search: string }>({
+          query,
+          fetcher,
+          url: '/search',
+          autoExecute: enabled,
+          debounce,
+        }),
+      {
+        initialProps: {
+          query: { search: 'A' } as { search: string } | undefined,
+          enabled: true,
+        },
+      },
+    );
+    await act(async () => {});
+    if (scenario === 'public cancel') {
+      act(() => {
+        result.current.setQuery({ search: 'B' });
+        result.current.cancel();
+      });
+      rerender({ query: { search: 'B' }, enabled: true });
+    } else if (scenario === 'controlled clear') {
+      rerender({ query: undefined, enabled: true });
+      rerender({ query: { search: 'A' }, enabled: true });
+    } else if (scenario === 'suppressed leading') {
+      act(() => result.current.setQuery({ search: 'B' }));
+      expect(result.current.isPending()).toBe(false);
+      await act(() => vi.advanceTimersByTimeAsync(101));
+      rerender({ query: { search: 'B' }, enabled: true });
+    } else {
+      if (scenario === 'suppressed then toggle') {
+        act(() => result.current.setQuery({ search: 'B' }));
+      }
+      rerender({ query: { search: 'A' }, enabled: false });
+      rerender({ query: { search: 'A' }, enabled: true });
+    }
+    await act(() => vi.advanceTimersByTimeAsync(101));
+    expect(queries).toEqual(
+      scenario === 'public cancel'
+        ? ['B']
+        : scenario === 'controlled clear'
+          ? ['A']
+          : scenario === 'auto toggle'
+            ? ['A', 'A']
+            : ['A', 'B'],
+    );
+  },
+);

--- a/packages/react/test/fetcher/debounced/useDebouncedFetcherQuery.strictMode.test.ts
+++ b/packages/react/test/fetcher/debounced/useDebouncedFetcherQuery.strictMode.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StrictMode } from 'react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { Fetcher } from '@ahoo-wang/fetcher';
+import { useDebouncedFetcherQuery } from '../../../src/fetcher/debounced/useDebouncedFetcherQuery';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+it.each([false, true])(
+  'restarts leading fetcher query immediately after StrictMode cleanup (trailing: %s)',
+  async trailing => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const requests: {
+      signal: AbortSignal;
+      resolve: (value: Response) => void;
+    }[] = [];
+    vi.stubGlobal(
+      'fetch',
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>(resolve =>
+          requests.push({ signal: init.signal!, resolve }),
+        ),
+    );
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const onAbort = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ query }) =>
+        useDebouncedFetcherQuery<{ id: number }, string>({
+          query,
+          fetcher: client,
+          url: '/leading',
+          autoExecute: true,
+          debounce: { delay: 100, leading: true, trailing },
+          onSuccess,
+          onError,
+          onAbort,
+        }),
+      { initialProps: { query: { id: 1 } }, wrapper: StrictMode },
+    );
+    await act(async () => {});
+    expect(requests).toHaveLength(2);
+    expect(requests[0].signal.aborted).toBe(true);
+    expect(requests[1].signal.aborted).toBe(false);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.isPending()).toBe(false);
+    await act(async () => requests[1].resolve(Response.json('current')));
+    expect(result.current.result).toBe('current');
+    expect(result.current.loading).toBe(false);
+    rerender({ query: { id: 1 } });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+    expect(requests).toHaveLength(2);
+    await act(async () => requests[0].resolve(Response.json('obsolete')));
+    expect(result.current.result).toBe('current');
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.status).toBe('success');
+    expect(onSuccess).toHaveBeenCalledExactlyOnceWith('current');
+    expect(onError).not.toHaveBeenCalled();
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  },
+);

--- a/packages/react/test/fetcher/debounced/useDebouncedFetcherQuery.test.ts
+++ b/packages/react/test/fetcher/debounced/useDebouncedFetcherQuery.test.ts
@@ -22,12 +22,12 @@ vi.mock('../../../src/fetcher/useFetcherQuery', () => ({
   useFetcherQuery: vi.fn(),
 }));
 
-vi.mock('../../../src/core', () => ({
-  useDebouncedCallback: vi.fn(),
+vi.mock('../../../src/core/debounced/useDebouncedCallback', () => ({
+  useDebouncedCallbackInternal: vi.fn(),
 }));
 
 import { useFetcherQuery } from '../../../src/fetcher/useFetcherQuery';
-import { useDebouncedCallback } from '../../../src/core';
+import { useDebouncedCallbackInternal as useDebouncedCallback } from '../../../src/core/debounced/useDebouncedCallback';
 
 const mockUseFetcherQuery = vi.mocked(useFetcherQuery);
 const mockUseDebouncedCallback = vi.mocked(useDebouncedCallback);
@@ -88,15 +88,14 @@ describe('useDebouncedFetcherQuery', () => {
       expect(result.current).toHaveProperty('abort', mockAbort);
       expect(result.current).toHaveProperty('getQuery', mockGetQuery);
       expect(result.current).toHaveProperty('setQuery', expect.any(Function)); // setQuery function from useQueryState
-      expect(result.current).toHaveProperty('run', mockDebouncedReturn.run);
-      expect(result.current).toHaveProperty(
-        'cancel',
-        mockDebouncedReturn.cancel,
-      );
+      expect(result.current).toHaveProperty('run', expect.any(Function));
+      expect(result.current).toHaveProperty('cancel', expect.any(Function));
       expect(result.current).toHaveProperty(
         'isPending',
         mockDebouncedReturn.isPending,
       );
+      act(() => result.current.cancel());
+      expect(mockDebouncedReturn.cancel).toHaveBeenCalledExactlyOnceWith();
       expect(result.current).not.toHaveProperty('execute'); // execute should be omitted
     });
 
@@ -118,9 +117,11 @@ describe('useDebouncedFetcherQuery', () => {
         }),
       );
       expect(mockUseDebouncedCallback).toHaveBeenCalledWith(
-        mockExecute,
+        expect.any(Function),
         options.debounce,
       );
+      mockUseDebouncedCallback.mock.lastCall![0]();
+      expect(mockExecute).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should memoize the return object correctly', () => {
@@ -234,9 +235,11 @@ describe('useDebouncedFetcherQuery', () => {
         renderHook(() => useDebouncedFetcherQuery(options));
 
         expect(mockUseDebouncedCallback).toHaveBeenCalledWith(
-          mockExecute,
+          expect.any(Function),
           debounceConfig,
         );
+        mockUseDebouncedCallback.mock.lastCall![0]();
+        expect(mockExecute).toHaveBeenLastCalledWith();
       });
     });
   });
@@ -382,9 +385,11 @@ describe('useDebouncedFetcherQuery', () => {
         renderHook(() => useDebouncedFetcherQuery(options));
 
         expect(mockUseDebouncedCallback).toHaveBeenCalledWith(
-          mockExecute,
+          expect.any(Function),
           debounce,
         );
+        mockUseDebouncedCallback.mock.lastCall![0]();
+        expect(mockExecute).toHaveBeenLastCalledWith();
       });
     });
 
@@ -523,8 +528,10 @@ describe('useDebouncedFetcherQuery', () => {
       rerender();
 
       // The return object should be different due to memoization dependencies
-      expect(result.current.run).toBe(newRun);
-      expect(result.current.cancel).toBe(newCancel);
+      act(() => result.current.run());
+      expect(newRun).toHaveBeenCalledTimes(1);
+      act(() => result.current.cancel());
+      expect(newCancel).toHaveBeenCalledExactlyOnceWith();
       expect(result.current.isPending).toBe(newIsPending);
     });
   });
@@ -662,9 +669,14 @@ describe('useDebouncedFetcherQuery', () => {
         { initialProps: { delay: 300 } },
       );
 
-      expect(mockUseDebouncedCallback).toHaveBeenCalledWith(mockExecute, {
-        delay: 300,
-      });
+      expect(mockUseDebouncedCallback).toHaveBeenCalledWith(
+        expect.any(Function),
+        {
+          delay: 300,
+        },
+      );
+      mockUseDebouncedCallback.mock.lastCall![0]();
+      expect(mockExecute).toHaveBeenCalledExactlyOnceWith();
 
       mockUseDebouncedCallback.mockClear();
 
@@ -672,9 +684,14 @@ describe('useDebouncedFetcherQuery', () => {
       rerender({ delay: 500 });
 
       // useDebouncedCallback should be called again with new config
-      expect(mockUseDebouncedCallback).toHaveBeenCalledWith(mockExecute, {
-        delay: 500,
-      });
+      expect(mockUseDebouncedCallback).toHaveBeenCalledWith(
+        expect.any(Function),
+        {
+          delay: 500,
+        },
+      );
+      mockUseDebouncedCallback.mock.lastCall![0]();
+      expect(mockExecute).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/react/test/fetcher/useFetcher.strictMode.test.ts
+++ b/packages/react/test/fetcher/useFetcher.strictMode.test.ts
@@ -1,0 +1,479 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { StrictMode, useEffect, useRef } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { Fetcher, FetchExchange } from '@ahoo-wang/fetcher';
+import type { FetchRequest } from '@ahoo-wang/fetcher';
+import { useFetcher } from '../../src/fetcher/useFetcher';
+
+function createDeferredFetcher() {
+  const client = new Fetcher();
+  let resolve!: (exchange: FetchExchange) => void;
+  let reject!: (error: Error) => void;
+  const exchange = vi.spyOn(client, 'exchange').mockImplementation(
+    () =>
+      new Promise<FetchExchange>((yes, no) => {
+        resolve = yes;
+        reject = no;
+      }),
+  );
+  return {
+    client,
+    exchange,
+    resolve: (value: FetchExchange) => resolve(value),
+    reject: (error: Error) => reject(error),
+  };
+}
+
+it.each(['success', 'failure'] as const)(
+  'does not publish a late %s after the attached request controller is externally aborted',
+  async outcome => {
+    const deferred = createDeferredFetcher();
+    const request: FetchRequest = { url: '/externally-aborted' };
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const { result } = renderHook(
+      () =>
+        useFetcher<string>({
+          fetcher: deferred.client,
+          propagateError: true,
+          onSuccess,
+          onError,
+        }),
+      { wrapper: StrictMode },
+    );
+    let execution!: Promise<void | Error>;
+    act(() => {
+      execution = result.current
+        .execute(request)
+        .catch((error: Error) => error);
+      request.abortController!.abort();
+    });
+    expect(request.abortController?.signal.aborted).toBe(true);
+    const failure = new Error('late extraction failure');
+    const exchange = new FetchExchange({
+      fetcher: deferred.client,
+      request,
+      resultExtractor: () => {
+        if (outcome === 'failure') throw failure;
+        return 'late value';
+      },
+    });
+    await act(async () => {
+      deferred.resolve(exchange);
+      expect(await execution).toBe(outcome === 'failure' ? failure : undefined);
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.exchange).toBeUndefined();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  },
+);
+
+it.each(['success', 'failure'] as const)(
+  'ignores an exchange returned after StrictMode cleanup with late %s',
+  async outcome => {
+    const deferred = createDeferredFetcher();
+    const request: FetchRequest = { url: '/once' };
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const onAbort = vi.fn();
+    let execution!: Promise<void>;
+    const { result } = renderHook(
+      () => {
+        const fetcher = useFetcher<string>({
+          fetcher: deferred.client,
+          onSuccess,
+          onError,
+          onAbort,
+        });
+        const started = useRef(false);
+        useEffect(() => {
+          if (started.current) return;
+          started.current = true;
+          execution = fetcher.execute(request);
+        }, [fetcher.execute]);
+        return fetcher;
+      },
+      { wrapper: StrictMode },
+    );
+    expect(deferred.exchange).toHaveBeenCalledTimes(1);
+    expect(request.abortController?.signal.aborted).toBe(true);
+    expect(onAbort).toHaveBeenCalledTimes(1);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe('idle');
+    const exchange = new FetchExchange({
+      fetcher: deferred.client,
+      request,
+      resultExtractor: () => {
+        if (outcome === 'failure') throw new Error('obsolete extraction');
+        return 'obsolete';
+      },
+    });
+    await act(async () => {
+      deferred.resolve(exchange);
+      await execution;
+    });
+    expect(result.current.exchange).toBeUndefined();
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe('idle');
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  },
+);
+
+it.each(['abort', 'reset'] as const)(
+  'preserves %s behavior when the fetcher ignores cancellation',
+  async action => {
+    const deferred = createDeferredFetcher();
+    const request: FetchRequest = { url: '/pending' };
+    const onSuccess = vi.fn();
+    const onAbort = vi.fn();
+    const { result } = renderHook(() =>
+      useFetcher<string>({ fetcher: deferred.client, onSuccess, onAbort }),
+    );
+    let execution!: Promise<void>;
+    act(() => {
+      execution = result.current.execute(request);
+    });
+    act(() => result.current[action]());
+    expect(result.current.status).toBe('idle');
+    expect(request.abortController?.signal.aborted).toBe(action === 'abort');
+    const exchange = new FetchExchange({
+      fetcher: deferred.client,
+      request,
+      resultExtractor: () => 'completed',
+    });
+    await act(async () => {
+      deferred.resolve(exchange);
+      await execution;
+    });
+    expect(result.current.status).toBe(action === 'abort' ? 'idle' : 'success');
+    expect(result.current.exchange).toBe(
+      action === 'abort' ? undefined : exchange,
+    );
+    expect(result.current.result).toBe(
+      action === 'abort' ? undefined : 'completed',
+    );
+    expect(onSuccess).toHaveBeenCalledTimes(action === 'abort' ? 0 : 1);
+    expect(onAbort).toHaveBeenCalledTimes(action === 'abort' ? 1 : 0);
+  },
+);
+
+it.each([false, true])(
+  'preserves error propagation after cancellation=%s',
+  async cancelled => {
+    const deferred = createDeferredFetcher();
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useFetcher<string>({
+        fetcher: deferred.client,
+        propagateError: true,
+        onError,
+      }),
+    );
+    let execution!: Promise<void | Error>;
+    act(() => {
+      execution = result.current
+        .execute({ url: '/error' })
+        .catch(error => error);
+    });
+    if (cancelled) act(() => result.current.abort());
+    const error = new Error('fetch failed');
+    await act(async () => {
+      deferred.reject(error);
+      expect(await execution).toBe(error);
+    });
+    expect(result.current.exchange).toBeUndefined();
+    expect(result.current.error).toBe(cancelled ? undefined : error);
+    expect(result.current.status).toBe(cancelled ? 'idle' : 'error');
+    expect(onError).toHaveBeenCalledTimes(cancelled ? 0 : 1);
+  },
+);
+
+it('keeps the exchange started by a reentrant onAbort during StrictMode cleanup', async () => {
+  const client = new Fetcher();
+  const staleRequest: FetchRequest = { url: '/stale' };
+  const currentRequest: FetchRequest = { url: '/current' };
+  let resolveStale!: (exchange: FetchExchange) => void;
+  let resolveCurrent!: (exchange: FetchExchange) => void;
+  let finishAbort!: () => void;
+  const stale = new Promise<FetchExchange>(resolve => {
+    resolveStale = resolve;
+  });
+  const current = new Promise<FetchExchange>(resolve => {
+    resolveCurrent = resolve;
+  });
+  const callback = new Promise<void>(resolve => {
+    finishAbort = resolve;
+  });
+  const exchange = vi
+    .spyOn(client, 'exchange')
+    .mockImplementation(request =>
+      request === staleRequest ? stale : current,
+    );
+  let execute!: ReturnType<typeof useFetcher<string>>['execute'];
+  let staleExecution!: Promise<void>;
+  let currentExecution!: Promise<void>;
+  const onSuccess = vi.fn();
+  const onAbort = vi.fn(() => {
+    currentExecution = execute(currentRequest);
+    return callback;
+  });
+  const { result } = renderHook(
+    () => {
+      const hook = useFetcher<string>({ fetcher: client, onSuccess, onAbort });
+      const started = useRef(false);
+      useEffect(() => {
+        execute = hook.execute;
+        if (started.current) return;
+        started.current = true;
+        staleExecution = hook.execute(staleRequest);
+      }, [hook.execute]);
+      return hook;
+    },
+    { wrapper: StrictMode },
+  );
+  expect(exchange).toHaveBeenCalledTimes(2);
+  expect(staleRequest.abortController?.signal.aborted).toBe(true);
+  expect(currentRequest.abortController?.signal.aborted).toBe(false);
+  expect(result.current.loading).toBe(true);
+  const currentExchange = new FetchExchange({
+    fetcher: client,
+    request: currentRequest,
+    resultExtractor: () => 'current',
+  });
+  await act(async () => {
+    resolveCurrent(currentExchange);
+    await currentExecution;
+  });
+  expect(result.current.result).toBe('current');
+  expect(result.current.exchange).toBe(currentExchange);
+  await act(async () => {
+    finishAbort();
+    resolveStale(
+      new FetchExchange({
+        fetcher: client,
+        request: staleRequest,
+        resultExtractor: () => 'stale',
+      }),
+    );
+    await staleExecution;
+  });
+  expect(result.current.loading).toBe(false);
+  expect(result.current.status).toBe('success');
+  expect(result.current.result).toBe('current');
+  expect(result.current.exchange).toBe(currentExchange);
+  expect(onSuccess).toHaveBeenCalledExactlyOnceWith('current');
+  expect(onAbort).toHaveBeenCalledTimes(1);
+});
+
+it.each(['caller cleanup', 'onAbort callback'] as const)(
+  'stays idle when %s repeats the StrictMode cancellation',
+  async mode => {
+    const deferred = createDeferredFetcher();
+    const request: FetchRequest = { url: '/once' };
+    let abortAgain!: () => void;
+    let execution!: Promise<void>;
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const onAbort = vi.fn(() => {
+      if (mode === 'onAbort callback') abortAgain();
+    });
+    const { result } = renderHook(
+      () => {
+        const hook = useFetcher<string>({
+          fetcher: deferred.client,
+          onSuccess,
+          onError,
+          onAbort,
+        });
+        const started = useRef(false);
+        useEffect(() => {
+          abortAgain = hook.abort;
+          if (started.current) return;
+          started.current = true;
+          execution = hook.execute(request);
+          if (mode === 'caller cleanup') return () => hook.abort();
+        }, [hook.execute, hook.abort]);
+        return hook;
+      },
+      { wrapper: StrictMode },
+    );
+    expect(deferred.exchange).toHaveBeenCalledTimes(1);
+    expect(request.abortController?.signal.aborted).toBe(true);
+    expect(onAbort).toHaveBeenCalledTimes(1);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe('idle');
+    await act(async () => {
+      deferred.resolve(
+        new FetchExchange({
+          fetcher: deferred.client,
+          request,
+          resultExtractor: () => 'obsolete',
+        }),
+      );
+      await execution;
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe('idle');
+    expect(result.current.exchange).toBeUndefined();
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  },
+);
+
+function deferredResult<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+it.each([
+  ['exchange', 'success'],
+  ['exchange', 'error'],
+  ['extract', 'success'],
+  ['extract', 'error'],
+] as const)(
+  'clears retained exchange after external abort during %s with late %s',
+  async (stage, outcome) => {
+    const deferred = createDeferredFetcher();
+    const previous = new FetchExchange({
+      fetcher: deferred.client,
+      request: { url: '/previous' },
+      resultExtractor: () => 'previous',
+    });
+    deferred.exchange.mockResolvedValueOnce(previous);
+    const { result } = renderHook(
+      () =>
+        useFetcher<string, Error>({
+          fetcher: deferred.client,
+          propagateError: true,
+        }),
+      { wrapper: StrictMode },
+    );
+    await act(async () => {
+      await result.current.execute({ url: '/previous' });
+    });
+    expect(result.current.exchange).toBe(previous);
+    const extraction = deferredResult<string>();
+    const extractionStarted = deferredResult<void>();
+    const request: FetchRequest = { url: '/cancelled' };
+    const failure = new Error('late ordinary failure');
+    const next = new FetchExchange({
+      fetcher: deferred.client,
+      request,
+      resultExtractor: () => {
+        extractionStarted.resolve();
+        return extraction.promise;
+      },
+    });
+    let execution!: Promise<void | Error>;
+    act(() => {
+      execution = result.current
+        .execute(request)
+        .catch((error: Error) => error);
+    });
+    if (stage === 'extract') {
+      await act(async () => {
+        deferred.resolve(next);
+        await extractionStarted.promise;
+      });
+      expect(result.current.exchange).toBe(next);
+    }
+    act(() => request.abortController!.abort());
+    await act(async () => {
+      if (stage === 'exchange') deferred.resolve(next);
+      if (outcome === 'success') extraction.resolve('cancelled');
+      else extraction.reject(failure);
+      expect(await execution).toBe(outcome === 'error' ? failure : undefined);
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.result).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.exchange).toBeUndefined();
+  },
+);
+
+it.each(['success', 'error'] as const)(
+  'does not clear a newer execution when an externally aborted old %s callback finishes',
+  async outcome => {
+    const client = new Fetcher();
+    const callbackStarted = deferredResult<void>();
+    const callbackFinished = deferredResult<void>();
+    const failure = new Error('old failure');
+    const oldRequest: FetchRequest = { url: '/old' };
+    const oldExchange = new FetchExchange({
+      fetcher: client,
+      request: oldRequest,
+      resultExtractor: () => {
+        if (outcome === 'error') throw failure;
+        return 'old';
+      },
+    });
+    const next = new FetchExchange({
+      fetcher: client,
+      request: { url: '/new' },
+      resultExtractor: () => 'new',
+    });
+    vi.spyOn(client, 'exchange').mockImplementation(async request =>
+      request.url === '/old' ? oldExchange : next,
+    );
+    const callback = async () => {
+      callbackStarted.resolve();
+      await callbackFinished.promise;
+      await result.current.execute({ url: '/new' });
+    };
+    const { result } = renderHook(
+      () =>
+        useFetcher<string, Error>({
+          fetcher: client,
+          propagateError: true,
+          onSuccess: async value => {
+            if (value === 'old') await callback();
+          },
+          onError: callback,
+        }),
+      { wrapper: StrictMode },
+    );
+    let oldExecution!: Promise<void | Error>;
+    await act(async () => {
+      oldExecution = result.current
+        .execute(oldRequest)
+        .catch((error: Error) => error);
+      await callbackStarted.promise;
+    });
+    act(() => oldRequest.abortController!.abort());
+    await act(async () => {
+      callbackFinished.resolve();
+      expect(await oldExecution).toBe(
+        outcome === 'error' ? failure : undefined,
+      );
+    });
+    expect(result.current.status).toBe('success');
+    expect(result.current.result).toBe('new');
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.exchange).toBe(next);
+  },
+);

--- a/packages/react/test/fetcher/useFetcher.test.ts
+++ b/packages/react/test/fetcher/useFetcher.test.ts
@@ -224,10 +224,14 @@ describe('useFetcher', () => {
       extractResult: vi.fn().mockResolvedValue(mockResult3),
     };
 
-    mockFetcher.exchange
-      .mockResolvedValueOnce(mockExchange1)
-      .mockResolvedValueOnce(mockExchange2)
-      .mockResolvedValueOnce(mockExchange3);
+    const exchanges: Record<string, unknown> = {
+      '/test1': mockExchange1,
+      '/test2': mockExchange2,
+      '/test3': mockExchange3,
+    };
+    mockFetcher.exchange.mockImplementation(
+      async ({ url }: { url: string }) => exchanges[url],
+    );
 
     const { result } = renderHook(() => useFetcher<string>());
 
@@ -242,6 +246,43 @@ describe('useFetcher', () => {
     expect(result.current.result).toBe(mockResult3);
     expect(result.current.exchange).toBe(mockExchange3);
   });
+
+  it.each(['success', 'failure'] as const)(
+    'keeps the latest exchange after a cancelled request finishes with %s',
+    async outcome => {
+      const staleExchange = { extractResult: async () => 'stale' };
+      const latestExchange = { extractResult: async () => 'latest' };
+      let resolve!: (value: unknown) => void;
+      let reject!: (error: Error) => void;
+      mockFetcher.exchange.mockImplementation(({ url }: { url: string }) =>
+        url === '/stale'
+          ? new Promise((yes, no) => {
+              resolve = yes;
+              reject = no;
+            })
+          : Promise.resolve(latestExchange),
+      );
+      const { result } = renderHook(() =>
+        useFetcher<string>({ propagateError: true }),
+      );
+      let stale!: Promise<void>;
+      act(() => {
+        stale = result.current
+          .execute({ url: '/stale' })
+          .catch(() => undefined);
+      });
+      await act(async () => {
+        await result.current.execute({ url: '/latest' });
+      });
+      await act(async () => {
+        if (outcome === 'success') resolve(staleExchange);
+        else reject(new Error('stale failure'));
+        await stale;
+      });
+      expect(result.current.result).toBe('latest');
+      expect(result.current.exchange).toBe(latestExchange);
+    },
+  );
 
   it('should maintain correct state during loading', async () => {
     const mockResult = 'success data';

--- a/packages/react/test/fetcher/useFetcherQuery.strictMode.test.ts
+++ b/packages/react/test/fetcher/useFetcherQuery.strictMode.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { StrictMode } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { Fetcher } from '@ahoo-wang/fetcher';
+import { useFetcherQuery } from '../../src/fetcher/useFetcherQuery';
+
+it.each(['success', 'abort'] as const)(
+  'finishes automatic useFetcherQuery after StrictMode replay and ignores late %s',
+  async outcome => {
+    const requests: {
+      signal: AbortSignal;
+      resolve: (value: Response) => void;
+      reject: (reason: Error) => void;
+    }[] = [];
+    const successes: string[] = [];
+    const errors: unknown[] = [];
+    vi.stubGlobal(
+      'fetch',
+      (_url: string, init: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          requests.push({ signal: init.signal!, resolve, reject });
+        }),
+    );
+    const client = new Fetcher({ baseURL: 'https://example.test' });
+    const { result, rerender } = renderHook(
+      () =>
+        useFetcherQuery<{ id: number }, string>({
+          query: { id: 1 },
+          url: '/query',
+          fetcher: client,
+          autoExecute: true,
+          onSuccess: value => {
+            successes.push(value);
+          },
+          onError: error => {
+            errors.push(error);
+          },
+        }),
+      { wrapper: StrictMode },
+    );
+    await act(async () => {});
+    expect(result.current.loading).toBe(true);
+    await act(async () => {
+      requests[requests.length - 1].resolve(Response.json('current'));
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.status).toBe('success');
+    expect(result.current.result).toBe('current');
+    expect(requests).toHaveLength(2);
+    expect(requests[0].signal.aborted).toBe(true);
+    await act(async () => {
+      if (outcome === 'success') requests[0].resolve(Response.json('obsolete'));
+      else
+        requests[0].reject(
+          Object.assign(new Error('obsolete'), { name: 'AbortError' }),
+        );
+    });
+    rerender();
+    expect(requests).toHaveLength(2);
+    expect(result.current.result).toBe('current');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+    expect(successes).toEqual(['current']);
+    expect(errors).toEqual([]);
+  },
+);

--- a/packages/react/test/storage/useImmerKeyStorage.test.ts
+++ b/packages/react/test/storage/useImmerKeyStorage.test.ts
@@ -11,8 +11,9 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createElement, Suspense, useLayoutEffect } from 'react';
+import { render, renderHook, act, waitFor } from '@testing-library/react';
 import { useImmerKeyStorage } from '../../src';
 import { KeyStorage, InMemoryStorage } from '@ahoo-wang/fetcher-storage';
 
@@ -373,4 +374,225 @@ describe('useImmerKeyStorage', () => {
       newKeyStorage.destroy();
     });
   });
+});
+
+it('applies consecutive Immer updaters to the latest stored value', async () => {
+  const storage = new KeyStorage<{ count: number }>({
+    key: 'counter',
+    storage: new InMemoryStorage(),
+  });
+  const { result } = renderHook(() =>
+    useImmerKeyStorage(storage, { count: 0 }),
+  );
+  await act(async () => {
+    result.current[1](draft => {
+      draft.count++;
+    });
+    result.current[1](draft => {
+      draft.count++;
+    });
+  });
+  expect(storage.get()).toEqual({ count: 2 });
+  storage.destroy();
+});
+
+it('keeps the Immer updater stable with inline defaults and reads the latest default', async () => {
+  const storage = new KeyStorage<{ count: number }>({
+    key: 'inline-default',
+    storage: new InMemoryStorage(),
+  });
+  try {
+    const { result, rerender } = renderHook(
+      ({ count }) => useImmerKeyStorage(storage, { count }),
+      { initialProps: { count: 0 } },
+    );
+    const update = result.current[1];
+    rerender({ count: 0 });
+    expect(result.current[1]).toBe(update);
+
+    rerender({ count: 10 });
+    await act(async () => {
+      update(draft => {
+        draft.count++;
+      });
+    });
+    expect(storage.get()).toEqual({ count: 11 });
+    expect(result.current[0]).toEqual({ count: 11 });
+  } finally {
+    storage.destroy();
+  }
+});
+
+it('keeps a retained updater paired with its storage and latest default before switching', async () => {
+  const backing = new InMemoryStorage();
+  const first = new KeyStorage<{ owner: string; count: number }>({
+    key: 'first',
+    storage: backing,
+  });
+  const second = new KeyStorage<{ owner: string; count: number }>({
+    key: 'second',
+    storage: backing,
+  });
+  try {
+    const { result, rerender } = renderHook(
+      ({ storage, owner, count }) =>
+        useImmerKeyStorage(storage, { owner, count }),
+      { initialProps: { storage: first, owner: 'A', count: 0 } },
+    );
+    const updateFirst = result.current[1];
+    rerender({ storage: first, owner: 'A', count: 10 });
+    expect(result.current[1]).toBe(updateFirst);
+    rerender({ storage: second, owner: 'B', count: 100 });
+    const updateSecond = result.current[1];
+    expect(updateSecond).not.toBe(updateFirst);
+    rerender({ storage: second, owner: 'B', count: 200 });
+    expect(result.current[1]).toBe(updateSecond);
+
+    await act(async () => {
+      updateFirst(draft => {
+        draft.count++;
+      });
+    });
+    expect(first.get()).toEqual({ owner: 'A', count: 11 });
+    expect(second.get()).toBeNull();
+    expect(result.current[0]).toEqual({ owner: 'B', count: 200 });
+    await act(async () => {
+      updateSecond(draft => {
+        draft.count++;
+      });
+    });
+    expect(second.get()).toEqual({ owner: 'B', count: 201 });
+  } finally {
+    first.destroy();
+    second.destroy();
+  }
+});
+
+it('makes the current default available to updates in a consumer layout effect', () => {
+  const storage = new KeyStorage<{ count: number }>({
+    key: 'layout-default',
+    storage: new InMemoryStorage(),
+  });
+  try {
+    const { result } = renderHook(() => {
+      const [value, update] = useImmerKeyStorage(storage, { count: 10 });
+      useLayoutEffect(() => {
+        update(draft => {
+          draft.count++;
+        });
+      }, [update]);
+      return value;
+    });
+    expect(storage.get()).toEqual({ count: 11 });
+    expect(result.current).toEqual({ count: 11 });
+  } finally {
+    storage.destroy();
+  }
+});
+
+it.each(['mount', 'changed default'] as const)(
+  'makes the current default available to descendant layout effects on %s',
+  phase => {
+    const storage = new KeyStorage<{ count: number }>({
+      key: 'descendant-layout-default',
+      storage: new InMemoryStorage(),
+    });
+    type Update = (updater: (draft: { count: number }) => void) => void;
+    function Child({ update, apply }: { update: Update; apply: boolean }) {
+      useLayoutEffect(() => {
+        if (apply)
+          update(draft => {
+            draft.count++;
+          });
+      }, [update, apply]);
+      return null;
+    }
+    function Parent({ count, apply }: { count: number; apply: boolean }) {
+      const [, update] = useImmerKeyStorage(storage, { count });
+      return createElement(Child, { update, apply });
+    }
+    try {
+      const view = render(
+        createElement(Parent, { count: 10, apply: phase === 'mount' }),
+      );
+      if (phase === 'changed default') {
+        view.rerender(createElement(Parent, { count: 20, apply: true }));
+      }
+      expect(storage.get()).toEqual({ count: phase === 'mount' ? 11 : 21 });
+    } finally {
+      storage.destroy();
+    }
+  },
+);
+
+it.each([undefined, 10])(
+  'passes a deserialized undefined to the updater (default: %s)',
+  async defaultValue => {
+    const backing = new InMemoryStorage();
+    backing.setItem('undefined-value', 'undefined');
+    const storage = new KeyStorage<number | undefined>({
+      key: 'undefined-value',
+      storage: backing,
+      serializer: {
+        serialize: value => String(value),
+        deserialize: raw => (raw === 'undefined' ? undefined : Number(raw)),
+      },
+    });
+    try {
+      const { result } = renderHook(() =>
+        useImmerKeyStorage(storage, defaultValue),
+      );
+      expect(result.current[0]).toBeUndefined();
+      let received: number | null | undefined = null;
+      await act(async () => {
+        result.current[1](draft => {
+          received = draft;
+          return 1;
+        });
+      });
+      expect(received).toBeUndefined();
+      expect(storage.get()).toBe(1);
+    } finally {
+      storage.destroy();
+    }
+  },
+);
+
+it('keeps uncommitted defaults out of a retained updater when a render suspends', async () => {
+  const storage = new KeyStorage<{ count: number }>({
+    key: 'suspended-default',
+    storage: new InMemoryStorage(),
+  });
+  type Update = (updater: (draft: { count: number }) => void) => void;
+  let committedUpdate: Update = () => {
+    throw new Error('not committed');
+  };
+  const suspended = new Promise<void>(() => {});
+  function Parent({ count, suspend }: { count: number; suspend: boolean }) {
+    const [, update] = useImmerKeyStorage(storage, { count });
+    useLayoutEffect(() => {
+      committedUpdate = update;
+    }, [update]);
+    if (suspend) throw suspended;
+    return null;
+  }
+  const tree = (count: number, suspend: boolean) =>
+    createElement(
+      Suspense,
+      { fallback: 'pending' },
+      createElement(Parent, { count, suspend }),
+    );
+  try {
+    const view = render(tree(10, false));
+    const update = committedUpdate;
+    view.rerender(tree(20, true));
+    await act(async () => {
+      update(draft => {
+        draft.count++;
+      });
+    });
+    expect(storage.get()).toEqual({ count: 11 });
+  } finally {
+    storage.destroy();
+  }
 });

--- a/skills/fetcher-react-hooks/references/api.md
+++ b/skills/fetcher-react-hooks/references/api.md
@@ -94,11 +94,24 @@ setIdle(); // status = IDLE, all cleared
 
 ### useExecutePromise
 
-Manages async operations with race condition protection, AbortController, and unmount safety. Race protection is built on `useRequestId` — each execution gets an id, and stale resolutions are discarded. Accepts a `PromiseSupplier<R>`:
+Manages async operations with race condition protection, AbortController, and unmount safety. Race protection is built on `useRequestId` — each execution gets an id, and stale resolutions are discarded. Manual cancellation invalidates the id even when the supplier ignores its signal, so late results and errors cannot restore state. Accepts a `PromiseSupplier<R>`:
 
 ```typescript
 type PromiseSupplier<R> = (abortController: AbortController) => Promise<R>;
 ```
+
+After StrictMode cleanup cancels an operation, effect replay returns it to idle
+unless another execution has started. Cleanup preserves the initial state when
+no operation is running.
+
+If the supplier's controller is aborted directly, a still-current execution returns
+to idle when it settles, even when the supplier ignores the signal. Cancellation
+before the supplier settles prevents `onSuccess` or `onError` from starting. If a
+callback is already running, execution waits for it and rechecks cancellation
+before settling. An older execution cannot clear a newer execution's state.
+`AbortError` remains ignored; other errors still reject `execute()` when
+`propagateError` is enabled. Directly aborting the controller does not add an
+`onAbort` callback invocation.
 
 ```tsx
 const { loading, result, error, execute, reset, abort } =
@@ -126,7 +139,13 @@ reset(); // reset to IDLE
 
 ### useFetcher
 
-HTTP-specific hook wrapping Fetcher with `FetchExchange` support.
+HTTP-specific hook wrapping Fetcher with `FetchExchange` support. Exchange
+snapshots follow the same cancellation and stale-request rules as result state.
+An exchange remains visible while its result is being extracted. When the current
+execution settles after its controller was externally aborted, the exchange is
+cleared together with result/error state, including cancellation during extraction
+or an async callback. Completion of a superseded request preserves the newer
+request's exchange.
 
 ```tsx
 import { useFetcher } from '@ahoo-wang/fetcher-react';
@@ -172,7 +191,7 @@ execute(); // manual re-execute with current query
 
 ### useQuery
 
-Generic query hook with custom `execute` function. Wraps `useExecutePromise` + `useQueryState`.
+Generic query hook with a custom `execute` function and request cancellation.
 
 ```tsx
 const { loading, result, execute, setQuery } = useQuery<UserQuery, User>({
@@ -190,6 +209,10 @@ const { loading, result, execute, setQuery } = useQuery<UserQuery, User>({
 ### useQueryState
 
 Standalone query state management (getQuery/setQuery) with optional autoExecute.
+When `query` is supplied, equal committed values stay deduplicated during
+StrictMode replay; this hook does not cancel `execute`. `useQuery` and
+`useFetcherQuery` restart their cancelled automatic requests during replay.
+Late results from those cancelled requests remain ignored.
 
 ```tsx
 const { getQuery, setQuery } = useQueryState<UserQuery>({
@@ -332,7 +355,15 @@ const [theme, setTheme, clearTheme] = useKeyStorage(themeStorage, 'light'); // w
 
 ### useImmerKeyStorage
 
-Immer-powered immutable updates for complex objects.
+Immer-powered immutable updates for complex objects. Each updater reads the
+latest stored value, so consecutive updates in one render batch accumulate.
+The updater stays stable while its `KeyStorage` instance is unchanged, including
+with inline default objects, and reads the latest committed default when storage
+is empty. Defaults are available before descendant layout effects run; a render
+that suspends without committing does not change the retained updater's default.
+Only `null` selects the default; a serializer-produced `undefined` is passed to
+the updater unchanged. After switching storage instances, a retained updater
+continues using its original storage and that storage's last committed default.
 
 ```tsx
 const [prefs, updatePrefs, resetPrefs] = useImmerKeyStorage(
@@ -397,7 +428,30 @@ subscribe({ name: 'onDataChanged', handle: event => console.log(event) });
 
 ### createExecuteApiHooks
 
-Generate `useExecutePromise`-based hooks from decorator API classes.
+Generate `useExecutePromise`-based hooks from decorator API classes. Creating the
+hook set does not evaluate accessors. Function-valued getters are resolved and
+cached when their corresponding hook is first read or the hook set is enumerated,
+with both the getter and its returned function bound to the API instance.
+The `in` operator, `Object.hasOwn`, and property-descriptor inspection also
+resolve the inspected getter. Non-function getters are removed from the hook
+set; function-valued getters are cached and evaluated only once.
+`Object.keys`, object spread, and `Object.assign` resolve accessors and include
+only function-valued getter hooks alongside ordinary methods.
+If multiple API names map to the same hook name (for example, `load` and `Load`),
+the last function in own-property then prototype traversal order wins.
+Non-function getters do not replace a function found earlier in that order.
+Generated hooks remain replaceable by assignment before and after getter
+resolution. Assigning a replacement before the first read does not evaluate
+the API getter.
+The shared `collectMethods<T>(api, onAccessor?)` utility still returns a
+`Map<string, T>` of bound methods, including functions returned by getters when
+called with one argument. Its optional callback has the signature
+`onAccessor(name: string, get: () => unknown, methods: ReadonlyMap<string, T>): void`.
+It receives each accessor name, a lazy reader, and the bound methods collected
+before that accessor. Existing callbacks accepting only `name` and `get` remain
+supported. Both ordinary properties and accessors preserve Proxy `get` traps.
+Accessor values are read through the original API object, preserving its getter
+receiver; these reads are deferred during hook creation.
 
 ```tsx
 @api('/users')
@@ -418,6 +472,8 @@ const apiHooks = createExecuteApiHooks({ api: new UserApi() });
 ### createQueryApiHooks
 
 Generate query hooks with `useQuery`-based state management (the generated hook wraps a typed `executeQuery` and calls `useQuery`).
+Function-valued getters have the same lazy resolution and instance binding as
+`createExecuteApiHooks`.
 
 ```tsx
 const apiHooks = createQueryApiHooks({ api: new UserApi() });
@@ -444,7 +500,32 @@ import {
 
 ## Debounced Hooks
 
-Rate-limiting variants of core hooks:
+Rate-limiting variants of core hooks. With `autoExecute: true`, controlled query
+changes schedule execution; equal query values do not schedule duplicate work.
+Changing a controlled query to `undefined` cancels pending automatic work instead
+of rescheduling the last stored query.
+If `query` is explicitly present but `undefined`, re-enabling automatic
+execution does not schedule the previous stored query. `initialQuery` seeds query
+storage only on initialization; a defined `query` takes precedence and updates
+that storage. Omitting `query` uses the stored value without resetting it to
+`initialQuery`, and manual `run()` remains available.
+Switching from an omitted `query` to explicit `query: undefined` cancels pending
+automatic work; switching back schedules the stored query again, even
+though both property values are `undefined`.
+Disabling automatic execution cancels pending automatic work. An explicit
+`run()` replaces the current schedule with manual work, which survives later
+disabling of automatic execution or clearing of the controlled query. `cancel()`
+still cancels either kind of pending work and preserves the existing leading-edge
+cooldown. Automatic cancellation also resets that cooldown.
+Public cancellation, controlled-query clearing, and automatic cancellation clear
+their automatic scheduling marker, so restoring the same controlled value can
+schedule it again. Scheduling also supports StrictMode
+effect replay, including `{ leading: true, trailing: false }`.
+When automatic execution is enabled, syncing the controlled `query` with the
+value just passed to `setQuery` does not schedule it again, including with
+`{ leading: true, trailing: true }`. Only an invoked callback or a pending timer
+marks an automatic query as scheduled; a call suppressed by a leading-only
+cooldown does not suppress a later controlled commit of that query. Restoring cancelled automatic work starts a fresh leading window.
 
 - `useDebouncedCallback` - Debounce any callback
 - `useDebouncedExecutePromise` - Debounce promise execution


### PR DESCRIPTION
## Description

Keep query, request, and storage hooks consistent through cancellation, controlled updates, and StrictMode replay. Cancelling the supplied controller now clears the current result and exchange after pending extraction or async success/error callbacks finish. Older executions cannot clear state owned by a newer request; error propagation and existing callback behavior are retained.

Both debounced query variants clear automatic scheduling records when work is cancelled. Automatic cancellation ends the leading cooldown; public cancel retains its existing cooldown behavior, including when passed directly as an event or value callback. Suppressed leading-only calls do not become records of accepted work, so delayed controlled prop updates can still schedule their query. Explicit runs and the distinction between omitted and undefined controlled queries are preserved.

Immer updaters read committed defaults before descendant layout effects can call them, while suspended renders cannot publish uncommitted defaults. Stored undefined values reach the updater unchanged; only null means empty storage. Updaters retain their identity and original storage ownership.

The layer also retains its API Hook factory fixes for lazy getters, Proxy lookup, writable replacement, reflection, and collision ordering. Matching API references and regression tests accompany the changes. Public hook signatures and React Compiler integration remain intact.

## Validation

Independent fixes are combined for full validation before being inserted into this owning layer; every later source delta is replayed and checked against the tested tree.

- `pnpm build`
- `pnpm test:unit` — 3800 passed, 1 skipped
- Package TypeScript checks and read-only ESLint
- `git diff --check`
- 17 real browser Storybook checks for Viewer and FetcherViewer consumers; runtime export comparison confirms all 57 exports are unchanged and the internal debounce helper remains private.

Node.js 24.11.0, pnpm 10.34.5. Focused regressions cover parent/child commit ordering, suspended renders, external cancellation at async boundaries, newer-request ownership, and both controlled debounce variants. No dependency or build-configuration changes.

## Review and CI

Ready for review. Merge requires completed GitHub Codex review, no unresolved review threads, and five successful CI workflows on the current head. Codacy quality findings remain separately documented with source evidence.

Native GitHub stack #1418, layer 13 of 16. Squash this layer separately, then verify the rebased upper heads. This is part of the pending 5.0.0 series; no release or tag is published. Split index: #1399.
