### PR TITLE
fix(react): isolate monitor notifications and preserve local callbacks

### DIFF
--- a/packages/react/src/dataMonitor/DataMonitorService.ts
+++ b/packages/react/src/dataMonitor/DataMonitorService.ts
@@ -1,4 +1,16 @@
-// packages/react/src/dataMonitor/DataMonitorService.ts
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { KeyStorage } from '@ahoo-wang/fetcher-storage';
 import type { Condition } from '@ahoo-wang/fetcher-wow';
 import { fetcher, ResultExtractors } from '@ahoo-wang/fetcher';
@@ -139,7 +151,7 @@ export class DataMonitorService {
 
       if (previousTotal !== null && previousTotal !== currentTotal) {
         currentMonitored.total = currentTotal;
-        this.notify(viewId, currentMonitored.notification, currentTotal);
+        void this.notify(viewId, currentMonitored.notification, currentTotal);
 
         await dataMonitorEventBus.emit({
           type: 'DATA_CHANGED',
@@ -168,26 +180,23 @@ export class DataMonitorService {
     );
   }
 
-  private notify(
+  private async notify(
     viewId: string,
     notification: DataMonitorNotificationConfig,
     currentTotal: number,
-  ): void {
-    const message = {
-      title: notification.title,
-      payload: {
-        body: `当前共 ${currentTotal} 条数据`,
-        icon: '/logo.png',
-      },
-      onClick: () => {
-        window.focus();
-        if (notification.navigationUrl) {
-          window.location.href = notification.navigationUrl;
-        }
-      },
-    };
-
-    notificationCenter.publish('browser', message);
+  ): Promise<void> {
+    try {
+      await notificationCenter.publishLocal('browser', {
+        title: notification.title,
+        payload: {
+          body: `当前共 ${currentTotal} 条数据`,
+          icon: '/logo.png',
+          data: { navigationUrl: notification.navigationUrl },
+        },
+      });
+    } catch (error) {
+      console.error(`DataMonitor: failed to notify for ${viewId}`, error);
+    }
   }
 
   private saveToStorage(): void {

--- a/packages/react/src/notification/channel/browserNotification.ts
+++ b/packages/react/src/notification/channel/browserNotification.ts
@@ -3,6 +3,7 @@ import type { Message, ChannelType } from '../';
 
 export const BROWSER_NOTIFICATION_TYPE: ChannelType = 'browser';
 
+/** Without a local onClick, clicks focus the window and follow HTTP(S) data.navigationUrl. */
 export type BrowserNotificationPayload = NotificationOptions;
 
 class BrowserNotificationChannel implements NotificationChannel<BrowserNotificationPayload> {
@@ -23,9 +24,26 @@ class BrowserNotificationChannel implements NotificationChannel<BrowserNotificat
       }
 
       const notification = new Notification(message.title, message.payload);
-      if (message.onClick) {
-        notification.addEventListener('click', message.onClick, { once: true });
-      }
+      notification.addEventListener(
+        'click',
+        message.onClick ??
+          (() => {
+            window.focus();
+            const navigationUrl = message.payload.data?.navigationUrl;
+            if (typeof navigationUrl === 'string' && navigationUrl) {
+              let url: URL;
+              try {
+                url = new URL(navigationUrl, window.location.href);
+              } catch {
+                return;
+              }
+              if (url.protocol === 'http:' || url.protocol === 'https:') {
+                window.location.assign(url.href);
+              }
+            }
+          }),
+        { once: true },
+      );
     } catch (e) {
       console.error('send notification failed.', e);
       return;

--- a/packages/react/src/notification/notificationCenter.ts
+++ b/packages/react/src/notification/notificationCenter.ts
@@ -1,3 +1,16 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { channelRegistry } from './channel';
 import type { ChannelType, Message } from './';
 import {
@@ -19,13 +32,33 @@ const beforeUnloadHandler = () => {
 
 export class NotificationCenter {
   public readonly eventBus: BroadcastTypedEventBus<NotificationCenterEvent>;
-
-  constructor() {
-    const delegate = new SerialTypedEventBus<NotificationCenterEvent>(
+  private readonly localEventBus =
+    new SerialTypedEventBus<NotificationCenterEvent>(
       NotificationCenterEventType,
     );
+
+  constructor() {
     this.eventBus = new BroadcastTypedEventBus<NotificationCenterEvent>({
-      delegate,
+      delegate: this.localEventBus,
+      messageTransformer: {
+        serialize: event => {
+          const { title, payload } = event.message;
+          const message = Object.fromEntries(
+            Reflect.ownKeys(event.message)
+              .filter(
+                key =>
+                  key !== 'onClick' &&
+                  key !== 'title' &&
+                  key !== 'payload' &&
+                  Object.getOwnPropertyDescriptor(event.message, key)
+                    ?.enumerable,
+              )
+              .map(key => [key, Reflect.get(event.message, key)]),
+          );
+          return { ...event, message: { ...message, title, payload } };
+        },
+        deserialize: message => message as NotificationCenterEvent,
+      },
     });
 
     this.eventBus.on({
@@ -50,6 +83,11 @@ export class NotificationCenter {
 
   publish(type: ChannelType, message: Message): Promise<void> {
     return this.eventBus.emit({ type, message });
+  }
+
+  /** Deliver through local handlers without serializing or broadcasting. */
+  publishLocal(type: ChannelType, message: Message): Promise<void> {
+    return this.localEventBus.emit({ type, message });
   }
 
   off() {

--- a/packages/react/src/notification/types.ts
+++ b/packages/react/src/notification/types.ts
@@ -7,5 +7,6 @@ export interface TypeCapable {
 export interface Message<Payload = any> {
   title: string;
   payload: Payload;
+  /** Local callback; omitted from notifications broadcast to other contexts. */
   onClick?: () => void;
 }

--- a/packages/react/test/dataMonitor/DataMonitorService.test.ts
+++ b/packages/react/test/dataMonitor/DataMonitorService.test.ts
@@ -1,9 +1,25 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type * as FetcherModule from '@ahoo-wang/fetcher';
+import { Operator } from '@ahoo-wang/fetcher-wow';
 
 // Use vi.hoisted to ensure mocks are properly set up
 const { notificationCenterMock } = vi.hoisted(() => ({
   notificationCenterMock: {
     publish: vi.fn().mockResolvedValue(undefined),
+    publishLocal: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -41,7 +57,7 @@ vi.mock('@ahoo-wang/fetcher-storage', () => {
 const fetcherPostMock = vi.hoisted(() => vi.fn(() => Promise.resolve(0)));
 
 vi.mock('@ahoo-wang/fetcher', async importOriginal => {
-  const actual = await importOriginal<typeof import('@ahoo-wang/fetcher')>();
+  const actual = await importOriginal<typeof FetcherModule>();
   return {
     ...actual,
     fetcher: {
@@ -50,11 +66,6 @@ vi.mock('@ahoo-wang/fetcher', async importOriginal => {
     },
   };
 });
-
-// Mock fetcher-wow
-vi.mock('@ahoo-wang/fetcher-wow', () => ({
-  all: vi.fn().mockReturnValue({}),
-}));
 
 import { DataMonitorService } from '../../src/dataMonitor/DataMonitorService';
 import { fetcher } from '@ahoo-wang/fetcher';
@@ -115,14 +126,14 @@ describe('DataMonitorService', () => {
         'view-1',
         '/api/count/v2',
         'Updated View',
-        { status: 'active' },
+        { field: 'status', operator: Operator.EQ, value: 'active' },
         { title: 'Updated' },
       );
 
       expect(service.isEnabled('view-1')).toBe(true);
       expect(fetcher.post).toHaveBeenLastCalledWith(
         '/api/count/v2',
-        { body: { status: 'active' } },
+        { body: { field: 'status', operator: Operator.EQ, value: 'active' } },
         expect.objectContaining({ resultExtractor: expect.any(Function) }),
       );
     });
@@ -159,7 +170,7 @@ describe('DataMonitorService', () => {
         'view-1',
         '/api/count',
         'Test View',
-        { status: 'active' },
+        { field: 'status', operator: Operator.EQ, value: 'active' },
         { title: 'Test', navigationUrl: '/test' },
       );
 
@@ -168,7 +179,11 @@ describe('DataMonitorService', () => {
       expect(savedView.enabled).toBe(true);
       expect(savedView.countUrl).toBe('/api/count');
       expect(savedView.viewName).toBe('Test View');
-      expect(savedView.condition).toEqual({ status: 'active' });
+      expect(savedView.condition).toEqual({
+        field: 'status',
+        operator: Operator.EQ,
+        value: 'active',
+      });
       expect(savedView.notification).toEqual({
         title: 'Test',
         navigationUrl: '/test',
@@ -329,7 +344,11 @@ describe('DataMonitorService', () => {
           enabled: true,
           countUrl: '/api/view2/count',
           viewName: 'View 2',
-          condition: { status: 'active' },
+          condition: {
+            field: 'status',
+            operator: Operator.EQ,
+            value: 'active',
+          },
           notification: { title: 'Notification 2' },
         },
         'view-3': {
@@ -374,7 +393,7 @@ describe('DataMonitorService', () => {
         currentTotal: 10,
       });
 
-      expect(notificationCenterMock.publish).toHaveBeenCalledWith(
+      expect(notificationCenterMock.publishLocal).toHaveBeenCalledWith(
         'browser',
         expect.objectContaining({
           title: 'Test Notification',
@@ -401,7 +420,7 @@ describe('DataMonitorService', () => {
       expect(fetcher.post).toHaveBeenCalledTimes(2);
 
       expect(dataMonitorEventBusMock.emit).not.toHaveBeenCalled();
-      expect(notificationCenterMock.publish).not.toHaveBeenCalled();
+      expect(notificationCenterMock.publishLocal).not.toHaveBeenCalled();
     });
 
     it('should not notify on first fetch (previousTotal is null)', async () => {
@@ -414,7 +433,7 @@ describe('DataMonitorService', () => {
       );
 
       expect(dataMonitorEventBusMock.emit).not.toHaveBeenCalled();
-      expect(notificationCenterMock.publish).not.toHaveBeenCalled();
+      expect(notificationCenterMock.publishLocal).not.toHaveBeenCalled();
     });
 
     it('should handle fetch errors gracefully without crashing', async () => {
@@ -435,7 +454,7 @@ describe('DataMonitorService', () => {
       await vi.advanceTimersByTimeAsync(30000);
 
       expect(service.isEnabled('view-1')).toBe(true);
-      expect(notificationCenterMock.publish).not.toHaveBeenCalled();
+      expect(notificationCenterMock.publishLocal).not.toHaveBeenCalled();
     });
 
     it('should not notify if view is disabled during fetch', async () => {
@@ -459,12 +478,11 @@ describe('DataMonitorService', () => {
 
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(notificationCenterMock.publish).not.toHaveBeenCalled();
+      expect(notificationCenterMock.publishLocal).not.toHaveBeenCalled();
     });
 
-    it('should include onClick with navigationUrl in notification', async () => {
+    it('publishes cloneable navigation data instead of a click closure', async () => {
       setupFetchResponses(0, 10);
-
       service.enable(
         'view-1',
         '/api/count',
@@ -472,60 +490,18 @@ describe('DataMonitorService', () => {
         {},
         { title: 'Test', navigationUrl: '/test' },
       );
-
       await vi.advanceTimersByTimeAsync(30000);
-
-      expect(notificationCenterMock.publish).toHaveBeenCalledWith(
-        'browser',
-        expect.objectContaining({
-          title: 'Test',
-          onClick: expect.any(Function),
-        }),
-      );
+      const message = notificationCenterMock.publishLocal.mock.calls[0][1];
+      expect(message.payload.data).toEqual({ navigationUrl: '/test' });
+      expect(message.onClick).toBeUndefined();
+      expect(structuredClone(message)).toEqual(message);
     });
 
-    it('should navigate to navigationUrl when notification onClick is called', async () => {
+    it('handles notification rejection without blocking DATA_CHANGED', async () => {
+      const error = new Error('Broadcast failed');
+      const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+      notificationCenterMock.publishLocal.mockRejectedValueOnce(error);
       setupFetchResponses(0, 10);
-
-      const originalLocation = window.location;
-      Object.defineProperty(window, 'location', {
-        value: { href: '' },
-        writable: true,
-        configurable: true,
-      });
-
-      service.enable(
-        'view-1',
-        '/api/count',
-        'Test View',
-        {},
-        { title: 'Test', navigationUrl: '/navigate-here' },
-      );
-
-      await vi.advanceTimersByTimeAsync(30000);
-
-      const publishedMessage = notificationCenterMock.publish.mock.calls[0][1];
-      publishedMessage.onClick();
-
-      expect(window.location.href).toBe('/navigate-here');
-
-      Object.defineProperty(window, 'location', {
-        value: originalLocation,
-        writable: true,
-        configurable: true,
-      });
-    });
-
-    it('should not navigate when navigationUrl is not set', async () => {
-      setupFetchResponses(0, 10);
-
-      const originalLocation = window.location;
-      Object.defineProperty(window, 'location', {
-        value: { href: '' },
-        writable: true,
-        configurable: true,
-      });
-
       service.enable(
         'view-1',
         '/api/count',
@@ -533,19 +509,108 @@ describe('DataMonitorService', () => {
         {},
         { title: 'Test' },
       );
-
       await vi.advanceTimersByTimeAsync(30000);
+      expect(errorLog).toHaveBeenCalledWith(
+        'DataMonitor: failed to notify for view-1',
+        error,
+      );
+      expect(dataMonitorEventBusMock.emit).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'DATA_CHANGED', currentTotal: 10 }),
+      );
+    });
 
-      const publishedMessage = notificationCenterMock.publish.mock.calls[0][1];
-      publishedMessage.onClick();
+    it.each(['getter', 'proxy'] as const)(
+      'still emits DATA_CHANGED when navigationUrl access throws through a %s',
+      async kind => {
+        const error = new Error('navigation unavailable');
+        const errorLog = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+        const notification =
+          kind === 'getter'
+            ? Object.defineProperty({ title: 'Test' }, 'navigationUrl', {
+                get() {
+                  throw error;
+                },
+              })
+            : new Proxy(
+                { title: 'Test' },
+                {
+                  get(target, key, receiver) {
+                    if (key === 'navigationUrl') throw error;
+                    return Reflect.get(target, key, receiver);
+                  },
+                },
+              );
+        try {
+          setupFetchResponses(0, 10);
+          service.enable('view-1', '/api/count', 'Test View', {}, notification);
+          await vi.advanceTimersByTimeAsync(30000);
+          expect(dataMonitorEventBusMock.emit).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'DATA_CHANGED', currentTotal: 10 }),
+          );
+          expect(errorLog).toHaveBeenCalledWith(
+            'DataMonitor: failed to notify for view-1',
+            error,
+          );
+        } finally {
+          errorLog.mockRestore();
+        }
+      },
+    );
 
-      expect(window.location.href).toBe('');
+    it('still emits DATA_CHANGED when the notification publisher throws synchronously', async () => {
+      const error = new Error('publisher failed');
+      const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const fail = () => {
+        throw error;
+      };
+      notificationCenterMock.publishLocal.mockImplementationOnce(fail);
+      try {
+        setupFetchResponses(0, 10);
+        service.enable(
+          'view-1',
+          '/api/count',
+          'Test View',
+          {},
+          { title: 'Test' },
+        );
+        await vi.advanceTimersByTimeAsync(30000);
+        expect(dataMonitorEventBusMock.emit).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'DATA_CHANGED', currentTotal: 10 }),
+        );
+        expect(errorLog).toHaveBeenCalledWith(
+          'DataMonitor: failed to notify for view-1',
+          error,
+        );
+      } finally {
+        errorLog.mockRestore();
+      }
+    });
 
-      Object.defineProperty(window, 'location', {
-        value: originalLocation,
-        writable: true,
-        configurable: true,
-      });
+    it('uses local notifications for each independently initialized monitor', async () => {
+      storageData = {
+        'view-1': {
+          enabled: true,
+          countUrl: '/api/count',
+          viewName: 'Shared View',
+          condition: {},
+          notification: { title: 'Test' },
+        },
+      };
+      setupFetchResponses(0, 0, 10, 10);
+      const peerService = new DataMonitorService();
+      service.initialize();
+      peerService.initialize();
+      try {
+        await vi.advanceTimersByTimeAsync(30000);
+        expect(notificationCenterMock.publishLocal).toHaveBeenCalledTimes(2);
+        expect(notificationCenterMock.publish).not.toHaveBeenCalled();
+        expect(dataMonitorEventBusMock.emit).toHaveBeenCalledTimes(2);
+      } finally {
+        service.disable('view-1');
+        peerService.disable('view-1');
+      }
     });
   });
 
@@ -555,15 +620,24 @@ describe('DataMonitorService', () => {
         'view-1',
         '/api/count',
         'Test View',
-        { status: 'old' },
+        { field: 'status', operator: Operator.EQ, value: 'old' },
         { title: 'Test' },
       );
 
-      service.updateCondition('view-1', { status: 'new', priority: 'high' });
+      service.updateCondition('view-1', {
+        operator: Operator.AND,
+        children: [
+          { field: 'status', operator: Operator.EQ, value: 'new' },
+          { field: 'priority', operator: Operator.EQ, value: 'high' },
+        ],
+      });
 
       expect(storageData['view-1']?.condition).toEqual({
-        status: 'new',
-        priority: 'high',
+        operator: Operator.AND,
+        children: [
+          { field: 'status', operator: Operator.EQ, value: 'new' },
+          { field: 'priority', operator: Operator.EQ, value: 'high' },
+        ],
       });
     });
 
@@ -575,7 +649,11 @@ describe('DataMonitorService', () => {
 
     it('should not persist when view does not exist', () => {
       const initialStorage = { ...storageData };
-      service.updateCondition('non-existent', { status: 'new' });
+      service.updateCondition('non-existent', {
+        field: 'status',
+        operator: Operator.EQ,
+        value: 'new',
+      });
       expect(storageData).toEqual(initialStorage);
     });
   });
@@ -654,25 +732,25 @@ describe('DataMonitorService', () => {
         'view-1',
         '/api/v1/count',
         'View 1',
-        { type: 'a' },
+        { field: 'type', operator: Operator.EQ, value: 'a' },
         { title: 'Test 1' },
       );
       service.enable(
         'view-2',
         '/api/v2/count',
         'View 2',
-        { type: 'b' },
+        { field: 'type', operator: Operator.EQ, value: 'b' },
         { title: 'Test 2' },
       );
 
       expect(fetcher.post).toHaveBeenCalledWith(
         '/api/v1/count',
-        { body: { type: 'a' } },
+        { body: { field: 'type', operator: Operator.EQ, value: 'a' } },
         expect.objectContaining({ resultExtractor: expect.any(Function) }),
       );
       expect(fetcher.post).toHaveBeenCalledWith(
         '/api/v2/count',
-        { body: { type: 'b' } },
+        { body: { field: 'type', operator: Operator.EQ, value: 'b' } },
         expect.objectContaining({ resultExtractor: expect.any(Function) }),
       );
     });

--- a/packages/react/test/notification/browserNotification.test.ts
+++ b/packages/react/test/notification/browserNotification.test.ts
@@ -152,3 +152,105 @@ describe('BrowserNotificationChannel', () => {
     });
   });
 });
+
+describe('received notification click behavior', () => {
+  let instance: Notification;
+  let originalUrl: string;
+  beforeEach(() => {
+    originalUrl = window.location.href;
+    vi.spyOn(window, 'focus').mockImplementation(() => {});
+    class TestNotification extends EventTarget {
+      static permission = 'granted';
+      constructor() {
+        super();
+        instance = this as unknown as Notification;
+      }
+    }
+    vi.stubGlobal('Notification', TestNotification);
+  });
+  afterEach(() => {
+    window.history.replaceState(null, '', originalUrl);
+  });
+
+  it('focuses and navigates from serialized notification data', async () => {
+    await BrowserNotificationChannel.send({
+      title: 'Changed',
+      payload: { data: { navigationUrl: '#changed' } },
+    });
+    instance.dispatchEvent(new Event('click'));
+    expect(window.focus).toHaveBeenCalledOnce();
+    expect(window.location.hash).toBe('#changed');
+  });
+
+  it('still focuses when there is no navigationUrl', async () => {
+    await BrowserNotificationChannel.send({ title: 'Changed', payload: {} });
+    instance.dispatchEvent(new Event('click'));
+    expect(window.focus).toHaveBeenCalledOnce();
+    expect(window.location.href).toBe(originalUrl);
+  });
+
+  it('uses an explicit local callback instead of the navigation fallback', async () => {
+    const onClick = vi.fn();
+    await BrowserNotificationChannel.send({
+      title: 'Changed',
+      payload: { data: { navigationUrl: '#changed' } },
+      onClick,
+    });
+    instance.dispatchEvent(new Event('click'));
+    instance.dispatchEvent(new Event('click'));
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(window.focus).not.toHaveBeenCalled();
+    expect(window.location.href).toBe(originalUrl);
+  });
+});
+
+describe('notification navigation URL validation', () => {
+  it.each([
+    ['javascript:alert(1)', 'https://app.example/views/current'],
+    [' \tJaVaScRiPt:\nalert(1)', 'https://app.example/views/current'],
+    [
+      'data:text/html,<script>alert(1)</script>',
+      'https://app.example/views/current',
+    ],
+    ['vbscript:msgbox(1)', 'https://app.example/views/current'],
+    ['http://[', 'https://app.example/views/current'],
+    [
+      '/orders?status=open#latest',
+      'https://app.example/orders?status=open#latest',
+    ],
+    ['../orders', 'https://app.example/orders'],
+    ['#latest', 'https://app.example/views/current#latest'],
+    ['https://other.example/orders', 'https://other.example/orders'],
+    ['http://other.example/orders', 'http://other.example/orders'],
+  ])('safely handles navigation URL %s', async (navigationUrl, expected) => {
+    let notification: EventTarget;
+    class TestNotification extends EventTarget {
+      static permission = 'granted';
+      constructor() {
+        super();
+        notification = this;
+      }
+    }
+    // jsdom cannot navigate documents; record the browser navigation boundary.
+    const location = {
+      href: 'https://app.example/views/current',
+      assign(url: string) {
+        this.href = url;
+      },
+    };
+    vi.stubGlobal('Notification', TestNotification);
+    vi.stubGlobal('window', {
+      Notification: TestNotification,
+      focus() {},
+      location,
+    });
+
+    await BrowserNotificationChannel.send({
+      title: 'Changed',
+      payload: { data: { navigationUrl } },
+    });
+    notification!.dispatchEvent(new Event('click'));
+
+    expect(location.href).toBe(expected);
+  });
+});

--- a/packages/react/test/notification/notificationCenter.broadcast.test.ts
+++ b/packages/react/test/notification/notificationCenter.broadcast.test.ts
@@ -1,0 +1,226 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BroadcastChannel as NativeBroadcastChannel } from 'node:worker_threads';
+import type { NotificationCenterEvent } from '../../src/notification/notificationCenter';
+import type { Message } from '../../src/notification/types';
+
+type TestMessage = Message<NotificationOptions> & { source: string };
+const messageFactories: [
+  string,
+  (payload: NotificationOptions, onClick: () => void) => TestMessage,
+][] = [
+  [
+    'plain properties',
+    (payload, onClick) => ({
+      title: 'Monitor',
+      payload,
+      onClick,
+      source: 'monitor',
+    }),
+  ],
+  [
+    'prototype getters',
+    (payload, onClick) =>
+      new (class implements TestMessage {
+        source = 'monitor';
+        onClick = onClick;
+        get title() {
+          return 'Monitor';
+        }
+        get payload() {
+          return payload;
+        }
+      })(),
+  ],
+  [
+    'non-enumerable properties',
+    (payload, onClick) =>
+      Object.defineProperties(
+        { title: 'Monitor', payload, onClick, source: 'monitor' },
+        { title: { enumerable: false }, payload: { enumerable: false } },
+      ),
+  ],
+];
+
+it.each(messageFactories)(
+  'keeps %s intact locally and omits onClick only on the wire',
+  async (_name, createMessage) => {
+    vi.stubGlobal('BroadcastChannel', NativeBroadcastChannel);
+    const { NotificationCenter, notificationCenter } =
+      await import('../../src/notification/notificationCenter');
+    notificationCenter.destroy();
+    const { channelRegistry } = await import('../../src/notification/channel');
+    const center = new NotificationCenter();
+    const peer = new NativeBroadcastChannel(
+      '_broadcast_:NOTIFICATION_CENTER_EVENT',
+    );
+    const onClick = vi.fn();
+    const payload = Object.freeze({
+      body: 'Changed',
+      data: { navigationUrl: '#changed' },
+    });
+    const original = Object.freeze(createMessage(payload, onClick));
+    let channelMessage: Message | undefined;
+    let channelTitle: string | undefined;
+    let channelPayload: NotificationOptions | undefined;
+    channelRegistry.register('test-message-identity', {
+      send(message) {
+        channelMessage = message;
+        channelTitle = message.title;
+        channelPayload = message.payload;
+      },
+    });
+    let localMessage: Message | undefined;
+    center.eventBus.on({
+      name: 'inspect-local-message',
+      handle: event => {
+        localMessage = event.message;
+      },
+    });
+    const received = new Promise<NotificationCenterEvent>(resolve => {
+      peer.onmessage = event => resolve(event.data);
+    });
+    try {
+      await expect(
+        center.publish('test-message-identity', original),
+      ).resolves.toBeUndefined();
+      expect(channelTitle).toBe('Monitor');
+      expect(channelPayload).toBe(payload);
+      expect(channelMessage).toBe(original);
+      expect(localMessage).toBe(original);
+      expect(localMessage?.title).toBe('Monitor');
+      expect(localMessage?.payload).toBe(payload);
+      const event = await received;
+      expect(event).toEqual({
+        type: 'test-message-identity',
+        message: { title: 'Monitor', payload, source: 'monitor' },
+      });
+      expect(event.message).not.toHaveProperty('onClick');
+      expect(localMessage?.onClick).toBe(onClick);
+      localMessage?.onClick?.();
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(original.onClick).toBe(onClick);
+      expect(
+        Object.getOwnPropertyDescriptor(original, 'onClick')?.enumerable,
+      ).toBe(true);
+      expect(original.payload).toBe(payload);
+    } finally {
+      peer.close();
+      center.destroy();
+      channelRegistry.unregister('test-message-identity');
+    }
+  },
+);
+
+it.each(['getter', 'proxy'] as const)(
+  'does not inspect onClick through a throwing %s while broadcasting',
+  async kind => {
+    vi.stubGlobal('BroadcastChannel', NativeBroadcastChannel);
+    const { NotificationCenter } =
+      await import('../../src/notification/notificationCenter');
+    const { channelRegistry } = await import('../../src/notification/channel');
+    const center = new NotificationCenter();
+    const peer = new NativeBroadcastChannel(
+      '_broadcast_:NOTIFICATION_CENTER_EVENT',
+    );
+    const readCallback = vi.fn(() => {
+      throw new Error('onClick is local only');
+    });
+    const target = {
+      title: 'Monitor',
+      payload: { body: 'Changed' },
+      source: 'monitor',
+    };
+    const original: Message =
+      kind === 'getter'
+        ? Object.defineProperty({ ...target }, 'onClick', {
+            enumerable: true,
+            get: readCallback,
+          })
+        : new Proxy(
+            { ...target, onClick() {} },
+            {
+              get(object, key, receiver) {
+                if (key === 'onClick') return readCallback();
+                return Reflect.get(object, key, receiver);
+              },
+              getOwnPropertyDescriptor(object, key) {
+                if (key === 'onClick') return readCallback();
+                return Reflect.getOwnPropertyDescriptor(object, key);
+              },
+            },
+          );
+    const send = vi.fn();
+    channelRegistry.register('skip-onclick', { send });
+    const received = new Promise<NotificationCenterEvent>(resolve => {
+      peer.onmessage = event => resolve(event.data);
+    });
+    try {
+      await expect(
+        center.publish('skip-onclick', original),
+      ).resolves.toBeUndefined();
+      expect(send.mock.calls[0][0]).toBe(original);
+      expect((await received).message).toEqual(target);
+      expect(readCallback).not.toHaveBeenCalled();
+    } finally {
+      peer.close();
+      center.destroy();
+      channelRegistry.unregister('skip-onclick');
+    }
+  },
+);
+
+it('publishes locally through every local handler without crossing the wire', async () => {
+  vi.stubGlobal('BroadcastChannel', NativeBroadcastChannel);
+  const { NotificationCenter } =
+    await import('../../src/notification/notificationCenter');
+  const { channelRegistry } = await import('../../src/notification/channel');
+  const center = new NotificationCenter();
+  const peer = new NativeBroadcastChannel(
+    '_broadcast_:NOTIFICATION_CENTER_EVENT',
+  );
+  const send = vi.fn();
+  const observe = vi.fn();
+  channelRegistry.register('local-monitor', { send });
+  center.eventBus.on({ name: 'observe-local', handle: observe });
+  const serialize = vi.spyOn(center.eventBus.messageTransformer!, 'serialize');
+  const original = {
+    title: 'Local',
+    payload: { body: 'Changed' },
+    onClick() {},
+  };
+  const wire: NotificationCenterEvent[] = [];
+  const barrier = new Promise<void>(resolve => {
+    peer.onmessage = event => {
+      wire.push(event.data);
+      if (event.data.message.title === 'Barrier') resolve();
+    };
+  });
+  try {
+    await center.publishLocal('local-monitor', original);
+    expect(send.mock.calls[0][0]).toBe(original);
+    expect(observe.mock.calls[0][0].message).toBe(original);
+    expect(serialize).not.toHaveBeenCalled();
+    await center.publish('local-monitor', { title: 'Barrier', payload: {} });
+    await barrier;
+    expect(wire.map(event => event.message.title)).toEqual(['Barrier']);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(observe).toHaveBeenCalledTimes(2);
+  } finally {
+    serialize.mockRestore();
+    peer.close();
+    center.destroy();
+    channelRegistry.unregister('local-monitor');
+  }
+});

--- a/skills/fetcher-react-hooks/references/api.md
+++ b/skills/fetcher-react-hooks/references/api.md
@@ -398,6 +398,12 @@ useEventSubscription({
 ### useDataMonitor
 
 Monitors data changes via periodic count queries with notification support.
+Set `notification.title` and an optional `notification.navigationUrl`. Clicking
+a browser notification focuses its receiving window and follows HTTP/HTTPS
+navigation. Relative URLs resolve against the receiving page; invalid URLs and
+other protocols are ignored. Each context sends its polling notifications locally,
+so parallel monitors do not rebroadcast the same notification to each other.
+Notification construction and delivery failures do not prevent data-change events.
 
 ```tsx
 import { useDataMonitor } from '@ahoo-wang/fetcher-react';


### PR DESCRIPTION
## Description

DataMonitorService sends polling notifications only through the current context's local handlers, preventing duplicate cross-tab notifications when multiple contexts monitor the same saved view. The internal `NotificationCenter.publishLocal(type, message)` reuses the existing local event bus; ordinary `publish` retains cross-context broadcasting.

Notification construction, synchronous publisher errors, and rejected delivery promises are isolated so DATA_CHANGED events still fire. Broadcast serialization filters onClick before reading its descriptor or value, including throwing getters and Proxies. Local channels and subscribers retain the original message; prototype/non-enumerable title and payload and serializable extension fields remain available.

Browser navigation continues to accept parsed HTTP/HTTPS and relative URLs while rejecting executable or malformed URLs. DataMonitor configuration uses notification.title and optional notification.navigationUrl. The consumer API reference describes the exported monitor Hook and its notification behavior.

## Validation

The combined stack passed before the scoped fix was inserted into this layer; later source deltas are replayed and verified against the tested tree.

- `pnpm build`
- `pnpm test:unit` — 3807 passed, 1 skipped, 280 files
- Package TypeScript checks, changed-source/test TypeScript checks, read-only ESLint, and `git diff --check`
- 51 focused notification/data-monitor checks, including real native BroadcastChannel delivery and a subsequent broadcast barrier proving local-only messages stay off the wire
- 17 Viewer and FetcherViewer browser Storybook checks

Existing monitor fixtures now use valid Condition shapes and retain their persistence/forwarding assertions. No dependencies, root/package tsconfig, or build configuration changed. Node.js 24.11.0, pnpm 10.34.5.

## Review and CI

Ready for review. Merge requires completed GitHub Codex review, no unresolved review threads, and five successful CI workflows on the current head. Codacy quality findings remain separately documented with source evidence.

Native GitHub stack #1418, layer 14 of 16. Squash this layer separately, then verify rebased upper heads. No release or tag is published. Split index: #1399.
