### PR TITLE
fix(view-engine): reject coerced enum values at input boundaries

### DIFF
--- a/packages/view-engine/src/contracts/validation/definitionValidation.ts
+++ b/packages/view-engine/src/contracts/validation/definitionValidation.ts
@@ -46,11 +46,10 @@ function validateFields(value: unknown) {
     names.add(field.field);
     if (
       field.type !== undefined &&
-      !['string', 'number', 'boolean', 'date', 'datetime', 'array'].includes(
-        // 校验器故意对未知类型值做 ToString 以校验其字符串形态。
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        String(field.type),
-      )
+      (typeof field.type !== 'string' ||
+        !['string', 'number', 'boolean', 'date', 'datetime', 'array'].includes(
+          field.type,
+        ))
     )
       throw new Error('字段类型不支持');
     if (field.sortable !== undefined && typeof field.sortable !== 'boolean')

--- a/packages/view-engine/src/contracts/validation/instanceValidation.ts
+++ b/packages/view-engine/src/contracts/validation/instanceValidation.ts
@@ -45,7 +45,7 @@ export function validateViewInstance(
     value.scope.type !== 'personal' &&
     !(
       value.scope.type === 'public' &&
-      ['system', 'shared'].includes(String(value.scope.source))
+      (value.scope.source === 'system' || value.scope.source === 'shared')
     )
   )
     throw new Error('实例范围无效');

--- a/packages/view-engine/src/record/validation/configurationValidation.ts
+++ b/packages/view-engine/src/record/validation/configurationValidation.ts
@@ -58,7 +58,8 @@ export function validateRecordConfiguration(
   }
   assertObject(config.pagination, '分页配置');
   if (
-    !['paged', 'cursor'].includes(String(config.pagination.mode)) ||
+    (config.pagination.mode !== 'paged' &&
+      config.pagination.mode !== 'cursor') ||
     !Number.isSafeInteger(config.pagination.size) ||
     Number(config.pagination.size) <= 0
   )

--- a/packages/view-engine/test/recordValidation.boundaries.test.ts
+++ b/packages/view-engine/test/recordValidation.boundaries.test.ts
@@ -51,6 +51,11 @@ it('accepts typed enum identities, nested fields and explicit operator editor bi
 
 it.each([
   [{ type: 'decimal' }, '字段类型不支持'],
+  [{ type: ['number'] }, '字段类型不支持'],
+  [
+    { fields: [{ field: 'amount', label: 'Amount', type: ['number'] }] },
+    '字段类型不支持',
+  ],
   [{ sortable: 'true' }, 'sortable'],
   [{ operators: 'EQ' }, '字段操作符'],
   [{ operators: ['UNKNOWN'] }, '字段操作符'],
@@ -95,6 +100,8 @@ it.each([
 
 it.each([
   [{ scope: { type: 'public', source: 'unknown' } }, '实例范围无效'],
+  [{ scope: { type: 'public', source: ['system'] } }, '实例范围无效'],
+  [{ scope: { type: 'public', source: ['shared'] } }, '实例范围无效'],
   [{ revision: 2 }, 'revision'],
 ])(
   'rejects malformed saved instance identity metadata %j',
@@ -127,6 +134,8 @@ it.each([
     '字段重复',
   ],
   [{ pagination: { mode: 'offset', size: 10 } }, '分页方式'],
+  [{ pagination: { mode: ['paged'], size: 10 } }, '分页方式'],
+  [{ pagination: { mode: ['cursor'], size: 10 } }, '分页方式'],
   [{ pagination: { mode: 'paged', size: 0 } }, '每页数量'],
   [{ pagination: { mode: 'paged', size: 1.5 } }, '每页数量'],
   [{ presentation: { layout: 'grid', table: { columns: [] } } }, '展示布局'],
@@ -202,6 +211,8 @@ it('keeps malformed host lists out of sessions and recovers after the host fixes
 it.each([
   { pagination: {} },
   { pagination: [] },
+  { pagination: { mode: ['paged'], size: 10 } },
+  { pagination: { mode: ['cursor'], size: 10 } },
   { presentation: {} },
   { presentation: { layout: 'table' } },
   { presentation: { layout: 'table', table: { columns: [null] } } },
@@ -244,29 +255,37 @@ it('retains unknown field references as semantic recovery issues', () => {
   );
 });
 
-it('does not publish or query a default record with missing layout discriminants', async () => {
-  const saved = instance();
-  const malformed = {
-    ...saved,
-    config: { ...saved.config, pagination: {}, presentation: {} },
-  };
-  const { engine, paged } = setup({
-    instances: undefined,
-    host: {
-      instance: {
-        list: async () => ({
-          instances: [malformed],
-          defaultInstanceId: saved.id,
-        }),
-      },
-    } as never,
-  });
-  try {
-    await expect(engine.load()).rejects.toThrow();
-    expect(engine.getSnapshot().status).toBe('error');
-    expect(engine.getSnapshot().sessions).toEqual({});
-    expect(paged).not.toHaveBeenCalled();
-  } finally {
-    engine.dispose();
-  }
-});
+it.each([
+  { pagination: {}, presentation: {} },
+  { pagination: { mode: ['paged'], size: 10 } },
+  { pagination: { mode: ['cursor'], size: 10 } },
+])(
+  'does not publish or query a default record with malformed layout discriminants: %j',
+  async patch => {
+    const saved = instance();
+    const malformed = {
+      ...saved,
+      config: { ...saved.config, ...patch },
+    };
+    const { engine, paged, cursor } = setup({
+      instances: undefined,
+      host: {
+        instance: {
+          list: async () => ({
+            instances: [malformed],
+            defaultInstanceId: saved.id,
+          }),
+        },
+      } as never,
+    });
+    try {
+      await expect(engine.load()).rejects.toThrow();
+      expect(engine.getSnapshot().status).toBe('error');
+      expect(engine.getSnapshot().sessions).toEqual({});
+      expect(paged).not.toHaveBeenCalled();
+      expect(cursor).not.toHaveBeenCalled();
+    } finally {
+      engine.dispose();
+    }
+  },
+);


### PR DESCRIPTION
View metadata and saved instances could pass enum validation with JSON arrays such as `type: ["number"]`, `scope.source: ["system"]`, or `pagination.mode: ["paged"]`. The validators checked `String(value)` while consumers use strict comparisons. A malformed paged configuration could therefore be admitted and take the cursor query branch.

Validate the original values in the three existing shared validators. This also protects recursive fields and structural recovery loading (`semantic=false`), while retaining recovery for valid configurations with obsolete field references. No new dependency, schema framework, or compatibility layer is needed for this fix.

Validation:
- Ten added regression cases failed against the previous implementation, then passed after the fix. They include nested fields, both public sources, both pagination modes, recovery validation, and loading that rejects malformed configurations before publishing sessions or issuing queries.
- Focused record validation: 71 tests passed.
- Package and dependency build; changed-file ESLint and formatting checks passed.
- Root `pnpm test:unit` passed with the CI concurrency settings (`VITEST_MAX_WORKERS=2`, `npm_config_workspace_concurrency=1`), including 1,661 view-engine tests plus 3 existing skips in each of source and compiled modes, coverage thresholds, and type checks. The first run hit a 5-second timeout in an unchanged date-picker overlay test. Its eight-test file passed on isolated reproduction (1.45 seconds test time), and the full rerun passed without changing assertions or timeouts.
- Independent read-only review found no blocking or non-blocking issues.
