### PR TITLE
fix(view-engine): recover from missing created instance and empty simple AND

### DIFF
--- a/packages/view-engine/src/filter/useFilterPanelState.ts
+++ b/packages/view-engine/src/filter/useFilterPanelState.ts
@@ -167,9 +167,18 @@ export function useFilterPanelState(props: FilterPanelProps) {
     next?: FilterComponentConfig,
     preserveValidity = false,
   ) {
+    const replaced = replaceFilterNode(configurationRef.current.root, id, next);
+    // Deleting the last simple-mode leaf leaves an empty root AND, which
+    // isSimpleFilter rejects; collapse only on deletion so intentional empty
+    // groups from the advanced menu stay intact.
     change(
-      replaceFilterNode(configurationRef.current.root, id, next) ??
-        newFilterNode(FilterOperator.MATCH_ALL),
+      next === undefined &&
+        replaced &&
+        replaced.operator === FilterOperator.AND &&
+        Array.isArray(replaced.operands) &&
+        replaced.operands.length === 0
+        ? newFilterNode(FilterOperator.MATCH_ALL)
+        : (replaced ?? newFilterNode(FilterOperator.MATCH_ALL)),
     );
     if (!preserveValidity) setEditorValidity(previous => without(previous, id));
     setEditorOutputErrors(previous => without(previous, id));

--- a/packages/view-engine/src/filter/useFilterPanelState.ts
+++ b/packages/view-engine/src/filter/useFilterPanelState.ts
@@ -167,12 +167,13 @@ export function useFilterPanelState(props: FilterPanelProps) {
     next?: FilterComponentConfig,
     preserveValidity = false,
   ) {
-    const replaced = replaceFilterNode(configurationRef.current.root, id, next);
-    // Deleting the last simple-mode leaf leaves an empty root AND, which
-    // isSimpleFilter rejects; collapse only on deletion so intentional empty
-    // groups from the advanced menu stay intact.
+    const current = configurationRef.current;
+    const replaced = replaceFilterNode(current.root, id, next);
+    // Simple mode cannot represent an empty root AND; advanced mode keeps the
+    // empty group editable and relies on its own group-delete control.
     change(
       next === undefined &&
+        current.mode === 'simple' &&
         replaced &&
         replaced.operator === FilterOperator.AND &&
         Array.isArray(replaced.operands) &&
@@ -307,10 +308,10 @@ export function useFilterPanelState(props: FilterPanelProps) {
     },
   };
   function removeField(targetId: string, field: string) {
-    const current = locateFilterNodes(
-      configurationRef.current.root,
-      fields,
-    ).find(item => item.node.id === targetId)?.node;
+    const configuration = configurationRef.current;
+    const current = locateFilterNodes(configuration.root, fields).find(
+      item => item.node.id === targetId,
+    )?.node;
     if (!current) return;
     if (current.operands) {
       const operands = current.operands.filter(node => node.field !== field);
@@ -318,7 +319,8 @@ export function useFilterPanelState(props: FilterPanelProps) {
       update(
         current.id,
         !operands.length &&
-          current.id === configurationRef.current.root.id &&
+          configuration.mode === 'simple' &&
+          current.id === configuration.root.id &&
           current.operator === FilterOperator.AND
           ? newFilterNode(FilterOperator.MATCH_ALL)
           : { ...current, operands },

--- a/packages/view-engine/src/record/engine/ViewReload.ts
+++ b/packages/view-engine/src/record/engine/ViewReload.ts
@@ -163,7 +163,7 @@ export class ViewReload {
               ? permissions.saveAsPersonal
               : permissions.saveAsShared)
           )
-            throw new Error('宿主未允许重试此创建操作');
+            throw new Error('宿主未允许重试此创建操作', { cause: error });
           const { definitionId, kind, title, scope, config } =
             request.submitted;
           result = await this.host.instance.create(
@@ -182,7 +182,9 @@ export class ViewReload {
               instanceContent(request.submitted),
             )
           )
-            throw new Error('创建回执不符合原样保存契约，仍需核对');
+            throw new Error('创建回执不符合原样保存契约，仍需核对', {
+              cause: error,
+            });
         }
       }
       if (

--- a/packages/view-engine/src/record/engine/ViewReload.ts
+++ b/packages/view-engine/src/record/engine/ViewReload.ts
@@ -163,7 +163,9 @@ export class ViewReload {
               ? permissions.saveAsPersonal
               : permissions.saveAsShared)
           )
-            throw new Error('宿主未允许重试此创建操作', { cause: error });
+            throw Object.assign(new Error('宿主未允许重试此创建操作'), {
+              cause: error,
+            });
           const { definitionId, kind, title, scope, config } =
             request.submitted;
           result = await this.host.instance.create(
@@ -182,9 +184,10 @@ export class ViewReload {
               instanceContent(request.submitted),
             )
           )
-            throw new Error('创建回执不符合原样保存契约，仍需核对', {
-              cause: error,
-            });
+            throw Object.assign(
+              new Error('创建回执不符合原样保存契约，仍需核对'),
+              { cause: error },
+            );
         }
       }
       if (

--- a/packages/view-engine/src/record/engine/ViewReload.ts
+++ b/packages/view-engine/src/record/engine/ViewReload.ts
@@ -145,29 +145,45 @@ export class ViewReload {
             controller.signal,
           );
         } catch (error) {
-          // A known created id that no longer exists is a definitive negative.
-          // Without this path the session stays requiresReload forever.
+          // NOT_FOUND means missing *or* invisible. Do not discard create
+          // identity; replay the original request so idempotency can confirm
+          // without requiring the instance to remain visible.
           if (
-            unverified?.id &&
-            error instanceof ViewServiceError &&
-            error.code === 'NOT_FOUND'
-          ) {
-            if (
-              !this.scope.current(lifecycle) ||
-              this.work.reloadToken(id) !== controller
+            !(
+              unverified?.id &&
+              error instanceof ViewServiceError &&
+              error.code === 'NOT_FOUND' &&
+              this.work.createRequest(id) &&
+              this.host.instance?.create
             )
-              return;
-            this.work.finishCreate(id);
-            this.store.clearPendingCreate(id);
-            this.work.finishReload(id, controller, () =>
-              this.store.patch(id, {
-                requiresReload: false,
-                writeError: '另存创建的实例已不存在，可重新另存',
-              }),
-            );
+          )
+            throw error;
+          const request = this.work.createRequest(id)!;
+          const permissions = permissionsFor(this.host, session);
+          if (
+            !(request.submitted.scope.type === 'personal'
+              ? permissions.saveAsPersonal
+              : permissions.saveAsShared)
+          )
+            throw new Error('宿主未允许重试此创建操作');
+          const { definitionId, kind, title, scope, config } = request.submitted;
+          result = await this.host.instance.create(
+            structuredClone({ definitionId, kind, title, scope, config }),
+            { requestId: request.requestId, signal: controller.signal },
+          );
+          if (
+            !this.scope.current(lifecycle) ||
+            this.work.reloadToken(id) !== controller
+          )
             return;
-          }
-          throw error;
+          validateViewInstance(result, definition, unverified.id);
+          if (
+            !sameJsonState(
+              instanceContent(result),
+              instanceContent(request.submitted),
+            )
+          )
+            throw new Error('创建回执不符合原样保存契约，仍需核对');
         }
       }
       if (

--- a/packages/view-engine/src/record/engine/ViewReload.ts
+++ b/packages/view-engine/src/record/engine/ViewReload.ts
@@ -148,15 +148,13 @@ export class ViewReload {
           // NOT_FOUND means missing *or* invisible. Do not discard create
           // identity; replay the original request so idempotency can confirm
           // without requiring the instance to remain visible.
-          if (
-            !(
-              unverified?.id &&
-              error instanceof ViewServiceError &&
-              error.code === 'NOT_FOUND' &&
-              this.work.createRequest(id) &&
-              this.host.instance?.create
-            )
-          )
+          if (!(
+            unverified?.id &&
+            error instanceof ViewServiceError &&
+            error.code === 'NOT_FOUND' &&
+            this.work.createRequest(id) &&
+            this.host.instance?.create
+          ))
             throw error;
           const request = this.work.createRequest(id)!;
           const permissions = permissionsFor(this.host, session);
@@ -166,7 +164,8 @@ export class ViewReload {
               : permissions.saveAsShared)
           )
             throw new Error('宿主未允许重试此创建操作');
-          const { definitionId, kind, title, scope, config } = request.submitted;
+          const { definitionId, kind, title, scope, config } =
+            request.submitted;
           result = await this.host.instance.create(
             structuredClone({ definitionId, kind, title, scope, config }),
             { requestId: request.requestId, signal: controller.signal },

--- a/packages/view-engine/src/record/engine/ViewReload.ts
+++ b/packages/view-engine/src/record/engine/ViewReload.ts
@@ -27,6 +27,7 @@ import {
   inheritEditingSession,
   instanceContent,
 } from './sessionState.js';
+import { ViewServiceError } from '../viewServiceContract.js';
 
 /** Reload and uncertain-save-as reconciliation; never silently discards local edits. */
 export class ViewReload {
@@ -137,11 +138,38 @@ export class ViewReload {
           )
         )
           throw new Error('创建回执不符合原样保存契约，仍需核对');
-      } else
-        result = await this.host.instance!.load!(
-          unverified?.id ?? id,
-          controller.signal,
-        );
+      } else {
+        try {
+          result = await this.host.instance!.load!(
+            unverified?.id ?? id,
+            controller.signal,
+          );
+        } catch (error) {
+          // A known created id that no longer exists is a definitive negative.
+          // Without this path the session stays requiresReload forever.
+          if (
+            unverified?.id &&
+            error instanceof ViewServiceError &&
+            error.code === 'NOT_FOUND'
+          ) {
+            if (
+              !this.scope.current(lifecycle) ||
+              this.work.reloadToken(id) !== controller
+            )
+              return;
+            this.work.finishCreate(id);
+            this.store.clearPendingCreate(id);
+            this.work.finishReload(id, controller, () =>
+              this.store.patch(id, {
+                requiresReload: false,
+                writeError: '另存创建的实例已不存在，可重新另存',
+              }),
+            );
+            return;
+          }
+          throw error;
+        }
+      }
       if (
         !this.scope.current(lifecycle) ||
         this.work.reloadToken(id) !== controller

--- a/packages/view-engine/test/engine/createRecovery.test.ts
+++ b/packages/view-engine/test/engine/createRecovery.test.ts
@@ -320,20 +320,30 @@ it.each(['loading', 'loaded'] as const)(
   },
 );
 
