### PR TITLE
feat(view-engine): support element match in simple filters

### DIFF
--- a/packages/view-engine/README.md
+++ b/packages/view-engine/README.md
@@ -452,9 +452,9 @@ export function OrderFilters({
 }
 ```
 
-Simple mode uses an implicit AND; advanced mode structurally edits all 50 Wow operators including AND / OR / NOR / ELEMENT_MATCH. Editing, clearing, undo and mode switches make no requests. Query calls `onApply` with `{configuration, expression}`. The host executes the request and supplies `querying` / `queryError`. Use `onPendingChange` to guard view saving.
+Simple mode uses an implicit AND at the root and within each ELEMENT_MATCH scope, including nested arrays; advanced mode structurally edits all 50 Wow operators including AND / OR / NOR / ELEMENT_MATCH. Editing, clearing, undo and mode switches make no requests. Query calls `onApply` with `{configuration, expression}`. The host executes the request and supplies `querying` / `queryError`. Use `onPendingChange` to guard view saving.
 
-Simple mode allows one condition per field, including unset values. Advanced AND/OR/NOR groups allow multiple conditions on the same field, including inside element scopes. Repeated bindings are valid for compilation and instance persistence; they keep the editor in advanced mode until each field occurs once and the tree is otherwise simple.
+Simple mode allows one condition per field within each scope, including unset values. Element predicates show “same element satisfies” with child filters and no logical-group selector. Empty element scopes remain editable but block Query until a child condition is added. Advanced AND/OR/NOR groups allow multiple conditions on the same field, including inside element scopes. Repeated bindings are valid for compilation and instance persistence; they keep the editor in advanced mode until each field occurs once per scope and the tree is otherwise simple.
 
 Add filter opens an anchored Popover with grouped checkboxes, keeping the table and query toolbar in place. Its height is capped and its field area scrolls internally. It stays open for continuous additions; Done or Escape closes it and returns focus to Add filter. Clicking outside dismisses it. Set `group` on field definitions to group choices in definition order. Ungrouped fields appear under Other fields when mixed with named groups. Checking a field adds its condition; unchecking removes that field's direct conditions in the current group. Checkbox state follows the draft even when a value is unset. Advanced mode shows each selected field’s condition count and an adjacent Append condition action for additional same-field predicates in any logical group; advanced mode places AND/OR/NOR in the adjacent icon dropdown instead of the field picker. Root-level operators remain add actions. Logical menu choices respect the definition allowlist. Changes apply only on Query.
 
@@ -464,8 +464,8 @@ Simple mode has no condition action menu or ordering controls. Advanced mode sup
 
 For composition, `FilterPanel.renderToolbar` replaces the default heading and receives
 `FilterPanelToolbarProps`: `panelId`, `mode`, `options`, `pending`, `disabled` and
-`onModeChange`. Use its guarded callback and disabled options; incomplete or nested
-advanced conditions cannot switch to simple. `collapsed` hides only the body and
+`onModeChange`. Use its guarded callback and disabled options; incomplete conditions, repeated fields within a scope, OR/NOR and nested logical groups
+cannot switch to simple. Supported element scopes switch without changing the tree. `collapsed` hides only the body and
 retains editors. `RecordView.toolbarStart` accepts leading global-toolbar content;
 `ViewPage` supplies saving, title and instance navigation there.
 

--- a/packages/view-engine/README.zh-CN.md
+++ b/packages/view-engine/README.zh-CN.md
@@ -281,9 +281,9 @@ export function OrderFilters({
 }
 ```
 
-简单模式隐含 AND，高级模式结构化编辑全部 50 种 Wow 操作以及 AND / OR / NOR / ELEMENT_MATCH。编辑、清空、撤销、模式切换都不请求服务；点击查询后通过 `onApply` 提交合法条件。宿主接收 `{configuration, expression}` 并管理请求，通过 `querying` / `queryError` 传回状态。`onPendingChange` 用于保存视图前的待查询保护。
+简单模式在根级和每个 ELEMENT_MATCH 元素作用域内隐含 AND，支持嵌套数组；高级模式结构化编辑全部 50 种 Wow 操作以及 AND / OR / NOR / ELEMENT_MATCH。编辑、清空、撤销、模式切换都不请求服务；点击查询后通过 `onApply` 提交合法条件。宿主接收 `{configuration, expression}` 并管理请求，通过 `querying` / `queryError` 传回状态。`onPendingChange` 用于保存视图前的待查询保护。
 
-简单模式中每个字段只保留一项，未设置值也占用该字段。高级模式的 AND、OR、NOR 均允许同一字段多条规则，元素作用域内同样适用；编译与实例保存接受合法的重复字段条件。包含重复字段的草稿保持高级模式，删除多余条件且结构可平铺后才允许切回简单模式。
+简单模式中每个作用域内的字段只保留一项，未设置值也占用该字段。元素条件显示“同一元素满足”和子筛选项，不显示逻辑组合选择器；空元素作用域可继续编辑，但添加子条件前不能查询。高级模式的 AND、OR、NOR 均允许同一字段多条规则，元素作用域内同样适用；编译与实例保存接受合法的重复字段条件。包含重复字段的草稿保持高级模式，删除多余条件且各作用域符合简单模式结构后才允许切回简单模式。
 
 点击“添加筛选”打开锚定按钮的 Popover，按组展示 Checkbox，打开和关闭不改变表格、查询按钮的位置。浮层限制高度，字段区内部滚动；添加后保持打开，支持连续添加。“完成”或 Esc 关闭并返回触发按钮焦点，点击外部也可关闭。字段定义可通过 `group` 指定分组，按定义中的首次出现顺序展示。与有分组字段混用时，未分组字段显示在“其他字段”下；复选框与当前分组的草稿同步：勾选添加条件，取消勾选移除该字段的直接条件，未设置值仍显示为已勾选。高级模式在已选字段旁显示条件数量和“追加条件”加号，AND、OR、NOR 统一支持追加；高级模式在“添加筛选”旁提供图标下拉按钮，独立选择 AND/OR/NOR 并添加到当前分组，这三项不进入字段面板；未获定义允许的操作禁用。根级操作仍保留添加按钮。所有变更仍在点击“查询”后统一生效。
 
@@ -295,7 +295,7 @@ export function OrderFilters({
 
 自定义筛选器可使用任意 React 组件。注册 `render: 'value'`（默认）替换值区域，或用 `render: 'filter'` 与 `FilterComponentProps` 接管完整非容器 UI。面板继续负责字段与能力校验、错误展示，以及点击查询后统一生效。
 
-组合布局可用 `FilterPanel.renderToolbar` 替换默认标题，接收 `FilterPanelToolbarProps`：`panelId`、`mode`、`options`、`pending`、`disabled`、`onModeChange`。使用面板提供的回调与禁用选项，嵌套或未完善的高级条件不能切回简单模式。`collapsed` 仅隐藏内容并保留编辑器；`RecordView.toolbarStart` 可插入全局工具栏左侧内容，`ViewPage` 在此提供保存、标题与实例选择。
+组合布局可用 `FilterPanel.renderToolbar` 替换默认标题，接收 `FilterPanelToolbarProps`：`panelId`、`mode`、`options`、`pending`、`disabled`、`onModeChange`。使用面板提供的回调与禁用选项，含 OR/NOR、嵌套逻辑分组、作用域内重复字段或未完善的条件不能切回简单模式；符合规则的元素作用域可切换且保留原树结构。`collapsed` 仅隐藏内容并保留编辑器；`RecordView.toolbarStart` 可插入全局工具栏左侧内容，`ViewPage` 在此提供保存、标题与实例选择。
 
 ## 单个控件
 

--- a/packages/view-engine/src/filter/FilterAddControl.tsx
+++ b/packages/view-engine/src/filter/FilterAddControl.tsx
@@ -62,10 +62,7 @@ export function FilterAddControl({
     );
     if (
       !operators.length ||
-      (!canAdd && !bindings.some(node => node.field === field.field)) ||
-      (mode === 'simple' &&
-        field.type === 'array' &&
-        operators.every(op => FILTER_OPERATORS[op].category === 'element'))
+      (!canAdd && !bindings.some(node => node.field === field.field))
     )
       return [];
     return [
@@ -123,8 +120,6 @@ export function FilterAddControl({
               op =>
                 (!props.allowedOperators ||
                   props.allowedOperators.includes(op)) &&
-                (mode === 'advanced' ||
-                  FILTER_OPERATORS[op].category !== 'element') &&
                 (getNamedFilterOperators(
                   resolveFilterComponent(op, field, props.editors).name,
                 )?.includes(op) ??

--- a/packages/view-engine/src/filter/FilterNode.tsx
+++ b/packages/view-engine/src/filter/FilterNode.tsx
@@ -62,6 +62,20 @@ export function FilterNode({
     field?.label ?? node.field ?? descriptor?.label ?? String(node.operator);
   const nodeIssues = issues.filter(issue => issue.id === node.id);
   const errorId = `${panelId}-${node.id}-error`;
+  if (mode === 'simple' && node.operator === FilterOperator.AND) {
+    return (
+      <>
+        {node.operands?.map(child => (
+          <FilterNode key={`${epoch}:${child.id}`} node={child} panel={panel} />
+        ))}
+        {nodeIssues.length > 0 && (
+          <div role="alert" id={errorId}>
+            {nodeIssues.map(issue => issue.message).join('；')}
+          </div>
+        )}
+      </>
+    );
+  }
   if (node.operands || node.operator === FilterOperator.ELEMENT_MATCH) {
     const element = node.operator === FilterOperator.ELEMENT_MATCH;
     return (
@@ -169,7 +183,8 @@ export function FilterNode({
   ).filter(
     op =>
       (!props.allowedOperators || props.allowedOperators.includes(op)) &&
-      (mode === 'advanced' || FILTER_OPERATORS[op].category === 'field') &&
+      (mode === 'advanced' ||
+        ['field', 'element'].includes(FILTER_OPERATORS[op].category)) &&
       !resolveFilterEditor(
         {
           ...location,

--- a/packages/view-engine/src/filter/FilterPanel.tsx
+++ b/packages/view-engine/src/filter/FilterPanel.tsx
@@ -108,7 +108,7 @@ export function FilterPanel(props: FilterPanelProps) {
         )}
         {!simple && (
           <p className="fve:m-0 fve:text-sm fve:text-muted-foreground">
-            当前包含同一字段的多条规则、嵌套或特殊条件，需使用高级模式。
+            当前包含同一作用域内的重复字段、逻辑分组或特殊条件，需使用高级模式。
           </p>
         )}
         {mode === 'advanced' && simple && issues.length > 0 && (

--- a/packages/view-engine/src/filter/filterDraftTransitions.ts
+++ b/packages/view-engine/src/filter/filterDraftTransitions.ts
@@ -30,6 +30,8 @@ export function transitionFilterOperator(
   op: FilterOperator,
 ): FilterComponentConfig {
   if (node.operator === op) return structuredClone(node);
+  if (op === FilterOperator.ELEMENT_MATCH)
+    return { ...newFilterNode(op, node.field), id: node.id };
   const next = {
     ...newFilterNode(op, node.field, node.component),
     id: node.id,

--- a/packages/view-engine/src/filter/filterNodes.ts
+++ b/packages/view-engine/src/filter/filterNodes.ts
@@ -40,21 +40,31 @@ export function newFilterNode(
 export function isSimpleFilter(
   draft: DeepReadonly<FilterComponentConfig>,
 ): boolean {
-  const ordinary = (node: DeepReadonly<FilterComponentConfig>) =>
-    Object.prototype.hasOwnProperty.call(FILTER_OPERATORS, node.operator) &&
-    FILTER_OPERATORS[node.operator].category === 'field' &&
-    typeof node.field === 'string' &&
-    node.field.length > 0 &&
-    node.operands === undefined &&
-    node.predicate === undefined;
-  return (
-    draft.operator === Op.MATCH_ALL ||
-    ordinary(draft) ||
-    (draft.operator === Op.AND &&
-      Array.isArray(draft.operands) &&
-      draft.operands.length > 0 &&
-      draft.operands.every(ordinary) &&
-      new Set(draft.operands.map(node => node.field)).size ===
-        draft.operands.length)
-  );
+  function bound(node: DeepReadonly<FilterComponentConfig>): boolean {
+    return (
+      Object.prototype.hasOwnProperty.call(FILTER_OPERATORS, node.operator) &&
+      typeof node.field === 'string' &&
+      node.field.length > 0 &&
+      node.operands === undefined &&
+      (node.operator === Op.ELEMENT_MATCH
+        ? !!node.predicate && scope(node.predicate, true)
+        : FILTER_OPERATORS[node.operator].category === 'field' &&
+          node.predicate === undefined)
+    );
+  }
+  function scope(
+    node: DeepReadonly<FilterComponentConfig>,
+    allowEmpty = false,
+  ): boolean {
+    return (
+      bound(node) ||
+      (node.operator === Op.AND &&
+        Array.isArray(node.operands) &&
+        (allowEmpty || node.operands.length > 0) &&
+        node.operands.every(bound) &&
+        new Set(node.operands.map(child => child.field)).size ===
+          node.operands.length)
+    );
+  }
+  return draft.operator === Op.MATCH_ALL || scope(draft);
 }

--- a/packages/view-engine/src/filter/useFilterPanelState.ts
+++ b/packages/view-engine/src/filter/useFilterPanelState.ts
@@ -203,7 +203,9 @@ export function useFilterPanelState(props: FilterPanelProps) {
     const next = transitionFilterOperator(node, op);
     const before = FILTER_OPERATORS[node.operator]?.input,
       after = FILTER_OPERATORS[op]?.input;
-    change(replaceFilterNode(configurationRef.current.root, node.id, next)!);
+    if (op === FilterOperator.ELEMENT_MATCH) update(node.id, next);
+    else
+      change(replaceFilterNode(configurationRef.current.root, node.id, next)!);
     if (
       before !== after &&
       after !== 'none' &&
@@ -242,7 +244,14 @@ export function useFilterPanelState(props: FilterPanelProps) {
       fields,
     ).find(item => item.node.id === target.id)?.node;
     if (!current || !canAppend(current)) return;
-    const next = appendNode(current, child);
+    const allowed = latest.current.props.allowedOperators;
+    const next =
+      current.operator === FilterOperator.AND &&
+      current.operands?.length === 0 &&
+      allowed &&
+      !allowed.includes(FilterOperator.AND)
+        ? child
+        : appendNode(current, child);
     if (mode === 'advanced' || isSimpleFilter(next)) update(current.id, next);
   }
   function currentEditorNode(node: FilterComponentConfig) {

--- a/packages/view-engine/test/filterConfiguration.test.ts
+++ b/packages/view-engine/test/filterConfiguration.test.ts
@@ -22,6 +22,7 @@ import type {
   FilterConfiguration,
   FilterComponentConfig,
 } from '../src/filter/filterModel.js';
+import { transitionFilterOperator } from '../src/filter/filterDraftTransitions.js';
 import { fields, node } from './fixtures/filterCore.js';
 
 it('round trips stable identities, unset controls, typed buffers and date/time attributes through JSON', () => {
@@ -232,4 +233,34 @@ it('keeps element and logical containers builtin when a field has a custom leaf 
   const config = createFilterConfiguration(draft, 'advanced');
   expect(config.root.component.name).toBe('builtin');
   expect(compileFilterConfiguration(config, fields).errors).toEqual([]);
+});
+
+it('round trips and compiles simple element predicates without flattening their scope', () => {
+  const root = {
+    ...node(Op.ELEMENT_MATCH, 'items'),
+    predicate: {
+      ...node(Op.AND),
+      operands: [node(Op.EQ, 'quantity', { value: 2 })],
+    },
+  };
+  const config = createFilterConfiguration(root, 'simple');
+  const reloaded = JSON.parse(JSON.stringify(config));
+  expect(reloaded).toEqual(config);
+  expect(() => validateFilterConfiguration(reloaded, fields)).not.toThrow();
+  expect(compileFilterConfiguration(reloaded, fields)).toEqual(
+    compileFilterConfiguration({ ...config, mode: 'advanced' }, fields),
+  );
+  expect(compileFilterConfiguration(reloaded, fields).errors).toEqual([]);
+});
+
+it('switches a custom array editor to a builtin element container', () => {
+  const source = {
+    ...node(Op.EQ, 'items'),
+    component: { name: 'custom' },
+    props: { value: ['a'] },
+  };
+  const result = transitionFilterOperator(source, Op.ELEMENT_MATCH);
+  expect(result.component).toEqual({ name: 'builtin' });
+  expect(result.props).toEqual({});
+  expect(() => createFilterConfiguration(result, 'simple')).not.toThrow();
 });

--- a/packages/view-engine/test/filterCoreTree.test.ts
+++ b/packages/view-engine/test/filterCoreTree.test.ts
@@ -280,7 +280,7 @@ it('validates fields, capabilities and element relative scope even for unset val
   ]);
 });
 
-it('recognizes only root match-all, field predicates and flat AND as simple', () => {
+it('recognizes root match-all, field predicates and flat AND as simple', () => {
   expect(isSimpleFilter(newFilterNode(Op.MATCH_ALL))).toBe(true);
   expect(isSimpleFilter(node(Op.EQ, 'amount'))).toBe(true);
   expect(
@@ -307,8 +307,35 @@ it('recognizes only root match-all, field predicates and flat AND as simple', ()
         ],
       },
     ),
-    node(Op.ELEMENT_MATCH, 'items'),
     node(Op.EQ),
   ])
     expect(isSimpleFilter(draft)).toBe(false);
+});
+
+it('recognizes recursive element scopes and enforces field uniqueness within each scope', () => {
+  const element = (predicate: FilterComponentConfig) => ({
+    ...newFilterNode(Op.ELEMENT_MATCH, 'items'),
+    predicate,
+  });
+  const and = (...operands: FilterComponentConfig[]) => ({
+    ...newFilterNode(Op.AND),
+    operands,
+  });
+  const nested = element(
+    and(node(Op.EQ, 'quantity'), element(node(Op.EQ, 'quantity'))),
+  );
+  expect(isSimpleFilter(and(node(Op.EQ, 'quantity'), nested))).toBe(true);
+  expect(isSimpleFilter(newFilterNode(Op.ELEMENT_MATCH, 'items'))).toBe(true);
+  expect(isSimpleFilter(newFilterNode(Op.AND))).toBe(false);
+  for (const predicate of [
+    and(node(Op.GTE, 'quantity'), node(Op.LTE, 'quantity')),
+    { ...and(node(Op.EQ, 'quantity')), operator: Op.OR },
+    { ...and(node(Op.EQ, 'quantity')), operator: Op.NOR },
+    and(and(node(Op.EQ, 'quantity'))),
+    node(Op.MATCH_ALL),
+  ])
+    expect(isSimpleFilter(element(predicate))).toBe(false);
+  expect(isSimpleFilter(and(nested, element(node(Op.EQ, 'quantity'))))).toBe(
+    false,
+  );
 });

--- a/packages/view-engine/test/filterPanelModes.test.tsx
+++ b/packages/view-engine/test/filterPanelModes.test.tsx
@@ -22,7 +22,9 @@ import {
 } from '@testing-library/react';
 import { afterEach, expect, it, vi } from 'vitest';
 import { FilterPanel } from '../src/filter/FilterPanel.js';
-import { fields, select } from './fixtures/filterPanel.js';
+import { useEffect } from 'react';
+import type { FilterComponentProps } from '../src/filter/filterReactTypes.js';
+import { fields, select, builtinCompiler } from './fixtures/filterPanel.js';
 
 afterEach(cleanup);
 
@@ -198,33 +200,165 @@ it('keeps simple filters free of condition menus and applies the original order'
   );
 });
 
-it('does not offer destructive simple-mode conversion for element conditions', async () => {
+it('switches element conditions to simple mode without changing their tree', async () => {
+  const apply = vi.fn(),
+    change = vi.fn();
+  const root = {
+    ...node('AND'),
+    operands: [
+      node('EQ', 'amount', { value: 10 }),
+      {
+        ...node('ELEMENT_MATCH', 'items'),
+        predicate: {
+          ...node('AND'),
+          operands: [node('EQ', 'quantity', { value: 2 })],
+        },
+      },
+    ],
+  };
   render(
     <FilterPanel
       fields={fields}
-      defaultValue={configuration({
-        ...node('AND'),
-        operands: [
-          node('EQ', 'amount', { value: 10 }),
-          {
-            ...node('ELEMENT_MATCH', 'items'),
-            predicate: {
-              ...node('AND'),
-              operands: [node('EQ', 'quantity', { value: 2 })],
-            },
-          },
-        ],
-      })}
-      onApply={() => {}}
+      defaultValue={configuration(root, 'advanced')}
+      onApply={apply}
+      onChange={change}
     />,
   );
-  fireEvent.click(screen.getByRole('combobox', { name: '筛选模式' }));
-  expect(
-    (await screen.findByRole('option', { name: '简单' })).getAttribute(
-      'aria-disabled',
-    ),
-  ).toBe('true');
-  fireEvent.keyDown(screen.getByRole('option', { name: '高级', exact: true }), {
-    key: 'Escape',
+  await select('筛选模式', '简单');
+  expect(change).toHaveBeenLastCalledWith({ mode: 'simple', root });
+  expect(screen.queryByRole('combobox', { name: '组合方式' })).toBeNull();
+  expect(screen.queryByRole('button', { name: /添加逻辑分组/ })).toBeNull();
+  expect(apply).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole('button', { name: '查询', exact: true }));
+  expect(apply).toHaveBeenCalledWith({
+    configuration: { mode: 'simple', root },
+    expression: filter.and([
+      filter.eq('amount', 10),
+      filter.elementMatch('items', filter.and([filter.eq('quantity', 2)])),
+    ]),
   });
+  await select('筛选模式', '高级');
+  expect(change).toHaveBeenLastCalledWith({ mode: 'advanced', root });
+});
+
+it.each([false, true])(
+  'adds and completes a simple element scope (element-only: %s)',
+  async onlyElement => {
+    const apply = vi.fn(),
+      change = vi.fn();
+    const definitions = fields.map(field =>
+      field.field === 'items' && onlyElement
+        ? { ...field, operators: [node('ELEMENT_MATCH').operator] }
+        : field,
+    );
+    render(
+      <FilterPanel fields={definitions} onApply={apply} onChange={change} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '添加筛选' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: '商品明细' }));
+    fireEvent.click(screen.getByRole('button', { name: '完成' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    if (!onlyElement) await select('商品明细操作', '同一元素满足');
+    expect(change.mock.lastCall?.[0].mode).toBe('simple');
+    expect(
+      screen.getByRole('group', { name: '商品明细元素条件' }),
+    ).toBeTruthy();
+    expect(screen.queryByRole('combobox', { name: '组合方式' })).toBeNull();
+    expect(
+      screen
+        .getByRole('button', { name: '查询', exact: true })
+        .hasAttribute('disabled'),
+    ).toBe(true);
+    fireEvent.click(
+      screen.getByRole('button', { name: '商品明细元素内添加筛选' }),
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: '数量' }));
+    expect(
+      screen
+        .getByRole('checkbox', { name: '数量' })
+        .getAttribute('aria-checked'),
+    ).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: '完成' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    fireEvent.change(screen.getByLabelText('数量值'), {
+      target: { value: '2' },
+    });
+    expect(apply).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: '查询', exact: true }));
+    expect(apply.mock.lastCall?.[0].expression).toEqual(
+      filter.elementMatch('items', filter.and([filter.eq('quantity', 2)])),
+    );
+    fireEvent.click(screen.getByRole('button', { name: '删除数量条件' }));
+    expect(screen.getByRole('alert').textContent).toContain('至少需要一个条件');
+    fireEvent.click(
+      screen.getByRole('button', { name: '商品明细元素内添加筛选' }),
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: '数量' }));
+    expect(change.mock.lastCall?.[0].root.predicate.operands).toHaveLength(1);
+  },
+);
+
+it('creates a single element predicate when AND is not allowed', async () => {
+  const apply = vi.fn();
+  render(
+    <FilterPanel
+      fields={fields}
+      allowedOperators={[node('ELEMENT_MATCH').operator, node('EQ').operator]}
+      onApply={apply}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: '添加筛选' }));
+  fireEvent.click(screen.getByRole('checkbox', { name: '商品明细' }));
+  fireEvent.click(screen.getByRole('button', { name: '完成' }));
+  await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  await select('商品明细操作', '同一元素满足');
+  fireEvent.click(
+    screen.getByRole('button', { name: '商品明细元素内添加筛选' }),
+  );
+  fireEvent.click(screen.getByRole('checkbox', { name: '数量' }));
+  fireEvent.click(screen.getByRole('button', { name: '完成' }));
+  await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  fireEvent.change(screen.getByLabelText('数量值'), { target: { value: '2' } });
+  fireEvent.click(screen.getByRole('button', { name: '查询', exact: true }));
+  expect(apply.mock.lastCall?.[0].expression).toEqual(
+    filter.elementMatch('items', filter.eq('quantity', 2)),
+  );
+});
+
+it('clears invalid custom-editor state when switching to an element container', async () => {
+  function InvalidEditor({ onValidityChange }: FilterComponentProps) {
+    useEffect(() => {
+      onValidityChange(false, '旧编辑器错误');
+    }, [onValidityChange]);
+    return null;
+  }
+  const apply = vi.fn();
+  render(
+    <FilterPanel
+      fields={fields}
+      defaultValue={configuration(node('EQ', 'items', {}, { name: 'custom' }))}
+      extensions={{
+        filters: {
+          custom: {
+            component: InvalidEditor,
+            modes: ['simple', 'advanced'],
+            ...builtinCompiler,
+          },
+        },
+      }}
+      onApply={apply}
+    />,
+  );
+  expect(screen.getByRole('alert').textContent).toContain('旧编辑器错误');
+  await select('商品明细操作', '同一元素满足');
+  fireEvent.click(
+    screen.getByRole('button', { name: '商品明细元素内添加筛选' }),
+  );
+  fireEvent.click(screen.getByRole('checkbox', { name: '数量' }));
+  fireEvent.click(screen.getByRole('button', { name: '完成' }));
+  await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  fireEvent.change(screen.getByLabelText('数量值'), { target: { value: '2' } });
+  expect(screen.queryByRole('alert')).toBeNull();
+  fireEvent.click(screen.getByRole('button', { name: '查询', exact: true }));
+  expect(apply).toHaveBeenCalledTimes(1);
 });

--- a/skills/fetcher-view-engine/references/api.md
+++ b/skills/fetcher-view-engine/references/api.md
@@ -32,12 +32,12 @@ Core imports do not load React, DOM or CSS. Field descriptors define field capab
 
 `createFilterConfiguration` and `isSimpleFilter` accept readonly canonical nodes. `FilterPanel.value`, `defaultValue` and `appliedValue` accept readonly configurations; emitted configurations remain independent editable values.
 
-| Export                                        | Contract                                                                                                                                     |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FILTER_OPERATORS`                            | Complete readonly record of all 50 Wow operators: label, category, input kind and relative-time flag.                                        |
-| `newFilterNode(operator, field?, component?)` | Creates a canonical node with an ID, explicit component (default builtin), unset props, initial container children or ACTIVE deletion state. |
-| `getFieldOperators(field)`                    | Returns operators from field type and explicit field allowlist only; ignores editor defaults.                                                |
-| `isSimpleFilter(root)`                        | Structural eligibility: MATCH_ALL, an ordinary field predicate, or a flat AND of those predicates. Mode changes also check validity.         |
+| Export                                        | Contract                                                                                                                                                                                                                                                                                              |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FILTER_OPERATORS`                            | Complete readonly record of all 50 Wow operators: label, category, input kind and relative-time flag.                                                                                                                                                                                                 |
+| `newFilterNode(operator, field?, component?)` | Creates a canonical node with an ID, explicit component (default builtin), unset props, initial container children or ACTIVE deletion state.                                                                                                                                                          |
+| `getFieldOperators(field)`                    | Returns operators from field type and explicit field allowlist only; ignores editor defaults.                                                                                                                                                                                                         |
+| `isSimpleFilter(root)`                        | Structural eligibility: root MATCH_ALL, field predicates, ELEMENT_MATCH, or a flat AND of these. Each element scope recursively allows fields/elements or their implicit AND, with unique fields per scope. Empty element AND drafts are editable; compilation and mode changes still check validity. |
 
 The persisted contract is:
 
@@ -95,7 +95,7 @@ Configuration is JSON data. An object property with undefined represents an unse
 
 A custom compiler may combine predicates for its bound field, but cannot escape that field or its scope. Logical/element containers remain structural component nodes. Custom compiled outputs must satisfy the declared field capabilities and global operator allowlist. The selected built-in operation is also checked before date-only lowering; its generated range/group operators implement that already-authorized calendar-day condition.
 
-Field uniqueness is a simple-mode editing rule, not a compiler restriction. Advanced AND/OR/NOR groups accept repeated direct field bindings, including within element predicates. Compilation and view-instance validation preserve these conditions. `isSimpleFilter` returns false for repeated-field AND drafts, including unset conditions; a requested simple mode is rendered as advanced until the draft can be represented without losing rules.
+Field uniqueness is a simple-mode editing rule, not a compiler restriction. Advanced AND/OR/NOR groups accept repeated direct field bindings, including within element predicates. Compilation and view-instance validation preserve these conditions. `isSimpleFilter` returns false for repeated-field AND drafts, including unset conditions; simple configurations must satisfy this rule in every scope. Element scopes preserve their predicate tree when switching modes; OR/NOR and nested logical groups require advanced mode.
 
 Fully unset scalar predicates and cleared collections are omitted. An explicitly empty new group is incomplete; a nonempty group whose children are all inactive is omitted. Empty output at the query root becomes MATCH_ALL. Inactive children never become MATCH_ALL inside OR/NOR. A missing part of a bound, collection item or date/time pair blocks compilation. False, zero, explicit null and valid empty strings retain their meaning. ELEMENT_MATCH only accepts element-relative fields and excludes root-only metadata/search/deletion nodes.
 
@@ -139,8 +139,8 @@ Import components from `@ahoo-wang/fetcher-view-engine/react` and compiled style
 `FilterPanelToolbarProps` supplies `panelId: string`, `mode: FilterMode`, readonly
 `options: FilterOption<FilterMode>[]`, `pending: boolean`, `disabled: boolean`, and
 `onModeChange(mode): void`. Use the supplied options and callback for mode controls;
-the callback also rejects transitions while disabled or to simple mode with nested
-or incomplete conditions. `panelId` connects external disclosure `aria-controls`
+the callback also rejects transitions while disabled or to simple mode with unsupported logical groups, repeated fields within a scope
+or incomplete conditions. Recursive ELEMENT_MATCH scopes with implicit AND can switch without rewriting the tree. `panelId` connects external disclosure `aria-controls`
 to the body. `renderToolbar` remains visible when collapsed. The default toolbar
 is unchanged for standalone panels. Add filter aligns left; Undo, Clear and Query
 align right, with Query last.

--- a/stories/view-engine/FilterPanel.stories.tsx
+++ b/stories/view-engine/FilterPanel.stories.tsx
@@ -62,6 +62,19 @@ export const BusinessFilters: Story = {
   render: args => <Scenario {...args} />,
 };
 
+export const SimpleElement: Story = {
+  name: '简单 · 同一元素满足',
+  render: args => (
+    <Scenario
+      {...args}
+      initial={createFilterConfiguration(
+        newFilterNode(FilterOperator.ELEMENT_MATCH, 'items'),
+        'simple',
+      )}
+    />
+  ),
+};
+
 export const AdvancedTree: Story = {
   name: '高级 · 逻辑与同一元素',
   render: args => <Scenario {...args} initial={nestedFilter} />,

--- a/stories/view-engine/FilterPanel.test.stories.tsx
+++ b/stories/view-engine/FilterPanel.test.stories.tsx
@@ -17,6 +17,7 @@ import {
   playSearchableSelect,
 } from './filterPanelExtensions.play.js';
 import {
+  playSimpleElement,
   playAdvancedTree,
   playAllOperators,
   playBusinessFilters,
@@ -28,6 +29,7 @@ import {
   playRepeatedFields,
 } from './filterPanelSelection.play.js';
 import displayMeta, {
+  SimpleElement as DisplaySimpleElement,
   AdvancedTree as DisplayAdvancedTree,
   AllOperators as DisplayAllOperators,
   BusinessFilters as DisplayBusinessFilters,
@@ -110,4 +112,10 @@ export const AllOperators: Story = {
   ...DisplayAllOperators,
   tags: ['!dev', '!autodocs', 'test'],
   play: playAllOperators,
+};
+
+export const SimpleElement: Story = {
+  ...DisplaySimpleElement,
+  tags: ['!dev', '!autodocs', 'test'],
+  play: playSimpleElement,
 };

--- a/stories/view-engine/filterPanelQuery.play.ts
+++ b/stories/view-engine/filterPanelQuery.play.ts
@@ -12,7 +12,7 @@
  */
 
 import { FILTER_OPERATORS } from '@ahoo-wang/fetcher-view-engine';
-import { FilterOperator } from '@ahoo-wang/fetcher-wow';
+import { filter, FilterOperator } from '@ahoo-wang/fetcher-wow';
 import type { StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, within } from 'storybook/test';
 import type { DemoArgs } from './FilterPanelExamples.js';
@@ -109,4 +109,59 @@ export const playAllOperators: NonNullable<Story['play']> = async ({
     await userEvent.click(canvas.getByRole('button', { name: '查询' }));
     await expect(canvas.getByTestId('applied-filter')).toHaveTextContent(op);
   }
+};
+
+export const playSimpleElement: NonNullable<Story['play']> = async ({
+  canvasElement,
+  args,
+}) => {
+  if (args.disabled) return;
+  const canvas = within(canvasElement),
+    page = within(canvasElement.ownerDocument.body);
+  await expect(
+    canvas.getByRole('combobox', { name: '筛选模式' }),
+  ).toHaveTextContent('简单');
+  await expect(canvas.queryByRole('combobox', { name: '组合方式' })).toBeNull();
+  await expect(
+    canvas.getByRole('button', { name: '查询', exact: true }),
+  ).toBeDisabled();
+  await userEvent.click(
+    canvas.getByRole('button', { name: '商品明细元素内添加筛选' }),
+  );
+  await userEvent.click(
+    await page.findByRole('checkbox', { name: '商品编码' }),
+  );
+  await userEvent.click(page.getByRole('checkbox', { name: '数量' }));
+  await expect(page.queryByRole('button', { name: /追加/ })).toBeNull();
+  await userEvent.click(page.getByRole('button', { name: '完成' }));
+  await userEvent.type(canvas.getByLabelText('商品编码值'), 'SKU-1');
+  await userEvent.type(canvas.getByLabelText('数量值'), '2');
+  await expect(canvas.getByLabelText('宿主状态')).toHaveTextContent(
+    '已应用 0 次',
+  );
+  await userEvent.click(
+    canvas.getByRole('button', { name: '查询', exact: true }),
+  );
+  const expected = filter.elementMatch(
+    'items',
+    filter.and([filter.eq('sku', 'SKU-1'), filter.eq('quantity', 2)]),
+  );
+  await expect(
+    JSON.parse(canvas.getByTestId('applied-filter').textContent!),
+  ).toEqual(expected);
+  for (const mode of ['高级', '简单']) {
+    await userEvent.click(canvas.getByRole('combobox', { name: '筛选模式' }));
+    await userEvent.click(
+      await page.findByRole('option', { name: mode, exact: true }),
+    );
+  }
+  await expect(canvas.queryByRole('combobox', { name: '组合方式' })).toBeNull();
+  await expect(canvas.getByLabelText('数量值')).toHaveValue('2');
+  await expect(canvas.getByLabelText('宿主状态')).toHaveTextContent(
+    '已应用 1 次',
+  );
+  await userEvent.click(canvas.getByRole('button', { name: '清空条件' }));
+  await expect(canvas.getByLabelText('数量值')).toHaveValue('');
+  await userEvent.click(canvas.getByRole('button', { name: '撤销筛选修改' }));
+  await expect(canvas.getByLabelText('数量值')).toHaveValue('2');
 };

--- a/wiki/guides/view-engine/filters.md
+++ b/wiki/guides/view-engine/filters.md
@@ -25,7 +25,7 @@ Options can declare `group`. IDs preserve type: `1` and `'1'` are different. `gr
 
 Typing edits a draft. Query or Enter applies valid input. An unset control remains rendered and contributes no value-dependent predicate; it is not removed from saved configuration. The applied-condition clear button clears that control's value and queries immediately. Removing a control from the editing panel changes the draft instead.
 
-Simple mode has one control per field. Advanced mode can repeat a field and nest AND/OR/NOR or supported element conditions. Existing nested branches are not flattened on a mode switch. The field picker uses grouped checkboxes in a popup; logical groups are added through the separate button-group menu.
+Simple mode has one control per field in each scope. It supports ELEMENT_MATCH, including nested arrays, with an implicit AND inside each “same element satisfies” section. Empty element scopes remain editable but block Query until a child condition is added. Advanced mode can repeat a field and nest AND/OR/NOR. Existing nested branches are not flattened on a mode switch. The field picker uses grouped checkboxes in a popup; logical groups are added through the separate button-group menu.
 
 Persist `ViewInstance.config.filters: FilterConfiguration`, including component name, options, operator and raw `props`. Do not replace it with the compiled Wow `FilterExpression`: an expression cannot restore unset controls, chosen editors or display-only properties. The component registration owns pure `compile` and optional `clear` semantics; the panel coordinates application. See [filter contracts](../../reference/view-engine/filters.md).
 

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -1431,7 +1431,7 @@ Options can declare `group`. IDs preserve type: `1` and `'1'` are different. `gr
 
 Typing edits a draft. Query or Enter applies valid input. An unset control remains rendered and contributes no value-dependent predicate; it is not removed from saved configuration. The applied-condition clear button clears that control's value and queries immediately. Removing a control from the editing panel changes the draft instead.
 
-Simple mode has one control per field. Advanced mode can repeat a field and nest AND/OR/NOR or supported element conditions. Existing nested branches are not flattened on a mode switch. The field picker uses grouped checkboxes in a popup; logical groups are added through the separate button-group menu.
+Simple mode has one control per field in each scope. It supports ELEMENT_MATCH, including nested arrays, with an implicit AND inside each “same element satisfies” section. Empty element scopes remain editable but block Query until a child condition is added. Advanced mode can repeat a field and nest AND/OR/NOR. Existing nested branches are not flattened on a mode switch. The field picker uses grouped checkboxes in a popup; logical groups are added through the separate button-group menu.
 
 Persist `ViewInstance.config.filters: FilterConfiguration`, including component name, options, operator and raw `props`. Do not replace it with the compiled Wow `FilterExpression`: an expression cannot restore unset controls, chosen editors or display-only properties. The component registration owns pure `compile` and optional `clear` semantics; the panel coordinates application. See [filter contracts](../../reference/view-engine/filters.md).
 
@@ -21130,7 +21130,7 @@ import '@ahoo-wang/fetcher-view-engine/styles.css';
 
 输入只修改草稿，点击查询或按 Enter 才应用有效输入。未设置的控件会保留，但不产生依赖值的查询条件。已应用条件的清空按钮会清空对应控件值并立即查询；编辑面板中的删除按钮则删除整个草稿控件。
 
-简单模式每个字段只有一个控件；高级模式允许同字段多条规则，并支持 AND/OR/NOR 嵌套及已声明的元素条件。切换模式不会自动展开或删除已有分支。字段选择使用分组 Checkbox 弹层；逻辑组合从独立的 Button Group 菜单添加。
+简单模式每个作用域内的字段只有一个控件，支持 ELEMENT_MATCH 及嵌套数组；每个“同一元素满足”子筛选区隐含 AND。空元素作用域可继续编辑，但添加子条件前不能查询。高级模式允许同字段多条规则，并支持 AND/OR/NOR 嵌套。切换模式不会自动展开或删除已有分支。字段选择使用分组 Checkbox 弹层；逻辑组合从独立的 Button Group 菜单添加。
 
 保存 `ViewInstance.config.filters: FilterConfiguration`，包括组件名、options、操作符和原始 `props`。不能用编译后的 Wow `FilterExpression` 替代，否则无法恢复未设置控件、所选编辑器和展示属性。组件注册负责纯 `compile` 与可选 `clear`，面板负责协调查询。参阅[筛选契约](../../reference/view-engine/filters.md)。
 

--- a/wiki/zh/guides/view-engine/filters.md
+++ b/wiki/zh/guides/view-engine/filters.md
@@ -25,7 +25,7 @@ description: 选择内置编辑器，保存组件配置，并显式应用查询�
 
 输入只修改草稿，点击查询或按 Enter 才应用有效输入。未设置的控件会保留，但不产生依赖值的查询条件。已应用条件的清空按钮会清空对应控件值并立即查询；编辑面板中的删除按钮则删除整个草稿控件。
 
-简单模式每个字段只有一个控件；高级模式允许同字段多条规则，并支持 AND/OR/NOR 嵌套及已声明的元素条件。切换模式不会自动展开或删除已有分支。字段选择使用分组 Checkbox 弹层；逻辑组合从独立的 Button Group 菜单添加。
+简单模式每个作用域内的字段只有一个控件，支持 ELEMENT_MATCH 及嵌套数组；每个“同一元素满足”子筛选区隐含 AND。空元素作用域可继续编辑，但添加子条件前不能查询。高级模式允许同字段多条规则，并支持 AND/OR/NOR 嵌套。切换模式不会自动展开或删除已有分支。字段选择使用分组 Checkbox 弹层；逻辑组合从独立的 Button Group 菜单添加。
 
 保存 `ViewInstance.config.filters: FilterConfiguration`，包括组件名、options、操作符和原始 `props`。不能用编译后的 Wow `FilterExpression` 替代，否则无法恢复未设置控件、所选编辑器和展示属性。组件注册负责纯 `compile` 与可选 `clear`，面板负责协调查询。参阅[筛选契约](../../reference/view-engine/filters.md)。
 


### PR DESCRIPTION
## Description

Simple filters previously excluded `ELEMENT_MATCH`, requiring advanced mode to filter fields on the same array element. Simple mode now supports recursive element scopes with an implicit AND and one condition per field in each scope, while preserving the condition tree across mode switches.

Reuse the existing element editor, keep empty scopes incomplete, and retain advanced mode for OR/NOR, nested logical groups and repeated fields. Also handle array-editor transitions and single element predicates when AND is unavailable. Update bilingual documentation and add regression coverage.

## Type of change

- [x] New feature (non-breaking)
- [x] Documentation update

## How Has This Been Tested?

- `pnpm -r --filter './packages/*' build`
- `pnpm test:unit`
- `pnpm --filter @ahoo-wang/fetcher-view-engine test` — 919 tests in both standard and React compiler modes, plus type checks
- `VIEW_ENGINE_BROWSER_CHANNEL=chrome pnpm exec vitest run --project=storybook stories/view-engine/FilterPanel.test.stories.tsx` — 11 browser interaction tests
- `pnpm lint:view-engine`
- `node --test wiki/test/documentation.test.mjs` — 10 tests
- `pnpm --dir wiki build`
- `git diff --check`

Toolchain: Node.js 24.11.0, pnpm 10.34.5, local Chrome for browser tests.

## Checklist

- [x] Followed existing package APIs and style
- [x] Completed self-review and independent code review
- [x] Added regression tests and updated documentation
- [x] Existing and new unit tests pass locally
