### PR TITLE
fix(view-engine): clarify view titles and preserve sidebar focus

### DIFF
--- a/packages/view-engine/src/record/page/ViewNavigation.tsx
+++ b/packages/view-engine/src/record/page/ViewNavigation.tsx
@@ -193,9 +193,9 @@ export function ViewSidebar({
       </div>
       {groups.map(group => (
         <section key={group.id} className="fve:flex fve:flex-col fve:gap-1">
-          <h3 className="fve:px-2 fve:py-1 fve:text-xs fve:font-medium fve:text-muted-foreground">
+          <h2 className="fve:px-2 fve:py-1 fve:text-xs fve:font-medium fve:text-muted-foreground">
             {group.label}
-          </h3>
+          </h2>
           {group.sessions.map(session => (
             <Button
               key={session.instance.id}

--- a/packages/view-engine/src/record/page/ViewNavigation.tsx
+++ b/packages/view-engine/src/record/page/ViewNavigation.tsx
@@ -149,19 +149,27 @@ export function ViewInstanceSwitcher({
 }
 
 export function ViewSidebar({
+  title,
   groups,
   selectedId,
   onSelect,
   onManage,
   onCollapse,
-}: NavigationProps & { onCollapse(): void }) {
+  toggleRef,
+}: NavigationProps & {
+  title: string;
+  toggleRef: RefObject<HTMLButtonElement | null>;
+  onCollapse(): void;
+}) {
   return (
     <aside
       aria-label="视图列表"
       className="fve:hidden fve:w-52 fve:shrink-0 fve:flex-col fve:gap-3 fve:border-r fve:pr-3 fve:@min-[64rem]:flex"
     >
       <div className="fve:flex fve:items-center fve:justify-between fve:gap-2">
-        <span className="fve:font-medium">视图</span>
+        <h1 className="fve:min-w-0 fve:truncate fve:font-medium" title={title}>
+          {title}
+        </h1>
         <div className="fve:flex fve:items-center fve:gap-1">
           <Button
             variant="ghost"
@@ -176,6 +184,7 @@ export function ViewSidebar({
             variant="ghost"
             size="icon"
             aria-label="收起视图列表"
+            ref={toggleRef}
             onClick={onCollapse}
           >
             <PanelLeftCloseIcon aria-hidden="true" />

--- a/packages/view-engine/src/record/page/ViewPageContent.tsx
+++ b/packages/view-engine/src/record/page/ViewPageContent.tsx
@@ -149,14 +149,14 @@ export function ViewPageContent({
         />
       </div>
       {session && (
-        <span
+        <h2
           className={cn(
             'fve:text-sm fve:font-medium fve:text-foreground',
             collapsed ? 'fve:hidden' : 'fve:hidden fve:@min-[64rem]:inline',
           )}
         >
           {session.instance.title}
-        </span>
+        </h2>
       )}
       {session && (
         <ViewInstanceActions

--- a/packages/view-engine/src/record/page/ViewPageContent.tsx
+++ b/packages/view-engine/src/record/page/ViewPageContent.tsx
@@ -12,7 +12,7 @@
  */
 
 import { PanelLeftOpenIcon } from 'lucide-react';
-import { useRef, useState, useSyncExternalStore } from 'react';
+import { useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { Button } from '../../components/ui/button.js';
 import { cn } from '../../lib/utils.js';
 import { RecordView, type RecordViewProps } from '../RecordView.js';
@@ -49,6 +49,18 @@ export function ViewPageContent({
   const pageRef = useRef<HTMLDivElement>(null);
   const expansion = useViewExpansion(pageRef, state.status === 'ready');
   const [collapsed, setCollapsed] = useState(initialSidebarCollapsed);
+  const sidebarToggleRef = useRef<HTMLButtonElement>(null);
+  const restoreSidebarFocus = useRef(false);
+  useLayoutEffect(() => {
+    if (restoreSidebarFocus.current) {
+      restoreSidebarFocus.current = false;
+      sidebarToggleRef.current?.focus();
+    }
+  }, [collapsed]);
+  function toggleSidebar() {
+    restoreSidebarFocus.current = true;
+    setCollapsed(value => !value);
+  }
   const [managerOpen, setManagerOpen] = useState(false);
   const switcherTrigger = useRef<HTMLButtonElement>(null);
   const managerReturnFocus = useRef<HTMLElement>(null);
@@ -110,12 +122,18 @@ export function ViewPageContent({
           size="icon"
           className="fve:hidden fve:@min-[64rem]:inline-flex"
           aria-label="展开视图列表"
-          onClick={() => setCollapsed(false)}
+          ref={sidebarToggleRef}
+          onClick={toggleSidebar}
         >
           <PanelLeftOpenIcon aria-hidden="true" />
         </Button>
       )}
-      <h1 className="fve:text-lg fve:font-semibold">
+      <h1
+        className={cn(
+          'fve:text-lg fve:font-semibold',
+          !collapsed && 'fve:@min-[64rem]:hidden',
+        )}
+      >
         {state.definition?.title}
       </h1>
       <div
@@ -133,7 +151,7 @@ export function ViewPageContent({
       {session && (
         <span
           className={cn(
-            'fve:text-sm fve:text-muted-foreground',
+            'fve:text-sm fve:font-medium fve:text-foreground',
             collapsed ? 'fve:hidden' : 'fve:hidden fve:@min-[64rem]:inline',
           )}
         >
@@ -176,7 +194,12 @@ export function ViewPageContent({
           />
         </div>
         {!collapsed && (
-          <ViewSidebar {...navigation} onCollapse={() => setCollapsed(true)} />
+          <ViewSidebar
+            {...navigation}
+            title={state.definition?.title ?? ''}
+            toggleRef={sidebarToggleRef}
+            onCollapse={toggleSidebar}
+          />
         )}
         <main
           tabIndex={-1}

--- a/packages/view-engine/test/viewPage.navigation.test.tsx
+++ b/packages/view-engine/test/viewPage.navigation.test.tsx
@@ -30,6 +30,12 @@ it('navigation collapse retains the filter buffer and does not query', async () 
   const { host, paged } = setup();
   render(<ViewPage scopeKey="test-user" definitionId="orders" host={host} />);
   await screen.findByRole('cell', { name: '42' });
+  expect(
+    within(screen.getByRole('complementary')).getByRole('heading', {
+      name: '订单管理',
+      level: 1,
+    }),
+  ).toBeTruthy();
   fireEvent.change(screen.getByRole('textbox', { name: '金额值' }), {
     target: { value: '99' },
   });
@@ -38,8 +44,49 @@ it('navigation collapse retains the filter buffer and does not query', async () 
   expect(
     (screen.getByRole('textbox', { name: '金额值' }) as HTMLInputElement).value,
   ).toBe('99');
+  const title = screen.getByRole('heading', { name: '订单管理', level: 1 });
+  expect(title.previousElementSibling).toBe(
+    screen.getByRole('button', { name: '展开视图列表' }),
+  );
+  fireEvent.click(screen.getByRole('button', { name: '展开视图列表' }));
+  expect(
+    within(screen.getByRole('complementary')).getByRole('heading', {
+      name: '订单管理',
+      level: 1,
+    }),
+  ).toBeTruthy();
   expect(paged).toHaveBeenCalledTimes(1);
 });
+it.each([false, true])(
+  'keeps focus on the sidebar toggle after each transition (initially collapsed: %s)',
+  async collapsed => {
+    const { host, paged } = setup();
+    render(
+      <ViewPage
+        scopeKey="test-user"
+        definitionId="orders"
+        host={host}
+        initialSidebarCollapsed={collapsed}
+      />,
+    );
+    await screen.findByRole('cell', { name: '42' });
+    expect(document.activeElement).toBe(document.body);
+    for (let index = 0; index < 2; index++) {
+      const current = screen.getByRole('button', {
+        name: collapsed ? '展开视图列表' : '收起视图列表',
+      });
+      current.focus();
+      fireEvent.click(current);
+      collapsed = !collapsed;
+      expect(document.activeElement).toBe(
+        screen.getByRole('button', {
+          name: collapsed ? '展开视图列表' : '收起视图列表',
+        }),
+      );
+    }
+    expect(paged).toHaveBeenCalledTimes(1);
+  },
+);
 it.each([false, true])(
   'restores each pending filter after navigating through the grouped view picker (collapsed: %s)',
   async collapsed => {

--- a/stories/view-engine/record-view/persistence.play.ts
+++ b/stories/view-engine/record-view/persistence.play.ts
@@ -26,7 +26,7 @@ export const playBusinessRecords: RecordViewPlay = async ({
   );
   await expect(
     sidebar
-      .getAllByRole('heading', { hidden: true })
+      .getAllByRole('heading', { level: 2, hidden: true })
       .map(item => item.textContent),
   ).toEqual(['个人视图', '公共视图']);
   const systemView = sidebar.getByRole('button', {

--- a/stories/view-engine/record-view/workbench.play.ts
+++ b/stories/view-engine/record-view/workbench.play.ts
@@ -37,7 +37,7 @@ export const playCompactWorkbench: RecordViewPlay = async ({
     .getByRole('button', { name: '保存' })
     .getBoundingClientRect();
   const title = within(toolbar)
-    .getByRole('heading', { name: '订单管理' })
+    .getByRole('heading', { name: '我的订单', level: 2 })
     .getBoundingClientRect();
   const create = within(toolbar)
     .getByRole('button', { name: '创建订单' })


### PR DESCRIPTION
## Summary

Show the view definition title in the expanded sidebar and in the toolbar when the sidebar is collapsed or hidden on narrow screens. Give the active view name normal foreground color and medium weight so it remains clear in the expanded layout.

Keep keyboard focus on the corresponding sidebar toggle after expanding or collapsing, without taking focus on initial load. Add regression coverage for both initial states, title placement, and retaining the filter buffer without querying again.

Keep the sidebar groups and active view heading at level 2 beneath the definition title, and update the Storybook assertions for the new title placement.

## Validation

- `npm_config_workspace_concurrency=1 pnpm test:unit` (full workspace suite; package concurrency reduced after four tests timed out in the parallel run)
- `pnpm -r --filter './packages/*' build`
- File-scoped ESLint and `git diff --check`
- Browser verification: Enter transfers focus to the corresponding toggle; Tab continues to the view picker or sidebar list. Verified title visibility and styling in both layouts.

- `VIEW_ENGINE_BROWSER_CHANNEL=chrome pnpm test:storybook`: 328 tests passed, including accessibility checks.
