### PR TITLE
ci: render conventional renovate titles and skip lockfile prettier check

### DIFF
--- a/.github/scripts/pr-quality.test.mjs
+++ b/.github/scripts/pr-quality.test.mjs
@@ -17,6 +17,15 @@ test('validates metadata as data, including dependency updates and breaking chan
   assert.throws(() => validate('fix: correct query', '  '));
 });
 
+test('accepts the title shape rendered from the repository renovate config', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { commitMessagePrefix } = JSON.parse(
+    readFileSync(new URL('../../renovate.json', import.meta.url), 'utf8'),
+  );
+  const title = `${commitMessagePrefix} Update yaml to ^2.9.1`;
+  assert.doesNotThrow(() => validate(title, 'Reason and validation'));
+});
+
 test('rejects an unchanged PR template but accepts filled-in content', async () => {
   const { readFileSync } = await import('node:fs');
   const template = readFileSync(

--- a/.prettierignore
+++ b/.prettierignore
@@ -20,3 +20,5 @@ coverage/
 # OS generated files
 .DS_Store
 Thumbs.db
+# Generated lockfile (pnpm style conflicts with Prettier's YAML formatting)
+pnpm-lock.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "timezone": "Asia/Shanghai",
   "labels": ["dependencies"],
-  "commitMessagePrefix": "fix(deps)",
+  "commitMessagePrefix": "fix(deps):",
   "commitMessageTopic": "{{depName}}",
   "rangeStrategy": "bump",
   "lockFileMaintenance": { "enabled": false },


### PR DESCRIPTION
## 变更内容

修复 #1430 引入的质量门槛对所有 Renovate 依赖更新 PR 的系统性误报（如 #1448、#1446、#1435）：

1. **PR Metadata**：`renovate.json` 的 `commitMessagePrefix` 由 `fix(deps)` 改为 `fix(deps):`，使 Renovate 生成的 PR 标题/提交信息符合 `pr-quality.mjs` 的 Conventional Commits 校验（此前缺少冒号，断言必然失败）。
2. **Engineering Quality**：将 `pnpm-lock.yaml` 加入 `.prettierignore`。pnpm 生成的 lockfile 与 Prettier 的 YAML 格式天然不一致，main 分支上的 lockfile 本身就无法通过 `prettier --check`，任何触及 lockfile 的 PR 都会失败。

新增测试 `pr-quality.test.mjs`：校验由 `renovate.json` 渲染出的标题形状能通过 `validate()`（TDD，先 RED 后修复）。

## 验证

- `node --test .github/scripts/*.test.mjs` 全部通过（13 个，含新增 1 个）
- `prettier --check pnpm-lock.yaml` 加入 ignore 后通过
- 变更文件 `prettier --check` 与 `eslint` 通过
