### PR TITLE
feat(view-engine): use a side sheet for order workflows

### DIFF
--- a/packages/view-engine/examples/react/sales-order/OrderForms.tsx
+++ b/packages/view-engine/examples/react/sales-order/OrderForms.tsx
@@ -207,7 +207,7 @@ export function OrderForms({
   }
   return (
     <form onSubmit={submit} className="sales-form">
-      <fieldset disabled={busy}>
+      <fieldset disabled={busy} className="sales-form-body">
         {isDraft ? (
           <>
             <div className="sales-fields">
@@ -528,7 +528,7 @@ export function OrderForms({
           disabled={busy}
           onClick={onCancel}
         >
-          返回
+          {order ? '返回详情' : '取消创建'}
         </Button>
         <Button type="submit" disabled={busy}>
           {busy

--- a/packages/view-engine/examples/react/sales-order/OrderWorkbench.tsx
+++ b/packages/view-engine/examples/react/sales-order/OrderWorkbench.tsx
@@ -432,23 +432,33 @@ function WorkbenchSession({
         <Dialog.Portal>
           <div className="fve-root sales-dialog-scope" data-theme={appearance}>
             <Dialog.Backdrop className="sales-backdrop" />
-            <Dialog.Popup ref={popupRef} className="sales-dialog">
-              <Dialog.Title>
-                {dialog?.action === 'create'
-                  ? '创建销售订单'
-                  : dialog?.action === 'detail'
-                    ? `订单详情 ${dialog.id}`
-                    : dialog
-                      ? actionLabels[dialog.action]
-                      : ''}
-              </Dialog.Title>
-              <Dialog.Description className="sales-muted">
-                {dialog?.action === 'detail'
-                  ? '核对订单记录，再选择当前岗位要执行的操作。'
-                  : '填写本次业务信息，确认后更新订单。'}
-              </Dialog.Description>
+            <Dialog.Popup ref={popupRef} className="sales-sheet">
+              <header className="sales-sheet-header">
+                <Dialog.Title>
+                  {dialog?.action === 'create'
+                    ? '创建销售订单'
+                    : dialog?.action === 'detail'
+                      ? `订单详情 ${dialog.id}`
+                      : dialog
+                        ? actionLabels[dialog.action]
+                        : ''}
+                </Dialog.Title>
+                <Dialog.Description className="sales-muted">
+                  {dialog?.action === 'detail'
+                    ? '核对订单记录，再选择当前岗位要执行的操作。'
+                    : '填写本次业务信息，确认后更新订单。'}
+                </Dialog.Description>
+                <Dialog.Close
+                  render={<Button variant="ghost" />}
+                  className="sales-close"
+                  disabled={busy}
+                  aria-label="关闭详情"
+                >
+                  关闭
+                </Dialog.Close>
+              </header>
               {dialog?.action === 'detail' && selected ? (
-                <>
+                <div className="sales-sheet-body">
                   {feedback}
                   <section className="sales-next" aria-label="订单下一步">
                     <div>
@@ -514,7 +524,7 @@ function WorkbenchSession({
                     })}
                   </section>
                   <OrderDetails order={selected} />
-                </>
+                </div>
               ) : (
                 dialog && (
                   <OrderForms
@@ -536,14 +546,6 @@ function WorkbenchSession({
                   />
                 )
               )}
-              <Dialog.Close
-                render={<Button variant="ghost" />}
-                className="sales-close"
-                disabled={busy}
-                aria-label="关闭详情"
-              >
-                关闭
-              </Dialog.Close>
             </Dialog.Popup>
           </div>
         </Dialog.Portal>

--- a/packages/view-engine/examples/react/sales-order/sales-order.css
+++ b/packages/view-engine/examples/react/sales-order/sales-order.css
@@ -102,27 +102,59 @@
   z-index: 100;
 }
 
-.sales-dialog {
+.sales-sheet {
   position: fixed;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: min(860px, calc(100vw - 32px));
-  max-height: 90vh;
-  overflow: auto;
+  inset: 0 0 0 auto;
+  width: min(860px, 100vw);
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   background: var(--fve-background);
   color: var(--fve-foreground);
   border: 1px solid var(--fve-border);
-  border-radius: 12px;
-  padding: 28px;
+  border-radius: 0;
   z-index: 101;
   box-shadow: 0 20px 60px #0003;
 }
 
-.sales-dialog h2 {
+.sales-sheet h2 {
   font-size: 20px;
   font-weight: 650;
   margin: 0 70px 8px 0;
+}
+
+.sales-sheet-header {
+  position: relative;
+  flex-shrink: 0;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--fve-border);
+}
+
+.sales-sheet-header p {
+  margin: 0;
+  padding-right: 48px;
+}
+
+.sales-sheet-body,
+.sales-form-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding: 16px 24px;
+}
+
+.sales-sheet-body .sales-notice:empty {
+  display: none;
+}
+
+.sales-form {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .sales-close {
@@ -133,7 +165,6 @@
 
 .sales-form fieldset {
   border: 0;
-  padding: 0;
   margin: 0;
   min-width: 0;
 }
@@ -191,8 +222,9 @@
   justify-content: flex-end;
   gap: 10px;
   border-top: 1px solid var(--fve-border);
-  padding-top: 18px;
-  margin-top: 20px;
+  flex-shrink: 0;
+  padding: 16px 24px max(16px, env(safe-area-inset-bottom));
+  background: var(--fve-background);
 }
 
 .sales-facts {
@@ -333,8 +365,12 @@
     grid-template-columns: 1fr 1fr;
   }
 
-  .sales-dialog {
-    padding: 20px;
+  .sales-sheet-header,
+  .sales-sheet-body,
+  .sales-form-body,
+  .sales-form-actions {
+    padding-left: 16px;
+    padding-right: 16px;
   }
 
   .sales-totals {

--- a/stories/view-engine/orders/Aftersales.test.stories.tsx
+++ b/stories/view-engine/orders/Aftersales.test.stories.tsx
@@ -12,7 +12,7 @@
  */
 
 import type { StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import displayMeta, {
   Workbench,
   ReturnFromReceipt,
@@ -25,6 +25,38 @@ const meta = {
   tags: ['!dev', '!autodocs', 'test'],
 };
 export default meta;
+export const SheetNavigation: StoryObj<typeof meta> = {
+  ...Workbench,
+  play: async ({ canvasElement }) => {
+    const { canvas, page, open } = orderJourney(canvasElement);
+    const dialog = await open('SO-202609-1005');
+    const window = canvasElement.ownerDocument.defaultView!;
+    await waitFor(() => {
+      const bounds = dialog.getBoundingClientRect();
+      expect(bounds.top).toBe(0);
+      expect(bounds.right).toBe(window.innerWidth);
+      expect(bounds.height).toBe(window.innerHeight);
+    });
+    await userEvent.click(
+      within(dialog).getByRole('button', {
+        name: '登记退款',
+        exact: true,
+      }),
+    );
+    await userEvent.click(page.getByRole('button', { name: '返回详情' }));
+    await expect(page.getByRole('dialog')).toBe(dialog);
+    await expect(dialog).toHaveAccessibleName('订单详情 SO-202609-1005');
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(page.queryByRole('dialog')).not.toBeInTheDocument(),
+    );
+    await expect(
+      canvas.getByRole('button', {
+        name: '查看订单 SO-202609-1005',
+      }),
+    ).toHaveFocus();
+  },
+};
 export const ReturnToClosure: StoryObj<typeof meta> = {
   ...ReturnFromReceipt,
   play: async ({ canvasElement }) => {


### PR DESCRIPTION
## Summary

The sales-order Storybook example uses a long centered dialog for order details and business actions. Replace it with a right-aligned, full-height sheet (up to 860px wide, full-screen on narrow viewports), keeping the header and close control visible while details scroll independently.

Keep form actions in a fixed footer and make the return destination explicit. Reuse the existing Base UI Dialog and order state transitions without adding dependencies or changing public APIs. Add browser coverage for sheet placement, return-to-details navigation, Escape dismissal, and restored trigger focus.

## Validation

- `pnpm -r --filter='./packages/*' build`
- `npm_config_workspace_concurrency=1 pnpm test:unit` (packages run serially to avoid concurrent-suite timeouts)
- `VIEW_ENGINE_BROWSER_CHANNEL=chrome pnpm exec vitest run --project=storybook stories/view-engine/orders` — 27 passed
- Scoped ESLint, Prettier, and `git diff --check`
- Browser checks at 1440px and 390px: order details, refund submission, and fixed controls in a long creation form
