### PR TITLE
ci: standardize PR labels and module areas

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,87 @@
-documentation:
-  - changed-files:
-      - any-glob-to-any-file: ['wiki/**', 'docs/**', '**/*.md']
-ci:
-  - changed-files:
-      - any-glob-to-any-file: ['.github/**']
+bug:
+  - head-branch:
+      - '^fix/'
+      - '^bugfix/'
+
+enhancement:
+  - head-branch:
+      - '^feature/'
+      - '^feat/'
+
+performance:
+  - head-branch:
+      - '^perf/'
+
+breaking-change:
+  - head-branch:
+      - '^breaking/'
+
+maintenance:
+  - head-branch:
+      - '^chore/'
+      - '^build/'
+      - '^ci/'
+
 dependencies:
+  - any:
+      - head-branch:
+          - '^renovate/'
+          - '^dependabot/'
+      - changed-files:
+          - any-glob-to-any-file:
+              - '**/package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+
+documentation:
+  - any:
+      - head-branch:
+          - '^docs/'
+      - changed-files:
+          - any-glob-to-any-file:
+              - 'wiki/**'
+              - 'docs/**'
+              - '**/*.md'
+
+'area: ci':
   - changed-files:
       - any-glob-to-any-file:
-          ['**/package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml']
-view-engine:
+          - '.github/**'
+
+'area: core':
   - changed-files:
       - any-glob-to-any-file:
-          ['packages/view-engine/**', 'stories/view-engine/**']
+          - 'packages/fetcher/**'
+          - 'packages/decorator/**'
+          - 'packages/storage/**'
+
+'area: events':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/eventbus/**'
+          - 'packages/eventstream/**'
+
+'area: openapi':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/openapi/**'
+          - 'packages/generator/**'
+
+'area: clients':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/openai/**'
+          - 'packages/cosec/**'
+          - 'packages/wow/**'
+
+'area: react':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/react/**'
+          - 'packages/viewer/**'
+
+'area: view-engine':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/view-engine/**'
+          - 'stories/view-engine/**'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,19 +1,28 @@
 name: Pull Request Labeler
+
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
-permissions:
-  contents: read
-  pull-requests: write
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
+
 jobs:
   label:
+    name: Label Pull Request
+    permissions:
+      contents: read
+      pull-requests: write
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       # Reads trusted base configuration; never checks out or executes PR code.
-      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
+      - name: Apply labels
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6
         with:
           sync-labels: false


### PR DESCRIPTION
## Changes and motivation

Align PR labeling with Wow so branch prefixes populate Fetcher's existing release-note categories. Add file-based areas covering all 13 packages, and standardize area labels as `area: ...`, including CI and view-engine. Use block lists consistently throughout the configuration.

Scope label-writing permissions to the label job and name the job and step explicitly. Retain the pinned action, five-minute timeout, trusted base configuration, and additive label behavior.

## Validation

- All package builds: `pnpm -r --filter './packages/*' build`
- CI policy tests: `node --test .github/scripts/*.test.mjs` (12 passed)
- Label rule smoke checks: branch categories, path fallback, combined matching, and exactly one area for each of the 13 packages
- Prettier checks for both YAML files, `actionlint`, and `git diff --check`

Full business-test runs were stopped at the user's request because this change only touches CI labeling configuration. Earlier default-concurrency runs encountered view-engine test timeouts; no business code or test configuration was changed.

## Compatibility

No public API changes. Future automatic labels use `area: ci` and `area: view-engine` in place of `ci` and `view-engine`. Existing PR labels are retained because `sync-labels` remains false. Rules take effect after landing in the trusted base branch; GitHub PR execution has not been exercised locally.
