### PR TITLE
fix(viewer): restore view state, selection and pagination consistently

### DIFF
--- a/packages/viewer/src/utils.ts
+++ b/packages/viewer/src/utils.ts
@@ -1,5 +1,6 @@
 import type { Key } from 'react';
 import type { TableRecordType } from './types';
+import { getPropertyValue } from '@ahoo-wang/fetcher-wow';
 
 /**
  * Performs a deep equality comparison between two values.
@@ -116,13 +117,7 @@ export function mapToTableRecord<RecordType = any>(
     return dataSource.map((record, index) => {
       let key: Key = (record as { key?: Key }).key ?? index;
       if (primaryKey) {
-        // Computed destructuring reads the primary key field dynamically
-        // (the field name comes from the viewer's field metadata).
-        const { [primaryKey]: primaryKeyValue } = record as Record<
-          string,
-          Key | undefined
-        >;
-        key = primaryKeyValue ?? key;
+        key = getPropertyValue<Key>(record, primaryKey.split('.')) ?? key;
       }
       return {
         ...record,

--- a/packages/viewer/src/view/View.tsx
+++ b/packages/viewer/src/view/View.tsx
@@ -25,7 +25,7 @@ import type * as React from 'react';
 import type { Condition, FieldSort, PagedList } from '@ahoo-wang/fetcher-wow';
 import type { FilterState } from '../filter/types';
 import type { Key, RefAttributes } from 'react';
-import { useCallback, useImperativeHandle, useRef } from 'react';
+import { useCallback, useImperativeHandle, useRef, useState } from 'react';
 import type { FieldDefinition, ViewColumn } from '../viewer';
 import type { ViewTableActionColumn, ViewTableRef } from '../table';
 import { ViewTable } from '../table';
@@ -160,11 +160,12 @@ export interface ViewProps<RecordType>
   defaultCondition?: Condition;
   /** Current filter condition (controlled mode) */
   externalCondition?: Condition;
-  /** Callback to update condition (controlled mode) */
+  /** Callback to update condition; reset also supplies the complete default filters. */
   externalUpdateCondition?: (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
     filterStates: Map<Key, FilterState>,
+    resetFilters?: ActiveFilter[],
   ) => void;
 
   /** Optional action column configuration for row-level operations */
@@ -176,8 +177,7 @@ export interface ViewProps<RecordType>
    * - Object: Antd Pagination props excluding 'onChange', 'onShowSizeChange', and 'total'.
    */
   pagination:
-    | false
-    | Omit<PaginationProps, 'onChange' | 'onShowSizeChange' | 'total'>;
+    false | Omit<PaginationProps, 'onChange' | 'onShowSizeChange' | 'total'>;
 
   /** Whether to enable row selection for batch operations */
   enableRowSelection: boolean;
