### PR TITLE
docs: restore header badges in root READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Fetcher
 
+[![npm version](https://img.shields.io/npm/v/@ahoo-wang/fetcher.svg)](https://www.npmjs.com/package/@ahoo-wang/fetcher)
+[![Build Status](https://github.com/Ahoo-Wang/fetcher/actions/workflows/ci.yml/badge.svg)](https://github.com/Ahoo-Wang/fetcher/actions)
+[![codecov](https://codecov.io/gh/Ahoo-Wang/fetcher/graph/badge.svg?token=JGiWZ52CvJ)](https://codecov.io/gh/Ahoo-Wang/fetcher)
+[![License](https://img.shields.io/npm/l/@ahoo-wang/fetcher.svg)](https://github.com/Ahoo-Wang/fetcher/blob/main/LICENSE)
+[![npm downloads](https://img.shields.io/npm/dm/@ahoo-wang/fetcher.svg)](https://www.npmjs.com/package/@ahoo-wang/fetcher)
+[![npm bundle size](https://img.shields.io/bundlephobia/minzip/%40ahoo-wang%2Ffetcher)](https://www.npmjs.com/package/@ahoo-wang/fetcher)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Ahoo-Wang/fetcher)
+[![Storybook](https://img.shields.io/badge/Storybook-Interactive%20Docs-FF4785)](https://fetcher.ahoo.me/storybook/)
+
 [中文](./README.zh-CN.md) · [Documentation](https://fetcher.ahoo.me/) ·
 [Skills](https://fetcher.ahoo.me/skills/) ·
 [Storybook](https://fetcher.ahoo.me/storybook/) ·
@@ -51,21 +60,21 @@ try {
 
 ## Choose packages by job
 
-| Job                          | Package                          |
-| ---------------------------- | -------------------------------- |
-| HTTP client and interceptors | `@ahoo-wang/fetcher`             |
-| Declarative service classes  | `@ahoo-wang/fetcher-decorator`   |
-| Typed events                 | `@ahoo-wang/fetcher-eventbus`    |
-| Server-Sent Events           | `@ahoo-wang/fetcher-eventstream` |
-| OpenAI Chat Completions      | `@ahoo-wang/fetcher-openai`      |
-| OpenAPI TypeScript types     | `@ahoo-wang/fetcher-openapi`     |
-| OpenAPI client generation    | `@ahoo-wang/fetcher-generator`   |
-| React hooks                  | `@ahoo-wang/fetcher-react`       |
-| Typed storage                | `@ahoo-wang/fetcher-storage`     |
-| CoSec authentication         | `@ahoo-wang/fetcher-cosec`       |
-| Wow commands and queries     | `@ahoo-wang/fetcher-wow`         |
-| Data views (new projects) | [`@ahoo-wang/fetcher-view-engine`](packages/view-engine/README.md) |
-| Legacy Viewer (maintenance mode, deprecated) | [`@ahoo-wang/fetcher-viewer`](packages/viewer/README.md) |
+| Job                                          | Package                                                            |
+| -------------------------------------------- | ------------------------------------------------------------------ |
+| HTTP client and interceptors                 | `@ahoo-wang/fetcher`                                               |
+| Declarative service classes                  | `@ahoo-wang/fetcher-decorator`                                     |
+| Typed events                                 | `@ahoo-wang/fetcher-eventbus`                                      |
+| Server-Sent Events                           | `@ahoo-wang/fetcher-eventstream`                                   |
+| OpenAI Chat Completions                      | `@ahoo-wang/fetcher-openai`                                        |
+| OpenAPI TypeScript types                     | `@ahoo-wang/fetcher-openapi`                                       |
+| OpenAPI client generation                    | `@ahoo-wang/fetcher-generator`                                     |
+| React hooks                                  | `@ahoo-wang/fetcher-react`                                         |
+| Typed storage                                | `@ahoo-wang/fetcher-storage`                                       |
+| CoSec authentication                         | `@ahoo-wang/fetcher-cosec`                                         |
+| Wow commands and queries                     | `@ahoo-wang/fetcher-wow`                                           |
+| Data views (new projects)                    | [`@ahoo-wang/fetcher-view-engine`](packages/view-engine/README.md) |
+| Legacy Viewer (maintenance mode, deprecated) | [`@ahoo-wang/fetcher-viewer`](packages/viewer/README.md)           |
 
 [Choose packages](https://fetcher.ahoo.me/architecture/package-boundaries) explains peer
 dependencies and the smallest useful combination.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,14 @@
 # Fetcher
 
+[![npm version](https://img.shields.io/npm/v/@ahoo-wang/fetcher.svg)](https://www.npmjs.com/package/@ahoo-wang/fetcher)
+[![Build Status](https://github.com/Ahoo-Wang/fetcher/actions/workflows/ci.yml/badge.svg)](https://github.com/Ahoo-Wang/fetcher/actions)
+[![codecov](https://codecov.io/gh/Ahoo-Wang/fetcher/graph/badge.svg?token=JGiWZ52CvJ)](https://codecov.io/gh/Ahoo-Wang/fetcher)
+[![License](https://img.shields.io/npm/l/@ahoo-wang/fetcher.svg)](https://github.com/Ahoo-Wang/fetcher/blob/main/LICENSE)
+[![npm downloads](https://img.shields.io/npm/dm/@ahoo-wang/fetcher.svg)](https://www.npmjs.com/package/@ahoo-wang/fetcher)
+[![npm bundle size](https://img.shields.io/bundlephobia/minzip/%40ahoo-wang%2Ffetcher)](https://www.npmjs.com/package/@ahoo-wang/fetcher)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Ahoo-Wang/fetcher)
+[![Storybook](https://img.shields.io/badge/Storybook-交互式文档-FF4785)](https://fetcher.ahoo.me/storybook/)
+
 [English](./README.md) · [文档](https://fetcher.ahoo.me/zh/) ·
 [Skills](https://fetcher.ahoo.me/zh/skills/) ·
 [Storybook](https://fetcher.ahoo.me/storybook/) ·
@@ -50,21 +59,21 @@ try {
 
 ## 按任务选择包
 
-| 任务                    | 包                               |
-| ----------------------- | -------------------------------- |
-| HTTP 客户端与拦截器     | `@ahoo-wang/fetcher`             |
-| 声明式服务类            | `@ahoo-wang/fetcher-decorator`   |
-| 类型化事件              | `@ahoo-wang/fetcher-eventbus`    |
-| Server-Sent Events      | `@ahoo-wang/fetcher-eventstream` |
-| OpenAI Chat Completions | `@ahoo-wang/fetcher-openai`      |
-| OpenAPI TypeScript 类型 | `@ahoo-wang/fetcher-openapi`     |
-| OpenAPI 客户端生成      | `@ahoo-wang/fetcher-generator`   |
-| React Hooks             | `@ahoo-wang/fetcher-react`       |
-| 类型化存储              | `@ahoo-wang/fetcher-storage`     |
-| CoSec 认证              | `@ahoo-wang/fetcher-cosec`       |
-| Wow 命令与查询          | `@ahoo-wang/fetcher-wow`         |
-| 数据视图（新项目） | [`@ahoo-wang/fetcher-view-engine`](packages/view-engine/README.zh-CN.md) |
-| 旧版 Viewer（维护期，已弃用） | [`@ahoo-wang/fetcher-viewer`](packages/viewer/README.zh-CN.md) |
+| 任务                          | 包                                                                       |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| HTTP 客户端与拦截器           | `@ahoo-wang/fetcher`                                                     |
+| 声明式服务类                  | `@ahoo-wang/fetcher-decorator`                                           |
+| 类型化事件                    | `@ahoo-wang/fetcher-eventbus`                                            |
+| Server-Sent Events            | `@ahoo-wang/fetcher-eventstream`                                         |
+| OpenAI Chat Completions       | `@ahoo-wang/fetcher-openai`                                              |
+| OpenAPI TypeScript 类型       | `@ahoo-wang/fetcher-openapi`                                             |
+| OpenAPI 客户端生成            | `@ahoo-wang/fetcher-generator`                                           |
+| React Hooks                   | `@ahoo-wang/fetcher-react`                                               |
+| 类型化存储                    | `@ahoo-wang/fetcher-storage`                                             |
+| CoSec 认证                    | `@ahoo-wang/fetcher-cosec`                                               |
+| Wow 命令与查询                | `@ahoo-wang/fetcher-wow`                                                 |
+| 数据视图（新项目）            | [`@ahoo-wang/fetcher-view-engine`](packages/view-engine/README.zh-CN.md) |
+| 旧版 Viewer（维护期，已弃用） | [`@ahoo-wang/fetcher-viewer`](packages/viewer/README.zh-CN.md)           |
 
 [选择包](https://fetcher.ahoo.me/zh/architecture/package-boundaries)说明 peer 依赖和最小可用组合。
 


### PR DESCRIPTION
## 变更内容

恢复被 #1371（`5ad03e80` 文档重写）误删的根 README 头部徽章，中英文版本各 8 枚：npm version、CI Build、codecov、License、npm downloads、bundle size、Ask DeepWiki、Storybook。Storybook 徽章链接由站点根路径改为当前的 `/storybook/` 路径，与正文导航一致。

包表格的 npm/size 徽章列未恢复：它们属于 #1426 重写时已废弃的旧四列表格格式，现表格为精简两列设计。此外 Prettier 将包表格重排为规范对齐（main 上该表格本就未通过 `prettier --check`，属 CI format 门的必要修正）。

## 验证

- `prettier --check README.md README.zh-CN.md` 通过
- badge 内容与 `5ad03e80^` 历史版本逐字一致（仅 Storybook 链接路径更新）

## 兼容性

纯文档变更，不影响代码与公共 API。
