### PR TITLE
docs: clarify view-engine unstable API policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,19 +11,19 @@ TypeScript HTTP-client ecosystem built around `Fetcher`.
 
 ## Repository Map
 
-| Path                                                                 | Responsibility                                       |
-| -------------------------------------------------------------------- | ---------------------------------------------------- |
-| `packages/fetcher/`                                                  | Core HTTP client; no internal dependencies           |
-| `packages/decorator/`, `packages/eventbus/`, `packages/eventstream/` | API decorators, event bus, SSE streams               |
-| `packages/openapi/`, `packages/generator/`                           | OpenAPI types and TypeScript client generation       |
-| `packages/openai/`, `packages/cosec/`                                | OpenAI client and CoSec authentication               |
-| `packages/storage/`                                                  | Cross-environment storage                            |
-| `packages/wow/`                                                      | Wow command/query clients and query DSLs             |
-| `packages/react/`, `packages/viewer/`                                | React hooks and Ant Design viewer components         |
-| `packages/view-engine/`                                             | Independent view engine contracts and shadcn/Base UI components |
-| `stories/`, `.storybook/`                                            | Shared Storybook stories and configuration           |
-| `integration-test/`                                                  | Integration tests; service setup in its README files |
-| `skills/`, `wiki/`                                                   | Agent skills and bilingual VitePress documentation   |
+| Path                                                                 | Responsibility                                                  |
+| -------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `packages/fetcher/`                                                  | Core HTTP client; no internal dependencies                      |
+| `packages/decorator/`, `packages/eventbus/`, `packages/eventstream/` | API decorators, event bus, SSE streams                          |
+| `packages/openapi/`, `packages/generator/`                           | OpenAPI types and TypeScript client generation                  |
+| `packages/openai/`, `packages/cosec/`                                | OpenAI client and CoSec authentication                          |
+| `packages/storage/`                                                  | Cross-environment storage                                       |
+| `packages/wow/`                                                      | Wow command/query clients and query DSLs                        |
+| `packages/react/`, `packages/viewer/`                                | React hooks and Ant Design viewer components                    |
+| `packages/view-engine/`                                              | Independent view engine contracts and shadcn/Base UI components |
+| `stories/`, `.storybook/`                                            | Shared Storybook stories and configuration                      |
+| `integration-test/`                                                  | Integration tests; service setup in its README files            |
+| `skills/`, `wiki/`                                                   | Agent skills and bilingual VitePress documentation              |
 
 ## Commands and Verification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ pnpm --filter @ahoo-wang/fetcher exec vitest run test/fetcher.test.ts
 - **Ask first** before adding packages, changing root `tsconfig.json`, or modifying build configuration, unless already authorized for the task.
 - Add external dependencies to the `pnpm-workspace.yaml` catalog and use `catalog:`; use the workspace protocol for internal dependencies.
 - Keep package versions aligned with `pnpm update-version <version>`. Never break a public API without a version bump.
+- Exception for `packages/view-engine/`: it is under active development and its API is not yet stable. Breaking API changes do not require compatibility preservation or a version bump solely for the break. Always prioritize a clean architecture and codebase; remove obsolete APIs and code instead of retaining compatibility layers, and update affected callers, tests, and documentation together.
 - Branch new work from `main`; use conventional commits (`feat:`, `fix:`, `chore:`, `test:`, `refactor:`, `docs:`). Merge PRs with squash only.
 
 ## Skills and Documentation


### PR DESCRIPTION
## Changes and motivation

Document an exception for view-engine while its API is unstable and under active development. Allow breaking API changes without preserving compatibility or bumping the version solely for the break, and prioritize clean architecture and code by removing obsolete APIs and updating callers, tests, and documentation together.

## Validation

- `git diff --check`
- Full test validation waived by the user for this documentation-only change. The initial run failed on eventbus localStorage availability under Node 26; the rerun with `NODE_OPTIONS=--no-experimental-webstorage` passed eventbus and was stopped at the user's request before the full suite completed.

## Compatibility

Documentation only. The exception applies to `packages/view-engine/`; other packages retain the existing rules.