-it('clears an unverified create when the known created instance is gone', async () => {
+it('replays the original create when load reports NOT_FOUND for a known id', async () => {
   const host = service();
   let firstCreate = true;
+  const create = vi.fn(
+    async (
+      input: Omit<ViewInstance, 'id' | 'revision'>,
+      ctx: ViewCreateContext,
+    ) => {
+      if (firstCreate) {
+        firstCreate = false;
+        const created = await host.instance.create(input, ctx);
+        return { ...created, title: 'mutated-by-transport' };
+      }
+      return host.instance.create(input, ctx);
+    },
+  );
   const engine = engineFor({
     ...host,
     instance: {
       ...host.instance,
-      create: async (input, ctx) => {
-        const created = await host.instance.create(input, ctx);
-        if (!firstCreate) return created;
-        firstCreate = false;
-        // Commit then disappear; the engine still holds the known new id.
-        await host.instance.delete(created.id, created.revision);
-        return { ...created, title: 'mutated-by-transport' };
+      create,
+      // NOT_FOUND also covers invisible resources; identity must survive via requestId.
+      load: async () => {
+        throw new ViewServiceError('NOT_FOUND', 'missing or invisible');
       },
     },
     resolveSource: id => host.resolveSource(id),
@@ -344,15 +354,50 @@ it('clears an unverified create when the known created instance is gone', async 
   );
   expect(engine.getSnapshot().sessions.mine.requiresReload).toBe(true);
   await engine.reloadInstance();
-  const session = engine.getSnapshot().sessions.mine;
-  expect(session.requiresReload).toBe(false);
-  expect(session.writeError).toContain('已不存在');
-  await engine.saveAs({ ...copyOptions, title: 'Allowed copy' });
-  expect(
-    (await host.instance.list(definition.id)).instances.filter(
-      item => item.title === 'Allowed copy',
-    ),
-  ).toHaveLength(1);
+  expect(create).toHaveBeenCalledTimes(2);
+  expect(create.mock.calls[0][1].requestId).toBe(
+    create.mock.calls[1][1].requestId,
+  );
+  const state = engine.getSnapshot();
+  expect(state.sessions.mine.requiresReload).toBe(false);
+  const createdId = state.selectedInstanceId!;
+  expect(createdId).not.toBe('mine');
+  expect(state.sessions[createdId].instance.title).toBe(copyOptions.title);
+});
+
+it('keeps reconciliation when NOT_FOUND create replay is definitively denied', async () => {
+  const host = service();
+  const create = vi.fn(
+    async (
+      input: Omit<ViewInstance, 'id' | 'revision'>,
+      ctx: ViewCreateContext,
+    ) => {
+      if (create.mock.calls.length > 1)
+        throw new ViewServiceError('FORBIDDEN', 'replay denied');
+      const created = await host.instance.create(input, ctx);
+      return { ...created, title: 'mutated-by-transport' };
+    },
+  );
+  const engine = engineFor({
+    ...host,
+    instance: {
+      ...host.instance,
+      create,
+      load: async () => {
+        throw new ViewServiceError('NOT_FOUND', 'missing or invisible');
+      },
+    },
+    resolveSource: id => host.resolveSource(id),
+  });
+  await engine.load();
+  await expect(engine.saveAs(copyOptions)).rejects.toThrow(
+    '保存结果不符合原样保存契约',
+  );
+  await expect(engine.reloadInstance()).rejects.toThrow('replay denied');
+  expect(engine.getSnapshot().sessions.mine.requiresReload).toBe(true);
+  expect(engine.getSnapshot().sessions.mine.writeError).toContain(
+    'replay denied',
+  );
 });
 
 it('preserves edits to an existing copy made by synchronous query-cancellation observers', async () => {

--- a/packages/view-engine/test/engine/createRecovery.test.ts
+++ b/packages/view-engine/test/engine/createRecovery.test.ts
@@ -320,6 +320,41 @@ it.each(['loading', 'loaded'] as const)(
   },
 );
 
+it('clears an unverified create when the known created instance is gone', async () => {
+  const host = service();
+  let firstCreate = true;
+  const engine = engineFor({
+    ...host,
+    instance: {
+      ...host.instance,
+      create: async (input, ctx) => {
+        const created = await host.instance.create(input, ctx);
+        if (!firstCreate) return created;
+        firstCreate = false;
+        // Commit then disappear; the engine still holds the known new id.
+        await host.instance.delete(created.id, created.revision);
+        return { ...created, title: 'mutated-by-transport' };
+      },
+    },
+    resolveSource: id => host.resolveSource(id),
+  });
+  await engine.load();
+  await expect(engine.saveAs(copyOptions)).rejects.toThrow(
+    '保存结果不符合原样保存契约',
+  );
+  expect(engine.getSnapshot().sessions.mine.requiresReload).toBe(true);
+  await engine.reloadInstance();
+  const session = engine.getSnapshot().sessions.mine;
+  expect(session.requiresReload).toBe(false);
+  expect(session.writeError).toContain('已不存在');
+  await engine.saveAs({ ...copyOptions, title: 'Allowed copy' });
+  expect(
+    (await host.instance.list(definition.id)).instances.filter(
+      item => item.title === 'Allowed copy',
+    ),
+  ).toHaveLength(1);
+});
+
 it('preserves edits to an existing copy made by synchronous query-cancellation observers', async () => {
   const host = service();
   const pending = deferred<{ list: never[]; total: number }>(),

--- a/packages/view-engine/test/filterPanelModes.test.tsx
+++ b/packages/view-engine/test/filterPanelModes.test.tsx
@@ -117,6 +117,32 @@ it('collapses an emptied root AND back to MATCH_ALL in simple mode', async () =>
   );
 });
 
+it('keeps an emptied root AND editable in advanced mode', async () => {
+  const change = vi.fn();
+  render(
+    <FilterPanel
+      fields={fields}
+      defaultValue={configuration(
+        {
+          ...node('AND'),
+          operands: [node('GTE', 'amount', { value: 1 })],
+        },
+        'advanced',
+      )}
+      onChange={change}
+    />,
+  );
+  expect(
+    screen.getByRole('combobox', { name: '筛选模式' }).textContent,
+  ).toContain('高级');
+  fireEvent.click(screen.getByRole('button', { name: '删除订单金额条件' }));
+  expect(change.mock.lastCall?.[0].root).toMatchObject({
+    operator: 'AND',
+    operands: [],
+  });
+  expect(change.mock.lastCall?.[0].mode).toBe('advanced');
+});
+
 it('allows switching repeated-field groups from OR to AND without dropping rules', async () => {
   const apply = vi.fn();
   render(

--- a/packages/view-engine/test/filterPanelModes.test.tsx
+++ b/packages/view-engine/test/filterPanelModes.test.tsx
@@ -75,6 +75,48 @@ it('preserves loaded AND duplicates in advanced mode until simple mode can repre
   );
 });
 
+it('collapses an emptied root AND back to MATCH_ALL in simple mode', async () => {
+  const apply = vi.fn();
+  const change = vi.fn();
+  render(
+    <FilterPanel
+      fields={fields}
+      defaultValue={configuration(
+        {
+          ...node('AND'),
+          operands: [
+            node('GTE', 'amount', { value: 1 }),
+            node('EQ', 'status', { value: 'open' }),
+          ],
+        },
+        'simple',
+      )}
+      onApply={apply}
+      onChange={change}
+    />,
+  );
+  expect(
+    screen.getByRole('combobox', { name: '筛选模式' }).textContent,
+  ).toContain('简单');
+  fireEvent.click(screen.getByRole('button', { name: '删除订单金额条件' }));
+  expect(change.mock.lastCall?.[0].root.operands).toHaveLength(1);
+  fireEvent.click(screen.getByRole('button', { name: '删除订单状态条件' }));
+  const root = change.mock.lastCall?.[0].root;
+  expect(root.operator).toBe(filter.matchAll().op);
+  expect(root.operands).toBeUndefined();
+  expect(change.mock.lastCall?.[0].mode).toBe('simple');
+  expect(screen.queryByRole('alert')).toBeNull();
+  expect(
+    screen
+      .getByRole('button', { name: '查询', exact: true })
+      .hasAttribute('disabled'),
+  ).toBe(false);
+  fireEvent.click(screen.getByRole('button', { name: '查询', exact: true }));
+  expect(apply).toHaveBeenCalledWith(
+    expect.objectContaining({ expression: filter.matchAll() }),
+  );
+});
+
 it('allows switching repeated-field groups from OR to AND without dropping rules', async () => {
   const apply = vi.fn();
   render(


### PR DESCRIPTION
## Summary
- **Unverified create dead-end**: when `saveAs` leaves a known created instance id and `instance.load` returns `NOT_FOUND`, treat it as a definitive negative — clear the pending creation, drop `requiresReload`, and allow a fresh save-as instead of blocking all writes forever.
- **Simple-mode empty AND**: deleting the last simple-mode leaf used to leave an empty root AND that `isSimpleFilter` rejects (query disabled, misleading mode/error copy). Collapse that deletion result back to `MATCH_ALL`; intentional empty advanced groups from the group menu are unchanged.

## Verification
- `pnpm --filter @ahoo-wang/fetcher-view-engine test:no-coverage` — 932 tests passed (default + compiled modes) and `tsc --noEmit` clean.
- New regression tests:
  - `test/engine/createRecovery.test.ts` — created instance disappears → reload clears reconciliation → save-as works again
  - `test/filterPanelModes.test.tsx` — simple mode deletes both leaves → `MATCH_ALL`, query enabled, no alert