@@ -232,19 +232,19 @@ export function View<RecordType>({
    */
   const {
     page,
-    setPage,
     activeFilters,
     setActiveFilters,
     columns,
     setColumns,
     pageSize,
-    setPageSize,
+    setPagination,
     tableSize,
     setTableSize,
     setCondition,
     setSorter,
     selectedCount,
     updateSelectedCount,
+    reset,
   } = useViewState(viewState);
 
   const { locale } = useLocale();
@@ -274,11 +274,8 @@ export function View<RecordType>({
     currentPage: number,
     currentPageSize: number,
   ) => {
-    if (page !== currentPage) {
-      setPage(currentPage);
-    }
-    if (pageSize !== currentPageSize) {
-      setPageSize(currentPageSize);
+    if (page !== currentPage || pageSize !== currentPageSize) {
+      setPagination(currentPage, currentPageSize);
     }
   };
 
@@ -333,6 +330,7 @@ export function View<RecordType>({
 
   /** Ref for accessing EditableFilterPanel imperative methods (reset) */
   const editableFilterPanelRef = useRef<FilterPanelRef | null>(null);
+  const [resetVersion, setResetVersion] = useState(0);
   /** Ref for accessing ViewTable imperative methods (reset, clearSelectedRowKeys) */
   const viewTableRef = useRef<ViewTableRef | null>(null);
 
@@ -348,8 +346,8 @@ export function View<RecordType>({
    * Called via ref imperatively from parent components.
    */
   const resetFn = () => {
-    // reset();
-    editableFilterPanelRef.current?.reset();
+    reset();
+    setResetVersion(version => version + 1);
     clearSelectedRowKeysFn();
   };
 
@@ -381,6 +379,7 @@ export function View<RecordType>({
           style={{ display: showFilter ? 'block' : 'none' }}
         >
           <EditableFilterPanel
+            key={resetVersion}
             row={{ gutter: [24, 16], wrap: true }}
             col={{
               xxl: 12,
@@ -406,6 +405,7 @@ export function View<RecordType>({
           style={{ display: showFilter ? 'block' : 'none' }}
         >
           <FilterPanel
+            key={resetVersion}
             ref={editableFilterPanelRef}
             filters={activeFilters}
             resetButton={false}
@@ -415,6 +415,7 @@ export function View<RecordType>({
       )}
       {/* Data table with columns, sorting, row selection, and actions */}
       <ViewTable<RecordType>
+        key={resetVersion}
         ref={viewTableRef}
         loading={loading}
         dataSource={dataSource.list}
@@ -448,16 +449,18 @@ export function View<RecordType>({
               : ''}
           </span>
           {/* Antd Pagination component */}
-          <Pagination
-            showTotal={total => `共 ${total} 条数据`}
-            defaultCurrent={page}
-            current={page}
-            pageSize={pageSize || 10}
-            total={dataSource.total}
-            pageSizeOptions={['10', '20', '50', '100']}
-            {...pagination}
-            onChange={handlePaginationChange}
-          />
+          {pagination !== false && (
+            <Pagination
+              showTotal={total => `共 ${total} 条数据`}
+              defaultCurrent={page}
+              current={page}
+              pageSize={pageSize || 10}
+              total={dataSource.total}
+              pageSizeOptions={['10', '20', '50', '100']}
+              {...pagination}
+              onChange={handlePaginationChange}
+            />
+          )}
         </div>
       )}
     </Space>

--- a/packages/viewer/src/view/hooks/useViewState.ts
+++ b/packages/viewer/src/view/hooks/useViewState.ts
@@ -93,11 +93,12 @@ export interface UseViewStateOptions {
   defaultCondition?: Condition;
   /** Current filter condition (controlled mode) */
   externalCondition?: Condition;
-  /** Callback to update condition (controlled mode) */
+  /** Callback to update condition; reset also supplies the complete default filters. */
   externalUpdateCondition?: (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
     filterStates: Map<Key, FilterState>,
+    resetFilters?: ActiveFilter[],
   ) => void;
   /** Default sort configuration (uncontrolled mode) */
   defaultSorter?: FieldSort[];
@@ -141,6 +142,8 @@ export interface UseViewStateReturn {
   pageSize: number;
   /** Function to update page size */
   setPageSize: (pageSize: number) => void;
+  /** Updates the page and page size together, emitting one change. */
+  setPagination: (page: number, pageSize: number) => void;
   /** Current filter condition */
   condition: Condition;
   /** Function to update condition */
@@ -267,6 +270,7 @@ export function useViewState({
     reset,
   } = useActiveViewState({
     defaultColumns: defaultColumns,
+    defaultPage: defaultPage,
     defaultPageSize: defaultPageSize,
     defaultActiveFilters: defaultActiveFilters || [],
     defaultTableSize: defaultTableSize,
@@ -326,6 +330,12 @@ export function useViewState({
     onChange?.(condition, page, pageSize, sorter);
   };
 
+  const setPagination = (page: number, pageSize: number) => {
+    setPage(page);
+    setPageSize(pageSize);
+    onChange?.(condition, page, pageSize, sorter);
+  };
+
   /**
    * Updates filter condition and triggers onChange callback.
    * Typically called when user applies a new filter.
@@ -359,6 +369,18 @@ export function useViewState({
    */
   const resetFn = () => {
     reset();
+    externalUpdateCondition?.(
+      defaultCondition || DEFAULT_CONDITION,
+      new Map(),
+      new Map(),
+      defaultActiveFilters ?? [],
+    );
+    externalUpdateSorter?.(defaultSorter ?? []);
+    externalUpdateColumns?.(defaultColumns);
+    externalUpdateActiveFilters?.(defaultActiveFilters ?? []);
+    externalUpdatePage?.(defaultPage);
+    externalUpdatePageSize?.(defaultPageSize);
+    externalUpdateTableSize?.(defaultTableSize);
     onChange?.(
       defaultCondition || DEFAULT_CONDITION,
       defaultPage,
@@ -384,6 +406,7 @@ export function useViewState({
     setPage: setPageFn,
     pageSize,
     setPageSize: setPageSizeFn,
+    setPagination,
     columns,
     setColumns,
     activeFilters,

--- a/packages/viewer/src/viewer/EmptyViewer.tsx
+++ b/packages/viewer/src/viewer/EmptyViewer.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Empty } from 'antd';
+import { useState } from 'react';
+import type { ViewType } from './types';
+import { SaveViewModal } from './panel/SaveViewModal';
+
+export function EmptyViewer({
+  onCreateView,
+}: {
+  onCreateView?: (name: string, type: ViewType, onSuccess: () => void) => void;
+}) {
+  const [creating, setCreating] = useState(false);
+  return (
+    <Empty description="未找到视图">
+      {onCreateView && (
+        <Button type="primary" onClick={() => setCreating(true)}>
+          创建视图
+        </Button>
+      )}
+      <SaveViewModal
+        mode="Create"
+        open={creating}
+        onCancel={() => setCreating(false)}
+        onSaveView={(name, type) => {
+          onCreateView?.(name, type, () => setCreating(false));
+        }}
+      />
+    </Empty>
+  );
+}

--- a/packages/viewer/src/viewer/Viewer.tsx
+++ b/packages/viewer/src/viewer/Viewer.tsx
@@ -8,6 +8,7 @@ import type {
   GetRecordCountActionCapable,
 } from './';
 import { ViewPanel, useViewerState } from './';
+import { EmptyViewer } from './EmptyViewer';
 import styles from './Viewer.module.css';
 import type {
   ViewTableSettingCapable,
@@ -27,13 +28,14 @@ import {
   useState,
 } from 'react';
 import type { Condition, FieldSort, PagedList } from '@ahoo-wang/fetcher-wow';
+import { all } from '@ahoo-wang/fetcher-wow';
 import type * as React from 'react';
 
 const { Header, Sider, Content } = Layout;
 
 export interface ViewerRef extends FilterPanelConditionCapableRef {
   clearSelectedRowKeys: () => void;
-  getActiveView: () => ViewState;
+  getActiveView: () => ViewState | undefined;
 }
 
 export interface ViewerProps<RecordType>
@@ -50,8 +52,7 @@ export interface ViewerProps<RecordType>
   // for view
   dataSource: PagedList<RecordType>;
   pagination:
-    | false
-    | Omit<PaginationProps, 'onChange' | 'onShowSizeChange' | 'total'>;
+    false | Omit<PaginationProps, 'onChange' | 'onShowSizeChange' | 'total'>;
   actionColumn?: ViewTableActionColumn<RecordType>;
   onClickPrimaryKey?: (id: any, record: RecordType) => void;
   enableRowSelection?: boolean;
@@ -109,7 +110,7 @@ export function Viewer<RecordType = any>({
     setCondition,
     sorter,
     setSorter,
-    onSwitchView: switchView,
+    onSwitchView: updateActiveView,
     views,
     setViews,
     reset,
@@ -120,15 +121,26 @@ export function Viewer<RecordType = any>({
   });
 
   const [tableSelectedData, setTableSelectedData] = useState<RecordType[]>([]);
+  const [resetVersion, setResetVersion] = useState(0);
 
   const viewRef = useRef<ViewRef | null>(null);
   const viewerRef = useRef<HTMLElement | null>(null);
+
+  const clearSelection = () => {
+    viewRef.current?.clearSelectedRowKeys();
+    setTableSelectedData([]);
+  };
+
+  const switchView = (view: ViewState) => {
+    clearSelection();
+    updateActiveView(view);
+    onSwitchView?.(view);
+  };
 
   const handleCreateView = (view: ViewState, onSuccess?: () => void) => {
     onCreateView?.(view, (newView: ViewState) => {
       setViews([...views, newView]);
       switchView(newView);
-      onSwitchView?.(newView);
       onSuccess?.();
     });
   };
@@ -150,10 +162,14 @@ export function Viewer<RecordType = any>({
 
   const handleDeleteView = (view: ViewState, onSuccess?: () => void) => {
     onDeleteView?.(view, (deletedView: ViewState) => {
-      setViews(views.filter(it => it.id !== deletedView.id));
+      const remainingViews = views.filter(it => it.id !== deletedView.id);
+      setViews(remainingViews);
       if (activeView.id === deletedView.id) {
-        switchView(views[0]);
-        onSwitchView?.(views[0]);
+        if (remainingViews.length) {
+          switchView(remainingViews[0]);
+        } else {
+          clearSelection();
+        }
       }
       onSuccess?.();
     });
@@ -165,14 +181,19 @@ export function Viewer<RecordType = any>({
 
   const handleSwitchView = (view: ViewState) => {
     switchView(view);
-    onSwitchView?.(view);
   };
 
   const handleReset = () => {
     const resetView = reset();
-    viewRef.current?.reset();
-    onLoadData?.(resetView.condition, 1, resetView.pageSize, resetView.sorter);
-    // Reset logic handled by View component internally
+    clearSelection();
+    // Recreate uncontrolled filter inputs from the restored saved defaults.
+    setResetVersion(version => version + 1);
+    onLoadData?.(
+      resetView.condition || all(),
+      1,
+      resetView.pageSize,
+      resetView.sorter,
+    );
   };
 
   const handleChange = useCallback(
@@ -194,13 +215,29 @@ export function Viewer<RecordType = any>({
         viewRef.current?.clearSelectedRowKeys();
       },
       getCondition: () => viewRef.current?.getCondition(),
-      getActiveView: () => activeView,
+      getActiveView: () => (views.length ? activeView : undefined),
     };
   });
 
   useEffect(() => {
     dataMonitorService.initialize();
   }, []);
+
+  if (views.length === 0) {
+    return (
+      <EmptyViewer
+        onCreateView={
+          onCreateView &&
+          ((name, type, onSuccess) => {
+            handleCreateView(
+              { ...activeView, name, type, source: 'CUSTOM', isDefault: false },
+              onSuccess,
+            );
+          })
+        }
+      />
+    );
+  }
 
   return (
     <Layout ref={viewerRef}>
@@ -263,7 +300,7 @@ export function Viewer<RecordType = any>({
             </Header>
             <View<RecordType>
               ref={viewRef}
-              key={activeView.id}
+              key={`${activeView.id}:${resetVersion}`}
               fields={definition.fields}
               availableFilters={definition.availableFilters}
               dataSource={otherProps.dataSource}

--- a/packages/viewer/src/viewer/hooks/useViewerState.ts
+++ b/packages/viewer/src/viewer/hooks/useViewerState.ts
@@ -56,6 +56,7 @@ export interface UseViewerStateReturn {
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
     filterStates: Map<Key, FilterState>,
+    resetFilters?: ActiveFilter[],
   ) => void;
   page: number;
   setPage: (page: number) => void;
@@ -151,78 +152,84 @@ export function useViewerState({
 
   const setColumnsFn = (newColumns: ViewColumn[]) => {
     setColumns(newColumns);
-    setActiveView({
-      ...activeView,
+    setActiveView(view => ({
+      ...view,
       columns: newColumns,
-    });
+    }));
   };
 
   const setPageSizeFn = (size: number) => {
     setPageSize(size);
-    setActiveView({
-      ...activeView,
+    setActiveView(view => ({
+      ...view,
       pageSize: size,
-    });
+    }));
   };
 
   const setActiveFiltersFn = (filters: ActiveFilter[]) => {
     setActiveFilters(filters);
-    setActiveView({
-      ...activeView,
+    setActiveView(view => ({
+      ...view,
       filters: filters,
-    });
+    }));
   };
 
   const setTableSizeFn = (size: SizeType) => {
     setTableSize(size);
-    setActiveView({
-      ...activeView,
+    setActiveView(view => ({
+      ...view,
       tableSize: size,
-    });
+    }));
   };
 
   const setConditionFn = (
     finalCondition: Condition,
     activeFilterValues: Map<Key, Condition>,
     filterStates: Map<Key, FilterState>,
+    resetFilters?: ActiveFilter[],
   ) => {
     setCondition(finalCondition);
-    const newActiveFilters = activeFilters.map(activeFilter => {
-      const activeFilterValue = activeFilterValues.get(activeFilter.key);
-      const activeFilterState = filterStates.get(activeFilter.key);     
-       
-      if (!activeFilterValue) {
+    const newActiveFilters =
+      resetFilters ??
+      activeFilters.map(activeFilter => {
+        const activeFilterValue = activeFilterValues.get(activeFilter.key);
+        const activeFilterState = filterStates.get(activeFilter.key);
 
-        if(activeFilterState?.operator) {
+        if (!activeFilterValue) {
           return {
             ...activeFilter,
-            operator: { 
+            operator: {
               ...activeFilter.operator,
-              defaultValue: activeFilterState.operator
-             },
-            value: null,
+              defaultValue:
+                activeFilterState?.operator ??
+                activeFilter.operator?.defaultValue,
+            },
+            value:
+              activeFilter.value == null
+                ? activeFilter.value
+                : { ...activeFilter.value, defaultValue: undefined },
           };
         }
 
         return {
           ...activeFilter,
-          value: null,
+          value: {
+            ...activeFilter.value,
+            defaultValue: activeFilterValue.value,
+          },
+          operator: {
+            ...activeFilter.operator,
+            defaultValue: activeFilterValue.operator,
+          },
         };
-      }
-      
-      return {
-        ...activeFilter,
-        value: { defaultValue: activeFilterValue.value },
-        operator: { defaultValue: activeFilterValue.operator },
-      };
-    });
+      });
     setActiveFilters(newActiveFilters);
 
-    setActiveView({
-      ...activeView,
+    setActiveView(view => ({
+      ...view,
       condition: finalCondition,
       filters: newActiveFilters,
-    });
+    }));
   };
 
   const setSorterFn = (sorter: FieldSort[]) => {
@@ -239,12 +246,11 @@ export function useViewerState({
         : { ...column, sortOrder: undefined };
     });
     setColumns(newColumns);
-    const newView: ViewState = {
-      ...activeView,
+    setActiveView(view => ({
+      ...view,
       sorter: sorter,
       columns: newColumns,
-    };
-    setActiveView(newView);
+    }));
   };
 
   const resetFn = (): ViewState => {

--- a/packages/viewer/test/hooks/useViewState.test.ts
+++ b/packages/viewer/test/hooks/useViewState.test.ts
@@ -13,7 +13,8 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useViewState } from '../../src';
+import { useViewerState, useViewState } from '../../src';
+import type { ViewState } from '../../src';
 import { ViewColumn } from '../../src';
 import { Operator, SortDirection } from '@ahoo-wang/fetcher-wow';
 import { SizeType } from 'antd/es/config-provider/SizeContext';
@@ -202,6 +203,92 @@ describe('useViewState', () => {
   });
 
   describe('controlled mode', () => {
+    it('restores saved filters when only the condition is controlled by useViewerState', () => {
+      const savedView: ViewState = {
+        id: 'saved',
+        name: 'Saved',
+        definitionId: 'definition',
+        type: 'PERSONAL',
+        source: 'CUSTOM',
+        isDefault: false,
+        columns: defaultColumns,
+        pageSize: 10,
+        tableSize: 'middle',
+        sorter: [],
+        condition: { field: 'status', operator: Operator.EQ, value: 'saved' },
+        filters: [
+          {
+            key: 'status',
+            type: 'text',
+            field: { name: 'status', label: 'Status' },
+            operator: { defaultValue: Operator.EQ },
+            value: { defaultValue: 'saved' },
+          },
+          {
+            key: 'optional',
+            type: 'text',
+            field: { name: 'optional', label: 'Optional' },
+          },
+        ],
+      };
+      const onChange = vi.fn();
+      const { result } = renderHook(() => {
+        const viewer = useViewerState({
+          views: [savedView],
+          defaultView: savedView,
+          definition: {
+            id: 'definition',
+            name: 'Definition',
+            fields: [],
+            availableFilters: [],
+            dataUrl: '/data',
+            countUrl: '/count',
+          },
+        });
+        const view = useViewState({
+          defaultColumns,
+          defaultPageSize: 10,
+          defaultTableSize: 'middle',
+          defaultCondition: savedView.condition,
+          defaultActiveFilters: savedView.filters,
+          externalCondition: viewer.condition,
+          externalUpdateCondition: viewer.setCondition,
+          onChange,
+        });
+        return { view, viewer };
+      });
+      act(() => {
+        result.current.view.setCondition(
+          { field: 'status', operator: Operator.EQ, value: 'changed' },
+          new Map([
+            [
+              'status',
+              { field: 'status', operator: Operator.EQ, value: 'changed' },
+            ],
+          ]),
+          new Map([['status', { operator: Operator.EQ, value: 'changed' }]]),
+        );
+      });
+      expect(result.current.viewer.viewChanged).toBe(true);
+      onChange.mockClear();
+
+      act(() => result.current.view.reset());
+
+      expect(result.current.view.activeFilters).toEqual(savedView.filters);
+      expect(result.current.viewer.activeView.filters).toEqual(
+        savedView.filters,
+      );
+      expect(result.current.view.condition).toEqual(savedView.condition);
+      expect(result.current.viewer.condition).toEqual(savedView.condition);
+      expect(result.current.viewer.viewChanged).toBe(false);
+      expect(onChange).toHaveBeenCalledExactlyOnceWith(
+        savedView.condition,
+        1,
+        10,
+        undefined,
+      );
+    });
+
     it('should use external columns when provided', () => {
       const externalColumns: ViewColumn[] = [
         { key: 'external', name: 'external', fixed: false, hidden: true },

--- a/packages/viewer/test/hooks/useViewerState.test.ts
+++ b/packages/viewer/test/hooks/useViewerState.test.ts
@@ -142,7 +142,11 @@ describe('useViewerState', () => {
         value: '1',
       };
       act(() => {
-        result.current.setCondition(condition, new Map([['test', condition]]), new Map());
+        result.current.setCondition(
+          condition,
+          new Map([['test', condition]]),
+          new Map(),
+        );
       });
 
       expect(result.current.viewChanged).toBe(true);
@@ -150,6 +154,34 @@ describe('useViewerState', () => {
   });
 
   describe('setCondition', () => {
+    it.each([null, undefined])(
+      'preserves an empty value config (%s) without marking the view changed',
+      value => {
+        const view = createViewState({
+          condition: all(),
+          filters: [
+            {
+              type: 'test',
+              key: 'test',
+              field: { name: 'test', label: 'test' },
+              operator: { defaultValue: Operator.EQ },
+              value,
+            },
+          ],
+        });
+        const { result } = renderHook(() =>
+          useViewerState({
+            views: [view],
+            defaultView: view,
+            definition: viewDefinition,
+          }),
+        );
+        act(() => result.current.setCondition(all(), new Map(), new Map()));
+        expect(result.current.activeView.filters[0].value).toBe(value);
+        expect(result.current.viewChanged).toBe(false);
+      },
+    );
+
     it('should preserve operator when value is empty (partial filter save)', () => {
       const view = createViewState({
         filters: [
@@ -185,10 +217,10 @@ describe('useViewerState', () => {
         );
       });
 
-      // Verify operator is preserved with value: null
+      // Verify the operator is preserved and only the default value is cleared.
       const savedFilter = result.current.activeView.filters[0];
       expect(savedFilter.operator?.defaultValue).toBe(newOperator);
-      expect(savedFilter.value).toBe(null);
+      expect(savedFilter.value?.defaultValue).toBeUndefined();
     });
 
     it('should save full filter when both operator and value are provided', () => {
@@ -234,7 +266,7 @@ describe('useViewerState', () => {
       expect(savedFilter.value).toEqual({ defaultValue: 'search term' });
     });
 
-    it('should reset value to null when no filterState exists', () => {
+    it('should clear the default value when no filterState exists', () => {
       const view = createViewState({
         filters: [
           {
@@ -264,7 +296,7 @@ describe('useViewerState', () => {
       });
 
       const savedFilter = result.current.activeView.filters[0];
-      expect(savedFilter.value).toBe(null);
+      expect(savedFilter.value?.defaultValue).toBeUndefined();
     });
   });
 

--- a/packages/viewer/test/view/View.regression.test.tsx
+++ b/packages/viewer/test/view/View.regression.test.tsx
@@ -1,0 +1,304 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+  renderHook,
+} from '@testing-library/react';
+import { View } from '../../src/view/View';
+import { useViewState } from '../../src/view/hooks/useViewState';
+import { mapToTableRecord } from '../../src/utils';
+import { Operator } from '@ahoo-wang/fetcher-wow';
+import { useViewerState } from '../../src/viewer/hooks/useViewerState';
+const props = {
+  fields: [
+    { name: 'id', label: 'ID', type: 'text', primaryKey: true },
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'text',
+      primaryKey: false,
+      sorter: true,
+    },
+  ],
+  availableFilters: [],
+  dataSource: { list: [{ id: 'a', name: 'A' }], total: 100 },
+  defaultColumns: [
+    { key: 'id', name: 'id', fixed: true, hidden: false },
+    { key: 'name', name: 'name', fixed: false, hidden: false },
+  ],
+  defaultPageSize: 10,
+  defaultTableSize: 'middle',
+  pagination: { showSizeChanger: true },
+  showFilter: false,
+  filterMode: 'none',
+  enableRowSelection: false,
+} as any;
+afterEach(cleanup);
+it('initializes the requested default page', () => {
+  const { result } = renderHook(() =>
+    useViewState({
+      defaultColumns: [],
+      defaultPage: 5,
+      defaultPageSize: 10,
+      defaultTableSize: 'middle',
+    }),
+  );
+  expect(result.current.page).toBe(5);
+});
+it('updates pagination atomically', () => {
+  const onChange = vi.fn();
+  const { result } = renderHook(() =>
+    useViewState({
+      defaultColumns: [],
+      defaultPageSize: 10,
+      defaultTableSize: 'middle',
+      onChange,
+    }),
+  );
+  act(() => result.current.setPage(10));
+  onChange.mockClear();
+  act(() => {
+    result.current.setPagination(2, 50);
+  });
+  expect(result.current.page).toBe(2);
+  expect(onChange.mock.calls.at(-1).slice(1, 3)).toEqual([2, 50]);
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+it('hides pagination while row selection is enabled', () => {
+  const { container } = render(
+    <View {...props} pagination={false} enableRowSelection />,
+  );
+  expect(container.querySelector('.ant-pagination')).toBeNull();
+});
+it('resets an uncontrolled View and queries once', () => {
+  const ref = React.createRef<any>();
+  const onChange = vi.fn();
+  render(<View {...props} ref={ref} onChange={onChange} />);
+  fireEvent.click(screen.getByTitle('2'));
+  expect(
+    document.querySelector('.ant-pagination-item-active')?.textContent,
+  ).toBe('2');
+  onChange.mockClear();
+  act(() => ref.current.reset());
+  expect(
+    document.querySelector('.ant-pagination-item-active')?.textContent,
+  ).toBe('1');
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+it('keeps nested primary keys stable across reordering', () => {
+  const data = [{ state: { id: 'A' } }, { state: { id: 'B' } }];
+  expect(mapToTableRecord(data, 'state.id').map(x => x.key)).toEqual([
+    'A',
+    'B',
+  ]);
+  expect(
+    mapToTableRecord([...data].reverse(), 'state.id').map(x => x.key),
+  ).toEqual(['B', 'A']);
+});
+
+it('preserves filter configuration when searching', () => {
+  const view = {
+    id: 'V',
+    name: 'V',
+    definitionId: 'D',
+    type: 'PERSONAL',
+    source: 'CUSTOM',
+    isDefault: false,
+    columns: [],
+    filters: [
+      {
+        key: 'status',
+        type: 'select',
+        field: { name: 'status', label: 'Status' },
+        value: {
+          defaultValue: ['open'],
+          options: [
+            { value: 'open', label: 'Open' },
+            { value: 'closed', label: 'Closed' },
+          ],
+        },
+        operator: {
+          defaultValue: Operator.IN,
+          supportedOperators: [Operator.IN],
+        },
+      },
+    ],
+    tableSize: 'middle',
+    pageSize: 10,
+    condition: { operator: 'ALL' },
+    sorter: [],
+  } as any;
+  const { result } = renderHook(() =>
+    useViewerState({
+      views: [view],
+      defaultView: view,
+      definition: {
+        id: 'D',
+        name: 'D',
+        fields: [],
+        availableFilters: [],
+        dataUrl: '/data',
+        countUrl: '/count',
+      },
+    }),
+  );
+  const condition = { field: 'status', operator: Operator.IN, value: ['open'] };
+  act(() =>
+    result.current.setCondition(
+      condition,
+      new Map([['status', condition]]),
+      new Map([['status', { operator: Operator.IN, value: ['open'] }]]),
+    ),
+  );
+  expect(result.current.activeFilters[0].value.options).toEqual(
+    view.filters[0].value.options,
+  );
+  expect(result.current.activeFilters[0].operator.supportedOperators).toEqual([
+    Operator.IN,
+  ]);
+  act(() =>
+    result.current.setCondition(
+      { operator: Operator.ALL },
+      new Map(),
+      new Map([['status', { operator: Operator.IN, value: undefined }]]),
+    ),
+  );
+  expect(result.current.activeFilters[0].value?.defaultValue).toBeUndefined();
+  expect(result.current.activeFilters[0].value.options).toEqual(
+    view.filters[0].value.options,
+  );
+  expect(result.current.activeFilters[0].operator.supportedOperators).toEqual([
+    Operator.IN,
+  ]);
+});
+it('updates controlled pagination once and resets controlled state', () => {
+  const onChange = vi.fn();
+  const columns = [{ key: 'id', name: 'id', hidden: false, fixed: true }];
+  const { result } = renderHook(() => {
+    const [page, setPage] = React.useState(10);
+    const [size, setSize] = React.useState(10);
+    const [tableSize, setTableSize] = React.useState<any>('small');
+    const [currentColumns, setColumns] = React.useState<any[]>([]);
+    return useViewState({
+      defaultColumns: columns,
+      defaultPage: 5,
+      defaultPageSize: 10,
+      defaultTableSize: 'middle',
+      externalPage: page,
+      externalUpdatePage: setPage,
+      externalPageSize: size,
+      externalUpdatePageSize: setSize,
+      externalTableSize: tableSize,
+      externalUpdateTableSize: setTableSize,
+      externalColumns: currentColumns,
+      externalUpdateColumns: setColumns,
+      onChange,
+    });
+  });
+  act(() => result.current.setPagination(2, 50));
+  expect(result.current.page).toBe(2);
+  expect(result.current.pageSize).toBe(50);
+  expect(onChange).toHaveBeenCalledExactlyOnceWith(
+    { operator: 'ALL' },
+    2,
+    50,
+    [],
+  );
+  onChange.mockClear();
+  act(() => result.current.reset());
+  expect(result.current.page).toBe(5);
+  expect(result.current.pageSize).toBe(10);
+  expect(result.current.tableSize).toBe('middle');
+  expect(result.current.columns).toEqual(columns);
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+it('resets all fields when controlled by useViewerState', () => {
+  const original = {
+    id: 'original',
+    name: 'Original',
+    definitionId: 'definition',
+    type: 'PERSONAL',
+    source: 'CUSTOM',
+    isDefault: false,
+    columns: [{ name: 'id', key: 'id', fixed: true, hidden: false }],
+    filters: [],
+    condition: { operator: Operator.ALL },
+    sorter: [],
+    pageSize: 10,
+    tableSize: 'middle',
+  } as any;
+  const onChange = vi.fn();
+  const { result } = renderHook(() => {
+    const viewer = useViewerState({
+      views: [original],
+      defaultView: original,
+      definition: {
+        id: 'definition',
+        name: 'Definition',
+        fields: [],
+        availableFilters: [],
+        dataUrl: '/data',
+        countUrl: '/count',
+      },
+    });
+    const view = useViewState({
+      defaultColumns: original.columns,
+      defaultActiveFilters: original.filters,
+      defaultCondition: original.condition,
+      defaultPageSize: original.pageSize,
+      defaultTableSize: original.tableSize,
+      defaultSorter: original.sorter,
+      externalColumns: viewer.columns,
+      externalUpdateColumns: viewer.setColumns,
+      externalActiveFilters: viewer.activeFilters,
+      externalUpdateActiveFilters: viewer.setActiveFilters,
+      externalCondition: viewer.condition,
+      externalUpdateCondition: viewer.setCondition,
+      externalPage: viewer.page,
+      externalUpdatePage: viewer.setPage,
+      externalPageSize: viewer.pageSize,
+      externalUpdatePageSize: viewer.setPageSize,
+      externalTableSize: viewer.tableSize,
+      externalUpdateTableSize: viewer.setTableSize,
+      externalSorter: viewer.sorter,
+      externalUpdateSorter: viewer.setSorter,
+      onChange,
+    });
+    return { viewer, view };
+  });
+  act(() => result.current.view.setColumns([]));
+  act(() => result.current.view.setPageSize(50));
+  act(() => result.current.view.setTableSize('small'));
+  onChange.mockClear();
+  act(() => result.current.view.reset());
+  expect(result.current.viewer.activeView).toEqual(original);
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+it('requests the clamped page once when the pagination size changes', () => {
+  const onChange = vi.fn();
+  render(<View {...props} defaultPage={10} onChange={onChange} />);
+  fireEvent.mouseDown(screen.getByRole('combobox'));
+  fireEvent.click(screen.getByText('50 / page'));
+  expect(onChange).toHaveBeenCalledExactlyOnceWith(
+    { operator: Operator.ALL },
+    2,
+    50,
+    [],
+  );
+});

--- a/packages/viewer/test/view/View.reset.test.tsx
+++ b/packages/viewer/test/view/View.reset.test.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRef, useRef } from 'react';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
+import type { Condition } from '@ahoo-wang/fetcher-wow';
+import { Operator, SortDirection } from '@ahoo-wang/fetcher-wow';
+import { useViewerState, View } from '../../src';
+import type { ViewDefinition, ViewRef, ViewState } from '../../src';
+
+afterEach(cleanup);
+
+it.each(['normal', 'editable'] as const)(
+  'resets controlled %s filter inputs before the next search',
+  filterMode => {
+    const definition: ViewDefinition = {
+      id: 'definition',
+      name: 'Definition',
+      fields: [],
+      availableFilters: [],
+      dataUrl: '/data',
+      countUrl: '/count',
+    };
+    const savedView: ViewState = {
+      id: 'saved',
+      name: 'Saved',
+      definitionId: definition.id,
+      type: 'PERSONAL',
+      source: 'CUSTOM',
+      isDefault: false,
+      columns: [],
+      pageSize: 10,
+      tableSize: 'middle',
+      sorter: [],
+      condition: { field: 'status', operator: Operator.EQ, value: 'saved' },
+      filters: [
+        {
+          key: 'status',
+          type: 'text',
+          field: { name: 'status', label: 'Status' },
+          operator: { defaultValue: Operator.EQ },
+          value: { defaultValue: 'saved' },
+        },
+      ],
+    };
+    const queries: Condition[] = [];
+    function ControlledView() {
+      const state = useViewerState({
+        views: [savedView],
+        defaultView: savedView,
+        definition,
+      });
+      const ref = useRef<ViewRef>(null);
+      return (
+        <>
+          <button onClick={() => ref.current?.reset()}>Reset view</button>
+          <View
+            ref={ref}
+            fields={[]}
+            availableFilters={[]}
+            dataSource={{ list: [], total: 0 }}
+            defaultColumns={[]}
+            defaultPageSize={10}
+            defaultTableSize="middle"
+            defaultActiveFilters={savedView.filters}
+            defaultCondition={savedView.condition}
+            externalActiveFilters={state.activeFilters}
+            externalUpdateActiveFilters={state.setActiveFilters}
+            externalCondition={state.condition}
+            externalUpdateCondition={state.setCondition}
+            pagination={false}
+            enableRowSelection={false}
+            showFilter
+            filterMode={filterMode}
+            onChange={condition => queries.push(condition)}
+          />
+        </>
+      );
+    }
+    render(<ControlledView />);
+    fireEvent.change(screen.getByLabelText('Status value'), {
+      target: { value: 'edited' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /搜\s*索/ }));
+    expect(queries.at(-1)?.value).toBe('edited');
+    queries.length = 0;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset view' }));
+
+    expect(queries).toEqual([savedView.condition]);
+    expect(screen.getByLabelText('Status value')).toHaveValue('saved');
+    fireEvent.click(screen.getByRole('button', { name: /搜\s*索/ }));
+    expect(queries.at(-1)).toEqual(savedView.condition);
+  },
+);
+
+it('restores the default table sort and clears row selection once on reset', () => {
+  const ref = createRef<ViewRef>();
+  const onChange = vi.fn();
+  const onSelectedDataChange = vi.fn();
+  const defaultSorter = [{ field: 'name', direction: SortDirection.ASC }];
+  render(
+    <View
+      ref={ref}
+      fields={[
+        { name: 'id', label: 'ID', type: 'text', primaryKey: true },
+        {
+          name: 'name',
+          label: 'Name',
+          type: 'text',
+          primaryKey: false,
+          sorter: true,
+        },
+      ]}
+      availableFilters={[]}
+      dataSource={{ list: [{ id: 'record', name: 'Alice' }], total: 1 }}
+      defaultColumns={[
+        { key: 'id', name: 'id', fixed: true, hidden: false },
+        {
+          key: 'name',
+          name: 'name',
+          fixed: false,
+          hidden: false,
+          sortOrder: 'ascend',
+        },
+      ]}
+      defaultSorter={defaultSorter}
+      defaultCondition={{ operator: Operator.ALL }}
+      defaultPageSize={10}
+      defaultTableSize="middle"
+      pagination={false}
+      enableRowSelection
+      showFilter={false}
+      filterMode="none"
+      onChange={onChange}
+      onSelectedDataChange={onSelectedDataChange}
+    />,
+  );
+  expect(screen.getByRole('columnheader', { name: /Name/ })).toHaveAttribute(
+    'aria-sort',
+    'ascending',
+  );
+  fireEvent.click(screen.getByRole('columnheader', { name: /Name/ }));
+  expect(screen.getByRole('columnheader', { name: /Name/ })).toHaveAttribute(
+    'aria-sort',
+    'descending',
+  );
+  expect(onChange).toHaveBeenLastCalledWith({ operator: Operator.ALL }, 1, 10, [
+    { field: 'name', direction: SortDirection.DESC },
+  ]);
+  fireEvent.click(screen.getAllByRole('checkbox').at(-1)!);
+  expect(screen.getAllByRole('checkbox').at(-1)).toBeChecked();
+  onChange.mockClear();
+  onSelectedDataChange.mockClear();
+
+  act(() => ref.current?.reset());
+
+  expect(onChange).toHaveBeenCalledExactlyOnceWith(
+    { operator: Operator.ALL },
+    1,
+    10,
+    defaultSorter,
+  );
+  expect(onSelectedDataChange).toHaveBeenCalledExactlyOnceWith([]);
+  for (const checkbox of screen.getAllByRole('checkbox')) {
+    expect(checkbox).not.toBeChecked();
+  }
+  expect(screen.getByRole('columnheader', { name: /Name/ })).toHaveAttribute(
+    'aria-sort',
+    'ascending',
+  );
+  fireEvent.click(screen.getByRole('columnheader', { name: /Name/ }));
+  expect(screen.getByRole('columnheader', { name: /Name/ })).toHaveAttribute(
+    'aria-sort',
+    'descending',
+  );
+  expect(onChange).toHaveBeenLastCalledWith({ operator: Operator.ALL }, 1, 10, [
+    { field: 'name', direction: SortDirection.DESC },
+  ]);
+});

--- a/packages/viewer/test/viewer/Viewer.regression.test.tsx
+++ b/packages/viewer/test/viewer/Viewer.regression.test.tsx
@@ -1,0 +1,252 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+  waitFor,
+} from '@testing-library/react';
+const state = vi.hoisted(() => ({ topbar: null as any }));
+vi.mock('../../src/topbar/TopBar', () => ({
+  TopBar: (props: any) => {
+    state.topbar = props;
+    return <output>{JSON.stringify(props.tableSelectedItems)}</output>;
+  },
+}));
+vi.mock('../../src/viewer/panel/ViewPanel', () => ({
+  ViewPanel: (props: any) => (
+    <button onClick={() => props.onSwitchView(props.views[1])}>
+      switch view B
+    </button>
+  ),
+}));
+vi.mock('@ahoo-wang/fetcher-react', async original => ({
+  ...(await original<any>()),
+  dataMonitorService: { initialize: () => {} },
+}));
+import { Viewer } from '../../src/viewer/Viewer';
+import { all } from '@ahoo-wang/fetcher-wow';
+const definition = {
+  id: 'D',
+  name: 'D',
+  fields: [{ name: 'id', label: 'ID', type: 'text', primaryKey: true }],
+  availableFilters: [],
+  dataUrl: '/data',
+  countUrl: '/count',
+};
+const a = {
+  id: 'A',
+  name: 'A',
+  definitionId: 'D',
+  type: 'PERSONAL',
+  source: 'CUSTOM',
+  isDefault: false,
+  columns: [{ key: 'id', name: 'id', fixed: true, hidden: false }],
+  filters: [],
+  tableSize: 'middle',
+  pageSize: 10,
+  condition: { operator: 'ALL' },
+  sorter: [],
+} as any;
+const b = { ...a, id: 'B', name: 'B' };
+afterEach(cleanup);
+it('requests ALL exactly once when resetting a saved view without a condition', () => {
+  const onLoadData = vi.fn();
+  const savedView = { ...a };
+  delete savedView.condition;
+  render(
+    <Viewer
+      defaultViews={[savedView]}
+      defaultView={savedView}
+      definition={definition}
+      dataSource={{ list: [], total: 0 }}
+      pagination={{}}
+      onLoadData={onLoadData}
+    />,
+  );
+  onLoadData.mockClear();
+  act(() => state.topbar.onReset());
+  expect(onLoadData).toHaveBeenCalledExactlyOnceWith(all(), 1, 10, []);
+});
+
+it('clears batch selection when switching views', () => {
+  const ref = React.createRef<any>();
+  const onLoadData = vi.fn();
+  render(
+    <Viewer
+      ref={ref}
+      defaultViews={[a, b]}
+      defaultView={a}
+      definition={definition}
+      dataSource={{ list: [{ id: 'old-A-record' }], total: 1 }}
+      pagination={false}
+      onLoadData={onLoadData}
+    />,
+  );
+  const checkboxes = screen.getAllByRole('checkbox');
+  fireEvent.click(checkboxes[checkboxes.length - 1]);
+  expect(state.topbar.tableSelectedItems).toHaveLength(1);
+  fireEvent.click(screen.getByText('switch view B'));
+  expect(ref.current.getActiveView().id).toBe('B');
+  expect(state.topbar.tableSelectedItems).toEqual([]);
+  expect(screen.getAllByRole('checkbox').every((c: any) => !c.checked)).toBe(
+    true,
+  );
+  expect(onLoadData).not.toHaveBeenCalled();
+});
+it('selects a remaining view after deleting the active view', () => {
+  const ref = React.createRef<any>();
+  render(
+    <Viewer
+      ref={ref}
+      defaultViews={[a, b]}
+      defaultView={a}
+      definition={definition}
+      dataSource={{ list: [], total: 0 }}
+      pagination={false}
+      onDeleteView={(v, done) => done?.(v)}
+    />,
+  );
+  act(() => state.topbar.onDeleteView(a));
+  expect(state.topbar.views.map((v: any) => v.id)).toEqual(['B']);
+  expect(ref.current.getActiveView().id).toBe('B');
+});
+it.each(['create', 'update'])(
+  'clears selection on %s success, including same-view updates',
+  operation => {
+    const onSwitchView = vi.fn();
+    render(
+      <Viewer
+        defaultViews={[a, b]}
+        defaultView={a}
+        definition={definition}
+        dataSource={{ list: [{ id: 'old-A-record' }], total: 1 }}
+        pagination={false}
+        onSwitchView={onSwitchView}
+        onCreateView={(view, done) => done?.(view)}
+        onUpdateView={(view, done) => done?.(view)}
+      />,
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[checkboxes.length - 1]);
+    act(() =>
+      operation === 'create'
+        ? state.topbar.onCreateView({ ...a, id: 'created' })
+        : state.topbar.onUpdateView({ ...a, name: 'Renamed' }),
+    );
+    expect(state.topbar.tableSelectedItems).toEqual([]);
+    expect(screen.getAllByRole('checkbox').every((c: any) => !c.checked)).toBe(
+      true,
+    );
+    expect(onSwitchView).toHaveBeenCalledTimes(1);
+  },
+);
+it('renders an empty viewer after deleting its last view', () => {
+  const ref = React.createRef<any>();
+  const { container } = render(
+    <Viewer
+      ref={ref}
+      defaultViews={[a]}
+      defaultView={a}
+      definition={definition}
+      dataSource={{ list: [], total: 0 }}
+      pagination={false}
+      onDeleteView={(v, done) => done?.(v)}
+    />,
+  );
+  act(() => state.topbar.onDeleteView(a));
+  expect(container.querySelector('.ant-table')).toBeNull();
+  expect(ref.current.getActiveView()).toBeUndefined();
+});
+it('creates a replacement view from the empty state after deleting the last view', async () => {
+  const ref = React.createRef<any>();
+  render(
+    <Viewer
+      ref={ref}
+      defaultViews={[a]}
+      defaultView={a}
+      definition={definition}
+      dataSource={{ list: [], total: 0 }}
+      pagination={false}
+      onDeleteView={(view, done) => done?.(view)}
+      onCreateView={(view, done) => done?.({ ...view, id: 'replacement' })}
+    />,
+  );
+  act(() => state.topbar.onDeleteView(a));
+  expect(ref.current.getActiveView()).toBeUndefined();
+
+  fireEvent.click(screen.getByRole('button', { name: '创建视图' }));
+  fireEvent.change(screen.getByLabelText('视图名称'), {
+    target: { value: 'Replacement' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: '确 认' }));
+
+  await waitFor(() => {
+    expect(ref.current.getActiveView()).toMatchObject({
+      id: 'replacement',
+      name: 'Replacement',
+      type: 'PERSONAL',
+      source: 'CUSTOM',
+      isDefault: false,
+    });
+  });
+  expect(screen.queryByText('未找到视图')).toBeNull();
+});
+it('restores saved filters and requests exactly once when resetting Viewer', () => {
+  const onLoadData = vi.fn();
+  const originalCondition = {
+    operator: 'EQ',
+    field: 'status',
+    value: 'original',
+  } as any;
+  const originalView = {
+    ...a,
+    condition: originalCondition,
+    filters: [
+      {
+        key: 'status',
+        type: 'text',
+        field: { name: 'status', label: 'Status' },
+        operator: { defaultValue: 'EQ' },
+        value: { defaultValue: 'original' },
+      },
+    ],
+  } as any;
+  const { container } = render(
+    <Viewer
+      defaultViews={[originalView]}
+      defaultView={originalView}
+      definition={definition}
+      dataSource={{ list: [], total: 0 }}
+      pagination={{}}
+      onLoadData={onLoadData}
+    />,
+  );
+  fireEvent.change(screen.getByLabelText('Status value'), {
+    target: { value: 'changed' },
+  });
+  fireEvent.click(container.querySelector('button.ant-btn-primary')!);
+  onLoadData.mockClear();
+  act(() => state.topbar.onReset());
+  expect(screen.getByLabelText('Status value')).toHaveValue('original');
+  expect(onLoadData).toHaveBeenCalledExactlyOnceWith(
+    originalCondition,
+    1,
+    10,
+    [],
+  );
+});

--- a/skills/fetcher-viewer-components/references/api.md
+++ b/skills/fetcher-viewer-components/references/api.md
@@ -256,6 +256,10 @@ Layout component with sidebar (ViewPanel), TopBar, and content area. Does not ha
 
 **ViewerRef methods:** `clearSelectedRowKeys()`, `getActiveView()`, `getCondition()`
 
+`getActiveView(): ViewState | undefined` returns `undefined` after the last view is deleted; the viewer displays an empty state. Switching views, including switches after create/update/delete, clears row selection and batch-action records. Reset restores the saved view and loads its query once.
+When `onCreateView` is supplied, the empty state keeps a create-view action and
+activates the new view after the callback succeeds.
+
 ---
 
 ## View Component
@@ -288,6 +292,23 @@ Combines filter panel + ViewTable + pagination. Supports controlled and uncontro
 
 **ViewRef methods:** `clearSelectedRowKeys()`, `updateTableSize(size)`, `reset()`, `getCondition()`
 
+`defaultPage` initializes the uncontrolled page (default `1`). `reset()` restores the `default*` values, notifies supplied external state setters in controlled mode, clears selection, and emits one `onChange` with the restored query. `pagination={false}` hides pagination even when row selection remains enabled.
+Filter inputs and the table are recreated from the restored props, so both
+normal and editable panels display the defaults and the table header restores
+the default sort order. The next search or sort action starts from those
+restored values; row selection is cleared with one notification.
+
+The exported `useViewState` hook also exposes `setPagination(page: number, pageSize: number): void`. Use it when page and page size change together; it updates both values and emits one `onChange` using those values. Individual `setPage` and `setPageSize` calls each emit their own change.
+
+`externalUpdateCondition(condition, activeFilterValues, filterStates, resetFilters?)`
+accepts an optional fourth `ActiveFilter[]` parameter. During reset, the first
+argument is the default condition, both Maps are empty, and `resetFilters` is the
+complete default filter list. `useViewerState.setCondition` accepts this same
+optional parameter and restores those definitions exactly, including omitted
+operator/value settings. Normal searches continue to use the existing three
+arguments. This supports controlling the condition while managing active filters
+inside `useViewState`.
+
 ---
 
 ## ViewTable Component
@@ -313,6 +334,8 @@ Ant Design Table wrapper with automatic column generation from field definitions
 ```
 
 Columns are auto-generated from `FieldDefinition[]` + `ViewColumn[]`. Each field maps to a cell type via `cellRegistry`. Primary key fields render as `PrimaryKeyCell` (clickable link). Action column uses `ActionsCell`.
+
+Primary key names may be nested paths such as `state.id`; row keys resolve that same path to remain stable when records are reordered.
 
 ---
 


### PR DESCRIPTION
## Description

Clear stale row selection when views change, preserve filter options, reset saved query state once, handle empty views, and honor defaultPage and disabled pagination. Resolve nested primary keys and update page/page size atomically.

Use one reset version to remount filter inputs and the table after resetting controlled state. Displayed filter values, table sort indicators and the next search now use the same saved defaults when View is used directly. Tests cover real parent state, both filter panels, header clicks and a single selection-clear callback.

Empty searches preserve null or absent filter-value configurations. Resetting older saved views without a condition now requests ALL exactly once, matching the restored local state.

This series prepares version 5.0.0 for its public type changes; no release is published by these updates.

## Validation

Local checks passed before this stack update. Each layer was also compared with its verified source delta; current stacked heads receive fresh CI:

- `pnpm build`
- `pnpm test:unit` — 280 files, 3810 passed, 1 skipped
- `pnpm -r --filter=./packages/* exec tsc --noEmit --ignoreDeprecations 6.0`
- `pnpm -r --filter=./packages/* exec eslint .`
- `git diff --check`
- Viewer and FetcherViewer real-browser Storybook tests — 17 passed

Node.js 24.11.0, pnpm 10.34.5. Existing lint warnings remain; no build configuration or third-party dependencies changed. Regressions were reproduced before behavior changes, and bilingual wiki updates were built.

## Review and CI

Ready for review. Each merge candidate requires a completed GitHub Codex review, no unresolved review threads, and five successful CI workflows for its current head. Old-head results do not satisfy that gate. Codacy quality-rule findings are tracked separately with source evidence.

Native GitHub stack #1418, layer 15 of 16. Keep this PR separate and squash layers in stack order. GitHub rebases the remaining layers after each partial merge; verify their new Codex reviews and CI before continuing.

Split index: #1399.
