### PR TITLE
feat(wow): align aggregation API with current Wow protocol

### DIFF
--- a/packages/view-engine/src/analysis/AnalysisEditor.tsx
+++ b/packages/view-engine/src/analysis/AnalysisEditor.tsx
@@ -297,6 +297,8 @@ function ComponentList({
                                           AVG: '平均值',
                                           MIN: '最小值',
                                           MAX: '最大值',
+                                          STDDEV: '标准差',
+                                          VARIANCE: '方差',
                                         } as Record<string, string>
                                       )[item.props.function as string] ??
                                       '选择统计方式')
@@ -513,6 +515,8 @@ function ComponentList({
                                                 AVG: '平均值',
                                                 MIN: '最小值',
                                                 MAX: '最大值',
+                                                STDDEV: '标准差',
+                                                VARIANCE: '方差',
                                               } as Record<string, string>
                                             )[value] ?? value,
                                         }))}

--- a/packages/view-engine/src/analysis/AnalysisResultSummary.tsx
+++ b/packages/view-engine/src/analysis/AnalysisResultSummary.tsx
@@ -60,6 +60,8 @@ export function AnalysisResultSummary({
               AVG: '平均值',
               MIN: '最小值',
               MAX: '最大值',
+              STDDEV: '标准差',
+              VARIANCE: '方差',
               COUNT: '计数',
               ANY: '代表值',
             };

--- a/packages/wow/src/query/aggregation.ts
+++ b/packages/wow/src/query/aggregation.ts
@@ -29,6 +29,9 @@ export enum AggregationMetricType {
   COUNT = 'COUNT',
   NUMERIC = 'NUMERIC',
   ANY = 'ANY',
+  DISTINCT_COUNT = 'DISTINCT_COUNT',
+  PERCENTILE = 'PERCENTILE',
+  DERIVED = 'DERIVED',
 }
 
 export enum AggregationExpressionType {
@@ -60,6 +63,8 @@ export enum AggregationFunction {
   AVG = 'AVG',
   MIN = 'MIN',
   MAX = 'MAX',
+  STDDEV = 'STDDEV',
+  VARIANCE = 'VARIANCE',
 }
 
 export interface AggregationElement {
@@ -76,6 +81,7 @@ export interface TermsAggregationGroup<
   FIELDS extends string = string,
 > extends AggregationGroupBase<FIELDS> {
   type: AggregationGroupType.TERMS;
+  missingKey?: string;
 }
 
 export interface HistogramAggregationGroup<
@@ -91,6 +97,7 @@ export interface DateHistogramAggregationGroup<
   type: AggregationGroupType.DATE_HISTOGRAM;
   unit: AggregationDateUnit;
   timeZone?: string;
+  dense?: boolean;
 }
 
 export type AggregationGroup<FIELDS extends string = string> =
@@ -120,12 +127,14 @@ export type AggregationExpression<FIELDS extends string = string> =
   | ConstantAggregationExpression
   | BinaryAggregationExpression<FIELDS>;
 
-export interface CountAggregationMetric {
+export interface CountAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.COUNT;
   alias: string;
 }
 
 export interface NumericAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.NUMERIC;
   function: AggregationFunction;
   expression: AggregationExpression<FIELDS>;
@@ -133,15 +142,102 @@ export interface NumericAggregationMetric<FIELDS extends string = string> {
 }
 
 export interface AnyAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.ANY;
   field: QueryField<FIELDS>;
   alias: string;
 }
 
+export interface DistinctCountAggregationMetric<
+  FIELDS extends string = string,
+> {
+  type: AggregationMetricType.DISTINCT_COUNT;
+  expression: AggregationExpression<FIELDS>;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+
+export interface PercentileAggregationMetric<FIELDS extends string = string> {
+  type: AggregationMetricType.PERCENTILE;
+  expression: AggregationExpression<FIELDS>;
+  percentile: number;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+
+export enum DerivedExpressionType {
+  METRIC_REF = 'METRIC_REF',
+  CONSTANT = 'CONSTANT',
+  BINARY = 'BINARY',
+}
+
+/** Post-aggregation arithmetic; references must name earlier non-ANY metrics. */
+export type DerivedExpression =
+  | { type: DerivedExpressionType.METRIC_REF; metric: string }
+  | { type: DerivedExpressionType.CONSTANT; value: number }
+  | {
+      type: DerivedExpressionType.BINARY;
+      operator: AggregationExpressionOperator;
+      left: DerivedExpression;
+      right: DerivedExpression;
+    };
+
+export interface DerivedAggregationMetric {
+  type: AggregationMetricType.DERIVED;
+  expression: DerivedExpression;
+  alias: string;
+}
+
+export enum HavingExpressionType {
+  CONDITION = 'CONDITION',
+  BETWEEN = 'BETWEEN',
+  IN = 'IN',
+  IS_NULL = 'IS_NULL',
+  AND = 'AND',
+  OR = 'OR',
+}
+
+export enum ComparisonOperator {
+  EQ = 'EQ',
+  NE = 'NE',
+  GT = 'GT',
+  GTE = 'GTE',
+  LT = 'LT',
+  LTE = 'LTE',
+}
+
+/** Filters grouped results by non-ANY metric aliases, before sorting/limit. */
+export type HavingExpression =
+  | {
+      type: HavingExpressionType.CONDITION;
+      metric: string;
+      operator: ComparisonOperator;
+      value: number;
+    }
+  | {
+      type: HavingExpressionType.BETWEEN;
+      metric: string;
+      lower: number;
+      upper: number;
+    }
+  | {
+      type: HavingExpressionType.IN;
+      metric: string;
+      values: [number, ...number[]];
+    }
+  | { type: HavingExpressionType.IS_NULL; metric: string; negated?: boolean }
+  | {
+      type: HavingExpressionType.AND | HavingExpressionType.OR;
+      operands: [HavingExpression, ...HavingExpression[]];
+    };
+
 export type AggregationMetric<FIELDS extends string = string> =
-  | CountAggregationMetric
+  | CountAggregationMetric<FIELDS>
   | NumericAggregationMetric<FIELDS>
-  | AnyAggregationMetric<FIELDS>;
+  | AnyAggregationMetric<FIELDS>
+  | DistinctCountAggregationMetric<FIELDS>
+  | PercentileAggregationMetric<FIELDS>
+  | DerivedAggregationMetric;
 
 export interface AggregationQuery<
   ROOT_FIELDS extends string = string,
@@ -156,6 +252,7 @@ export interface AggregationQuery<
   ];
   sort?: FieldSort[];
   limit?: number;
+  having?: HavingExpression;
 }
 
 export interface HistogramAggregationOptions {
@@ -167,6 +264,7 @@ export interface DateHistogramAggregationOptions {
   unit: AggregationDateUnit;
   alias: string;
   timeZone?: string;
+  dense?: boolean;
 }
 
 function aggregationField<FIELDS extends string>(field: FIELDS): FIELDS {
@@ -198,9 +296,11 @@ function numeric<FIELDS extends string>(
   fn: AggregationFunction,
   expression: AggregationExpression<FIELDS>,
   alias: string,
+  predicate?: FilterExpression<FIELDS>,
 ): NumericAggregationMetric<FIELDS> {
   return {
     type: AggregationMetricType.NUMERIC,
+    ...(predicate === undefined ? {} : { filter: predicate }),
     function: fn,
     expression,
     alias: aggregationAlias(alias),
@@ -250,9 +350,17 @@ export const aggregation = {
   terms<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    missingKey?: string,
   ): TermsAggregationGroup<FIELDS> {
+    if (
+      missingKey !== undefined &&
+      (typeof missingKey !== 'string' || !missingKey.trim())
+    ) {
+      throw new TypeError('terms missingKey must not be blank.');
+    }
     return {
       type: AggregationGroupType.TERMS,
+      ...(missingKey === undefined ? {} : { missingKey }),
       field: aggregationField(field),
       alias: aggregationAlias(alias),
     };
@@ -275,8 +383,11 @@ export const aggregation = {
   },
   dateHistogram<FIELDS extends string>(
     field: FIELDS,
-    { unit, alias, timeZone = 'UTC' }: DateHistogramAggregationOptions,
+    { unit, alias, timeZone = 'UTC', dense }: DateHistogramAggregationOptions,
   ): DateHistogramAggregationGroup<FIELDS> {
+    if (dense !== undefined && typeof dense !== 'boolean') {
+      throw new TypeError('date histogram dense must be boolean.');
+    }
     if (!Object.values(AggregationDateUnit).includes(unit)) {
       throw new TypeError('date histogram unit is invalid.');
     }
@@ -285,6 +396,7 @@ export const aggregation = {
     }
     return {
       type: AggregationGroupType.DATE_HISTOGRAM,
+      ...(dense === undefined ? {} : { dense }),
       field: aggregationField(field),
       unit,
       alias: aggregationAlias(alias),
@@ -294,33 +406,92 @@ export const aggregation = {
   any<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ): AnyAggregationMetric<FIELDS> {
     return {
       type: AggregationMetricType.ANY,
+      ...(predicate === undefined ? {} : { filter: predicate }),
       field: aggregationField(field),
       alias: aggregationAlias(alias),
     };
   },
-  count(alias: string): CountAggregationMetric {
+  count<FIELDS extends string = string>(
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): CountAggregationMetric<FIELDS> {
     return {
       type: AggregationMetricType.COUNT,
+      ...(predicate === undefined ? {} : { filter: predicate }),
       alias: aggregationAlias(alias),
     };
   },
   sum: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
-  ) => numeric(AggregationFunction.SUM, expression, alias),
+    predicate?: FilterExpression<FIELDS>,
+  ) => numeric(AggregationFunction.SUM, expression, alias, predicate),
   avg: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
-  ) => numeric(AggregationFunction.AVG, expression, alias),
+    predicate?: FilterExpression<FIELDS>,
+  ) => numeric(AggregationFunction.AVG, expression, alias, predicate),
   min: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
-  ) => numeric(AggregationFunction.MIN, expression, alias),
+    predicate?: FilterExpression<FIELDS>,
+  ) => numeric(AggregationFunction.MIN, expression, alias, predicate),
   max: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
-  ) => numeric(AggregationFunction.MAX, expression, alias),
+    predicate?: FilterExpression<FIELDS>,
+  ) => numeric(AggregationFunction.MAX, expression, alias, predicate),
+  stddev: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => numeric(AggregationFunction.STDDEV, expression, alias, predicate),
+  variance: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => numeric(AggregationFunction.VARIANCE, expression, alias, predicate),
+  distinctCount<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): DistinctCountAggregationMetric<FIELDS> {
+    return {
+      type: AggregationMetricType.DISTINCT_COUNT,
+      expression,
+      alias: aggregationAlias(alias),
+      ...(predicate === undefined ? {} : { filter: predicate }),
+    };
+  },
+  percentile<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    percentile: number,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): PercentileAggregationMetric<FIELDS> {
+    if (!Number.isFinite(percentile) || percentile <= 0 || percentile >= 100) {
+      throw new TypeError('percentile must be finite and within (0, 100).');
+    }
+    return {
+      type: AggregationMetricType.PERCENTILE,
+      expression,
+      percentile,
+      alias: aggregationAlias(alias),
+      ...(predicate === undefined ? {} : { filter: predicate }),
+    };
+  },
+  derived(
+    expression: DerivedExpression,
+    alias: string,
+  ): DerivedAggregationMetric {
+    return {
+      type: AggregationMetricType.DERIVED,
+      expression,
+      alias: aggregationAlias(alias),
+    };
+  },
 };

--- a/packages/wow/test/query/aggregation.test.ts
+++ b/packages/wow/test/query/aggregation.test.ts
@@ -14,6 +14,11 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
   AggregationDateUnit,
+  DerivedExpressionType,
+  HavingExpressionType,
+  ComparisonOperator,
+  type DerivedExpression,
+  type HavingExpression,
   AggregationExpressionOperator,
   AggregationExpressionType,
   AggregationFunction,
@@ -28,12 +33,7 @@ import {
 
 type RootFields = 'state.status' | 'state.orders';
 type ItemFields =
-  | 'status'
-  | 'quantity'
-  | 'productId'
-  | 'productName'
-  | 'amount'
-  | 'createdAt';
+  'status' | 'quantity' | 'productId' | 'productName' | 'amount' | 'createdAt';
 
 describe('AggregationQuery', () => {
   it('uses the Wow wire enum values', () => {
@@ -46,7 +46,14 @@ describe('AggregationQuery', () => {
       function: Object.values(AggregationFunction),
     }).toEqual({
       group: ['TERMS', 'HISTOGRAM', 'DATE_HISTOGRAM'],
-      metric: ['COUNT', 'NUMERIC', 'ANY'],
+      metric: [
+        'COUNT',
+        'NUMERIC',
+        'ANY',
+        'DISTINCT_COUNT',
+        'PERCENTILE',
+        'DERIVED',
+      ],
       expression: ['FIELD', 'CONSTANT', 'BINARY'],
       operator: ['ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE'],
       dateUnit: [
@@ -59,8 +66,188 @@ describe('AggregationQuery', () => {
         'MINUTE',
         'SECOND',
       ],
-      function: ['SUM', 'AVG', 'MIN', 'MAX'],
+      function: ['SUM', 'AVG', 'MIN', 'MAX', 'STDDEV', 'VARIANCE'],
     });
+  });
+
+  it('builds filtered metrics without changing unfiltered JSON', () => {
+    const predicate = filter.eq('status', 'PAID');
+    const expression = aggregation.field('amount');
+    const metrics = [
+      aggregation.count('rows', predicate),
+      aggregation.any('productName', 'name', predicate),
+      aggregation.sum(expression, 'sum', predicate),
+      aggregation.avg(expression, 'avg', predicate),
+      aggregation.min(expression, 'min', predicate),
+      aggregation.max(expression, 'max', predicate),
+      aggregation.stddev(expression, 'stddev', predicate),
+      aggregation.variance(expression, 'variance', predicate),
+      aggregation.distinctCount(expression, 'distinct', predicate),
+      aggregation.percentile(expression, 95, 'p95', predicate),
+    ];
+    expect(metrics.map(metric => metric.filter)).toEqual(
+      metrics.map(() => predicate),
+    );
+    expect(metrics.slice(6)).toEqual([
+      {
+        type: 'NUMERIC',
+        function: 'STDDEV',
+        expression,
+        alias: 'stddev',
+        filter: predicate,
+      },
+      {
+        type: 'NUMERIC',
+        function: 'VARIANCE',
+        expression,
+        alias: 'variance',
+        filter: predicate,
+      },
+      {
+        type: 'DISTINCT_COUNT',
+        expression,
+        alias: 'distinct',
+        filter: predicate,
+      },
+      {
+        type: 'PERCENTILE',
+        expression,
+        percentile: 95,
+        alias: 'p95',
+        filter: predicate,
+      },
+    ]);
+    expect(
+      aggregation.distinctCount(expression, 'distinct'),
+    ).not.toHaveProperty('filter');
+    expect(aggregation.percentile(expression, 50, 'p50')).not.toHaveProperty(
+      'filter',
+    );
+  });
+
+  it('supports missing terms and dense date groups explicitly', () => {
+    expect(aggregation.terms('productName', 'name', 'Unknown')).toEqual({
+      type: 'TERMS',
+      field: 'productName',
+      alias: 'name',
+      missingKey: 'Unknown',
+    });
+    expect(
+      aggregation.dateHistogram('createdAt', {
+        unit: AggregationDateUnit.DAY,
+        alias: 'day',
+        dense: true,
+      }),
+    ).toEqual({
+      type: 'DATE_HISTOGRAM',
+      field: 'createdAt',
+      unit: 'DAY',
+      alias: 'day',
+      timeZone: 'UTC',
+      dense: true,
+    });
+  });
+
+  it.each([0, 100, -1, Number.NaN, Infinity])(
+    'rejects invalid percentile %s',
+    p => {
+      expect(() =>
+        aggregation.percentile(aggregation.field('amount'), p, 'p'),
+      ).toThrow(TypeError);
+    },
+  );
+
+  it('rejects blank missing keys and non-boolean dense options', () => {
+    expect(() => aggregation.terms('productName', 'name', '  ')).toThrow(
+      TypeError,
+    );
+    expect(() =>
+      aggregation.dateHistogram('createdAt', {
+        unit: AggregationDateUnit.DAY,
+        alias: 'day',
+        dense: 'true' as never,
+      }),
+    ).toThrow(TypeError);
+  });
+
+  it('builds derived metrics and typed HAVING trees using metric aliases', () => {
+    const expression: DerivedExpression = {
+      type: DerivedExpressionType.BINARY,
+      operator: AggregationExpressionOperator.DIVIDE,
+      left: { type: DerivedExpressionType.METRIC_REF, metric: 'total' },
+      right: { type: DerivedExpressionType.CONSTANT, value: 100 },
+    };
+    const having: HavingExpression = {
+      type: HavingExpressionType.AND,
+      operands: [
+        {
+          type: HavingExpressionType.CONDITION,
+          metric: 'ratio',
+          operator: ComparisonOperator.GT,
+          value: 10,
+        },
+        {
+          type: HavingExpressionType.BETWEEN,
+          metric: 'total',
+          lower: 1,
+          upper: 10000,
+        },
+        {
+          type: HavingExpressionType.OR,
+          operands: [
+            { type: HavingExpressionType.IN, metric: 'rows', values: [1, 2] },
+            {
+              type: HavingExpressionType.IS_NULL,
+              metric: 'ratio',
+              negated: true,
+            },
+          ],
+        },
+      ],
+    };
+    const query: AggregationQuery = {
+      groupBy: [aggregation.terms('status', 'status')],
+      metrics: [
+        aggregation.count('rows'),
+        aggregation.sum(aggregation.field('amount'), 'total'),
+        aggregation.derived(expression, 'ratio'),
+      ],
+      having,
+    };
+    expect(JSON.parse(JSON.stringify(query))).toMatchObject({
+      metrics: [
+        { type: 'COUNT', alias: 'rows' },
+        { type: 'NUMERIC', alias: 'total' },
+        {
+          type: 'DERIVED',
+          alias: 'ratio',
+          expression: {
+            type: 'BINARY',
+            operator: 'DIVIDE',
+            left: { type: 'METRIC_REF', metric: 'total' },
+            right: { type: 'CONSTANT', value: 100 },
+          },
+        },
+      ],
+      having: {
+        type: 'AND',
+        operands: [
+          { type: 'CONDITION', metric: 'ratio', operator: 'GT', value: 10 },
+          { type: 'BETWEEN', metric: 'total', lower: 1, upper: 10000 },
+          {
+            type: 'OR',
+            operands: [
+              { type: 'IN', metric: 'rows', values: [1, 2] },
+              { type: 'IS_NULL', metric: 'ratio', negated: true },
+            ],
+          },
+        ],
+      },
+    });
+    expect(query.metrics[2]).not.toHaveProperty('filter');
+    expect(() => aggregation.derived(expression, '__wow_ratio')).toThrow(
+      TypeError,
+    );
   });
 
   it('builds aggregation elements', () => {
@@ -306,6 +493,44 @@ describe('AggregationQuery', () => {
         aggregation.any('unknown', 'name'),
       ],
     };
+    const filtered: AggregationQuery<RootFields, ItemFields> = {
+      metrics: [aggregation.count('paid', filter.eq('status', 'PAID'))],
+    };
+    const invalidMetricFilter: AggregationQuery<RootFields, ItemFields> = {
+      metrics: [
+        // @ts-expect-error metric filters use the aggregation scope, not the root scope.
+        aggregation.count('paid', filter.eq('state.status', 'PAID')),
+      ],
+    };
+    const invalidDistinct: AggregationQuery<RootFields, ItemFields> = {
+      metrics: [
+        // @ts-expect-error unknown is not an ItemFields member.
+        aggregation.distinctCount(aggregation.field('unknown'), 'distinct'),
+      ],
+    };
+    const invalidPercentile: AggregationQuery<RootFields, ItemFields> = {
+      metrics: [
+        // @ts-expect-error unknown is not an ItemFields member.
+        aggregation.percentile(aggregation.field('unknown'), 95, 'p95'),
+      ],
+    };
+    const invalidDerived: DerivedExpression = {
+      // @ts-expect-error derived expressions reference metrics, not source fields.
+      type: AggregationExpressionType.FIELD,
+      field: 'amount',
+    };
+    const invalidHaving: HavingExpression = {
+      type: HavingExpressionType.IN,
+      metric: 'rows',
+      // @ts-expect-error HAVING IN requires at least one value.
+      values: [],
+    };
+    void filtered;
+    void invalidMetricFilter;
+    void invalidDistinct;
+    void invalidPercentile;
+    void invalidDerived;
+    void invalidHaving;
     void valid;
     void invalidAggregationField;
     void invalidRootFilter;

--- a/packages/wow/test/query/event/eventStreamQueryApi.test.ts
+++ b/packages/wow/test/query/event/eventStreamQueryApi.test.ts
@@ -19,6 +19,8 @@ import {
   EventStreamQueryClient,
   EventStreamQueryEndpointPaths,
   aggregation,
+  HavingExpressionType,
+  ComparisonOperator,
   cursorQuery,
   filter,
   type AggregationQuery,
@@ -37,7 +39,13 @@ describe('EventStreamQueryEndpointPaths', () => {
   const query: AggregationQuery<RootFields, EventFields> = {
     elements: [aggregation.element('body')],
     groupBy: [aggregation.terms('name', 'eventType')],
-    metrics: [aggregation.count('count')],
+    metrics: [aggregation.count('count', filter.eq('name', 'OrderPaid'))],
+    having: {
+      type: HavingExpressionType.CONDITION,
+      metric: 'count',
+      operator: ComparisonOperator.GTE,
+      value: 1,
+    },
   };
 
   it('should have correct endpoint path values', () => {

--- a/packages/wow/test/query/snapshot/snapshotQueryApi.test.ts
+++ b/packages/wow/test/query/snapshot/snapshotQueryApi.test.ts
@@ -18,6 +18,8 @@ import type { SnapshotQueryApi } from '../../../src';
 import {
   SnapshotQueryEndpointPaths,
   aggregation,
+  HavingExpressionType,
+  ComparisonOperator,
   cursorQuery,
   filter,
   SnapshotQueryClient,
@@ -36,8 +38,21 @@ describe('SnapshotQueryEndpointPaths', () => {
   };
   const query: AggregationQuery<RootFields, ItemFields> = {
     filter: filter.eq('state.status', 'PAID'),
-    groupBy: [aggregation.terms('productId', 'product')],
-    metrics: [aggregation.sum(aggregation.field('amount'), 'total')],
+    groupBy: [aggregation.terms('productId', 'product', 'Unknown')],
+    metrics: [
+      aggregation.sum(
+        aggregation.field('amount'),
+        'total',
+        filter.gt('amount', 0),
+      ),
+      aggregation.percentile(aggregation.field('amount'), 95, 'p95'),
+    ],
+    having: {
+      type: HavingExpressionType.CONDITION,
+      metric: 'total',
+      operator: ComparisonOperator.GT,
+      value: 100,
+    },
   };
 
   it('should have correct endpoint path values', () => {

--- a/skills/fetcher-wow-cqrs/references/api.md
+++ b/skills/fetcher-wow-cqrs/references/api.md
@@ -759,6 +759,7 @@ these fields:
 - `metrics: [AggregationMetric<AGGREGATION_FIELDS>, ...AggregationMetric<AGGREGATION_FIELDS>[]]` (non-empty)
 - `sort?: FieldSort[]`
 - `limit?: number`
+- `having?: HavingExpression`
 
 Each `AggregationElement` has a `path` and optional `filter`.
 `elements[].filter` is an `ElementFilterExpression`.
@@ -768,17 +769,22 @@ to the current innermost element.
 
 `AggregationGroup` is one of:
 
-- `TERMS`: `field`, `alias`
+- `TERMS`: `field`, `alias`, optional `missingKey`
 - `HISTOGRAM`: `field`, `alias`, `interval`
-- `DATE_HISTOGRAM`: `field`, `alias`, `unit`, optional `timeZone`
+- `DATE_HISTOGRAM`: `field`, `alias`, `unit`, optional `timeZone` and `dense`
 
 `AggregationMetric` is one of:
 
 - `COUNT`: `alias`
 - `NUMERIC`: `function`, `expression`, `alias`
 - `ANY`: `field`, `alias`
+- `DISTINCT_COUNT`: `expression`, `alias`
+- `PERCENTILE`: `expression`, `percentile`, `alias`
+- `DERIVED`: `expression: DerivedExpression`, `alias`
 
-`AggregationFunction` values are `SUM`, `AVG`, `MIN`, and `MAX`.
+All non-derived metrics accept optional `filter: FilterExpression<AGGREGATION_FIELDS>`.
+
+`AggregationFunction` values are `SUM`, `AVG`, `MIN`, `MAX`, `STDDEV`, and `VARIANCE`.
 `AggregationDateUnit` values are `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`,
 `HOUR`, `MINUTE`, and `SECOND`. Aggregation expressions use these
 discriminators:
@@ -798,15 +804,20 @@ aggregation.add(left, right);
 aggregation.subtract(left, right);
 aggregation.multiply(left, right);
 aggregation.divide(left, right);
-aggregation.terms(field, alias);
+aggregation.terms(field, alias, missingKey?);
 aggregation.histogram(field, { interval, alias });
-aggregation.dateHistogram(field, { unit, alias, timeZone }); // timeZone defaults to UTC
-aggregation.any(field, alias);
-aggregation.count(alias);
-aggregation.sum(expression, alias);
-aggregation.avg(expression, alias);
-aggregation.min(expression, alias);
-aggregation.max(expression, alias);
+aggregation.dateHistogram(field, { unit, alias, timeZone, dense }); // timeZone defaults to UTC
+aggregation.any(field, alias, predicate?);
+aggregation.count(alias, predicate?);
+aggregation.sum(expression, alias, predicate?);
+aggregation.avg(expression, alias, predicate?);
+aggregation.min(expression, alias, predicate?);
+aggregation.max(expression, alias, predicate?);
+aggregation.stddev(expression, alias, predicate?);
+aggregation.variance(expression, alias, predicate?);
+aggregation.distinctCount(expression, alias, predicate?);
+aggregation.percentile(expression, percentile, alias, predicate?);
+aggregation.derived(expression, alias);
 ```
 
 `ANY` is a metric, not a group. It returns one non-null scalar from the current
@@ -820,6 +831,52 @@ Wow validates the complete aggregation's field capabilities, cardinality,
 aliases, sort fields, and expression depth on the server. Fetcher only validates
 field-path and alias syntax that can be known locally. The `Row` generic describes
 aggregation result rows only; Fetcher does not perform runtime decoding.
+
+### Derived metrics, HAVING and group options
+
+Aligned with Wow `main` at `fd1b3cd46`. Existing builder calls keep their JSON shape; optional metric filters, `missingKey`, and `dense` are omitted unless supplied.
+
+- `aggregation.distinctCount(expression, alias, predicate?)` counts distinct non-null contributions; `aggregation.percentile(expression, percentile, alias, predicate?)` accepts finite values strictly between 0 and 100 (use 50 for the median). `stddev` and `variance` compute population statistics. Percentiles are approximate on both backends; Elasticsearch distinct counts may be approximate, while MongoDB counts distinct values exactly.
+- Non-derived metrics accept an optional `FilterExpression` in the current aggregation scope. It affects only that metric. The backend validates scalar fields and rejects unsupported filter operators.
+- `aggregation.derived(expression, alias)` uses a `DerivedExpression` tree (`METRIC_REF`, `CONSTANT`, `BINARY`). References must name earlier metrics and cannot reference `ANY`. Derived metrics have no record filter; filter the referenced metrics instead. Null operands or division by zero produce null.
+- `having?: HavingExpression` supports `CONDITION`, `BETWEEN`, `IN`, `IS_NULL`, `AND`, and `OR`, using metric aliases, not field paths. `ComparisonOperator` contains `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`. HAVING requires grouping and cannot reference `ANY`; it runs before sorting and limit. Non-empty sets/operands are enforced by tuple types; finite values, bounds, references and depth are validated by the server.
+- `terms(field, alias, missingKey?)` optionally merges missing/null values into a nonblank string bucket key; the backend validates string field support. `dateHistogram(field, { unit, alias, timeZone?, dense? })` fills interior date gaps when `dense` is true; it requires the only group dimension. No rows means no generated date range.
+
+Backend requirements still apply (MongoDB 5.1+ for dense groups, 7.0+ for percentiles); the client performs no backend capability probing. Raw typed expression objects are not runtime validators.
+
+```ts
+import {
+  aggregation,
+  AggregationExpressionOperator,
+  ComparisonOperator,
+  DerivedExpressionType,
+  HavingExpressionType,
+  type AggregationQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const query: AggregationQuery = {
+  groupBy: [aggregation.terms('state.status', 'status', 'Unknown')],
+  metrics: [
+    aggregation.count('orders'),
+    aggregation.sum(aggregation.field('state.amount'), 'revenue'),
+    aggregation.derived(
+      {
+        type: DerivedExpressionType.BINARY,
+        operator: AggregationExpressionOperator.DIVIDE,
+        left: { type: DerivedExpressionType.METRIC_REF, metric: 'revenue' },
+        right: { type: DerivedExpressionType.METRIC_REF, metric: 'orders' },
+      },
+      'averageOrderValue',
+    ),
+  ],
+  having: {
+    type: HavingExpressionType.CONDITION,
+    metric: 'averageOrderValue',
+    operator: ComparisonOperator.GTE,
+    value: 100,
+  },
+};
+```
 
 ## Query DSL Conditions (Deprecated)
 

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -13631,19 +13631,19 @@ export interface CursorPage<T> {
 
 AggregationQuery describes a server aggregation, not a JavaScript reducer. Supply at least one metric. `aggregate(query, attributes?, controller?)` returns flat rows keyed by your aliases; `aggregateStream` returns JSON SSE rows and needs explicit stream consumption. Generics describe rows but do not validate their contents.
 
-| Builder                                        | Inputs / result                                                                                                                                  |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| aggregation.element(path, predicate?)          | Select an array/nested element path, with optional element-relative filter; root metadata/search/deletion filters are rejected inside predicate. |
-| field(field), constant(number)                 | Field reference or finite numeric constant expression.                                                                                           |
-| add/subtract/multiply/divide(left, right)      | Binary expression tree; division is evaluated by the backend, not here.                                                                          |
-| terms(field, alias)                            | Terms grouping.                                                                                                                                  |
-| histogram(field, {interval, alias})            | Finite interval &gt; 0.                                                                                                                          |
-| dateHistogram(field, {unit, alias, timeZone?}) | AggregationDateUnit from YEAR to SECOND, timeZone defaults UTC; empty zone and invalid enum throw.                                               |
-| count(alias)                                   | Count metric; no field argument.                                                                                                                 |
-| any(field, alias)                              | Backend-selected value; do not treat it as a deterministic first row.                                                                            |
-| sum/avg/min/max(expression, alias)             | Numeric metric over an expression.                                                                                                               |
+| Builder                                                        | Inputs / result                                                                                                                                  |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| aggregation.element(path, predicate?)                          | Select an array/nested element path, with optional element-relative filter; root metadata/search/deletion filters are rejected inside predicate. |
+| field(field), constant(number)                                 | Field reference or finite numeric constant expression.                                                                                           |
+| add/subtract/multiply/divide(left, right)                      | Binary expression tree; division is evaluated by the backend, not here.                                                                          |
+| terms(field, alias, missingKey?)                               | Terms grouping.                                                                                                                                  |
+| histogram(field, {interval, alias})                            | Finite interval &gt; 0.                                                                                                                          |
+| dateHistogram(field, {unit, alias, timeZone?, dense?})         | AggregationDateUnit from YEAR to SECOND, timeZone defaults UTC; empty zone and invalid enum throw.                                               |
+| count(alias, predicate?)                                       | Count metric; no field argument.                                                                                                                 |
+| any(field, alias, predicate?)                                  | Backend-selected value; do not treat it as a deterministic first row.                                                                            |
+| sum/avg/min/max/stddev/variance(expression, alias, predicate?) | Numeric metric over an expression.                                                                                                               |
 
-Query fields are filter, elements, groupBy, metrics (nonempty tuple), sort, limit. Root filter selects source documents; elements describes nested element traversal/filtering, and group/metric fields refer to that aggregation scope. Output stays flat; elements does not mean a nested output response. Sort fields refer to output aliases. Omitted filter/groupBy/sort/limit are left undefined; there is no hidden client limit or grouping.
+Query fields are filter, elements, groupBy, metrics (nonempty tuple), sort, limit, having. Root filter selects source documents; elements describes nested element traversal/filtering, and group/metric fields refer to that aggregation scope. Output stays flat; elements does not mean a nested output response. Sort fields refer to output aliases. Omitted filter/groupBy/sort/limit are left undefined; there is no hidden client limit or grouping.
 
 Field syntax is validated by the same logical-field validator as filter. Aliases must be one valid segment, cannot contain dots or begin `__wow`. Invalid aliases, nonfinite constants and invalid histogram options throw TypeError. These checks do not guarantee fields exist, are numeric, or that a backend supports the query; service errors still reject. Builders perform no I/O or cleanup. Streaming readers must be cancelled and released when abandoned.
 
@@ -13671,6 +13671,52 @@ export const revenue: AggregationQuery = {
 };
 ```
 
+## Extended aggregation protocol
+
+Aligned with Wow `main` at `fd1b3cd46`. Existing builder calls keep their JSON shape; optional metric filters, `missingKey`, and `dense` are omitted unless supplied.
+
+- `aggregation.distinctCount(expression, alias, predicate?)` counts distinct non-null contributions; `aggregation.percentile(expression, percentile, alias, predicate?)` accepts finite values strictly between 0 and 100 (use 50 for the median). `stddev` and `variance` compute population statistics. Percentiles are approximate on both backends; Elasticsearch distinct counts may be approximate, while MongoDB counts distinct values exactly.
+- Non-derived metrics accept an optional `FilterExpression` in the current aggregation scope. It affects only that metric. The backend validates scalar fields and rejects unsupported filter operators.
+- `aggregation.derived(expression, alias)` uses a `DerivedExpression` tree (`METRIC_REF`, `CONSTANT`, `BINARY`). References must name earlier metrics and cannot reference `ANY`. Derived metrics have no record filter; filter the referenced metrics instead. Null operands or division by zero produce null.
+- `having?: HavingExpression` supports `CONDITION`, `BETWEEN`, `IN`, `IS_NULL`, `AND`, and `OR`, using metric aliases, not field paths. `ComparisonOperator` contains `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`. HAVING requires grouping and cannot reference `ANY`; it runs before sorting and limit. Non-empty sets/operands are enforced by tuple types; finite values, bounds, references and depth are validated by the server.
+- `terms(field, alias, missingKey?)` optionally merges missing/null values into a nonblank string bucket key; the backend validates string field support. `dateHistogram(field, { unit, alias, timeZone?, dense? })` fills interior date gaps when `dense` is true; it requires the only group dimension. No rows means no generated date range.
+
+Backend requirements still apply (MongoDB 5.1+ for dense groups, 7.0+ for percentiles); the client performs no backend capability probing. Raw typed expression objects are not runtime validators.
+
+```ts
+import {
+  aggregation,
+  AggregationExpressionOperator,
+  ComparisonOperator,
+  DerivedExpressionType,
+  HavingExpressionType,
+  type AggregationQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const query: AggregationQuery = {
+  groupBy: [aggregation.terms('state.status', 'status', 'Unknown')],
+  metrics: [
+    aggregation.count('orders'),
+    aggregation.sum(aggregation.field('state.amount'), 'revenue'),
+    aggregation.derived(
+      {
+        type: DerivedExpressionType.BINARY,
+        operator: AggregationExpressionOperator.DIVIDE,
+        left: { type: DerivedExpressionType.METRIC_REF, metric: 'revenue' },
+        right: { type: DerivedExpressionType.METRIC_REF, metric: 'orders' },
+      },
+      'averageOrderValue',
+    ),
+  ],
+  having: {
+    type: HavingExpressionType.CONDITION,
+    metric: 'averageOrderValue',
+    operator: ComparisonOperator.GTE,
+    value: 100,
+  },
+};
+```
+
 ## Public signatures and types
 
 These signatures follow declarations reachable from the current root entry. `?` marks optional input; generics/interfaces only constrain compile-time types. Locate inherited and related types through the [symbol index](./symbols). Runtime defaults and failure behavior are described above.
@@ -13694,6 +13740,9 @@ export enum AggregationMetricType {
   COUNT = 'COUNT',
   NUMERIC = 'NUMERIC',
   ANY = 'ANY',
+  DISTINCT_COUNT = 'DISTINCT_COUNT',
+  PERCENTILE = 'PERCENTILE',
+  DERIVED = 'DERIVED',
 }
 ```
 
@@ -13709,7 +13758,7 @@ export enum AggregationExpressionType {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:34](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L34)
+[packages/wow/src/query/aggregation.ts:37](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L37)
 
 ### AggregationExpressionOperator {#api-AggregationExpressionOperator}
 
@@ -13722,7 +13771,7 @@ export enum AggregationExpressionOperator {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:40](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L40)
+[packages/wow/src/query/aggregation.ts:43](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L43)
 
 ### AggregationDateUnit {#api-AggregationDateUnit}
 
@@ -13739,7 +13788,7 @@ export enum AggregationDateUnit {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:47](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L47)
+[packages/wow/src/query/aggregation.ts:50](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L50)
 
 ### AggregationFunction {#api-AggregationFunction}
 
@@ -13749,10 +13798,12 @@ export enum AggregationFunction {
   AVG = 'AVG',
   MIN = 'MIN',
   MAX = 'MAX',
+  STDDEV = 'STDDEV',
+  VARIANCE = 'VARIANCE',
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:58](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L58)
+[packages/wow/src/query/aggregation.ts:61](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L61)
 
 ### AggregationElement {#api-AggregationElement}
 
@@ -13763,7 +13814,7 @@ export interface AggregationElement {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:65](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L65)
+[packages/wow/src/query/aggregation.ts:70](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L70)
 
 ### TermsAggregationGroup {#api-TermsAggregationGroup}
 
@@ -13772,10 +13823,11 @@ export interface TermsAggregationGroup<
   FIELDS extends string = string,
 > extends AggregationGroupBase<FIELDS> {
   type: AggregationGroupType.TERMS;
+  missingKey?: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:75](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L75)
+[packages/wow/src/query/aggregation.ts:80](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L80)
 
 ### HistogramAggregationGroup {#api-HistogramAggregationGroup}
 
@@ -13788,7 +13840,7 @@ export interface HistogramAggregationGroup<
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:81](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L81)
+[packages/wow/src/query/aggregation.ts:87](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L87)
 
 ### DateHistogramAggregationGroup {#api-DateHistogramAggregationGroup}
 
@@ -13799,10 +13851,11 @@ export interface DateHistogramAggregationGroup<
   type: AggregationGroupType.DATE_HISTOGRAM;
   unit: AggregationDateUnit;
   timeZone?: string;
+  dense?: boolean;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:88](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L88)
+[packages/wow/src/query/aggregation.ts:94](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L94)
 
 ### AggregationGroup {#api-AggregationGroup}
 
@@ -13813,7 +13866,7 @@ export type AggregationGroup<FIELDS extends string = string> =
   | DateHistogramAggregationGroup<FIELDS>;
 ```
 
-[packages/wow/src/query/aggregation.ts:96](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L96)
+[packages/wow/src/query/aggregation.ts:103](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L103)
 
 ### FieldAggregationExpression {#api-FieldAggregationExpression}
 
@@ -13824,7 +13877,7 @@ export interface FieldAggregationExpression<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:101](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L101)
+[packages/wow/src/query/aggregation.ts:108](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L108)
 
 ### ConstantAggregationExpression {#api-ConstantAggregationExpression}
 
@@ -13835,7 +13888,7 @@ export interface ConstantAggregationExpression {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:106](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L106)
+[packages/wow/src/query/aggregation.ts:113](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L113)
 
 ### BinaryAggregationExpression {#api-BinaryAggregationExpression}
 
@@ -13848,7 +13901,7 @@ export interface BinaryAggregationExpression<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:111](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L111)
+[packages/wow/src/query/aggregation.ts:118](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L118)
 
 ### AggregationExpression {#api-AggregationExpression}
 
@@ -13859,23 +13912,25 @@ export type AggregationExpression<FIELDS extends string = string> =
   | BinaryAggregationExpression<FIELDS>;
 ```
 
-[packages/wow/src/query/aggregation.ts:118](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L118)
+[packages/wow/src/query/aggregation.ts:125](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L125)
 
 ### CountAggregationMetric {#api-CountAggregationMetric}
 
 ```ts
-export interface CountAggregationMetric {
+export interface CountAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.COUNT;
   alias: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:123](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L123)
+[packages/wow/src/query/aggregation.ts:130](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L130)
 
 ### NumericAggregationMetric {#api-NumericAggregationMetric}
 
 ```ts
 export interface NumericAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.NUMERIC;
   function: AggregationFunction;
   expression: AggregationExpression<FIELDS>;
@@ -13883,30 +13938,163 @@ export interface NumericAggregationMetric<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:128](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L128)
+[packages/wow/src/query/aggregation.ts:136](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L136)
 
 ### AnyAggregationMetric {#api-AnyAggregationMetric}
 
 ```ts
 export interface AnyAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.ANY;
   field: QueryField<FIELDS>;
   alias: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:135](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L135)
+[packages/wow/src/query/aggregation.ts:144](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L144)
+
+### DistinctCountAggregationMetric {#api-DistinctCountAggregationMetric}
+
+```ts
+export interface DistinctCountAggregationMetric<
+  FIELDS extends string = string,
+> {
+  type: AggregationMetricType.DISTINCT_COUNT;
+  expression: AggregationExpression<FIELDS>;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:151](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L151)
+
+### PercentileAggregationMetric {#api-PercentileAggregationMetric}
+
+```ts
+export interface PercentileAggregationMetric<FIELDS extends string = string> {
+  type: AggregationMetricType.PERCENTILE;
+  expression: AggregationExpression<FIELDS>;
+  percentile: number;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:160](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L160)
+
+### DerivedExpressionType {#api-DerivedExpressionType}
+
+```ts
+export enum DerivedExpressionType {
+  METRIC_REF = 'METRIC_REF',
+  CONSTANT = 'CONSTANT',
+  BINARY = 'BINARY',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:168](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L168)
+
+### DerivedExpression {#api-DerivedExpression}
+
+```ts
+export type DerivedExpression =
+  | { type: DerivedExpressionType.METRIC_REF; metric: string }
+  | { type: DerivedExpressionType.CONSTANT; value: number }
+  | {
+      type: DerivedExpressionType.BINARY;
+      operator: AggregationExpressionOperator;
+      left: DerivedExpression;
+      right: DerivedExpression;
+    };
+```
+
+[packages/wow/src/query/aggregation.ts:175](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L175)
+
+### DerivedAggregationMetric {#api-DerivedAggregationMetric}
+
+```ts
+export interface DerivedAggregationMetric {
+  type: AggregationMetricType.DERIVED;
+  expression: DerivedExpression;
+  alias: string;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:185](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L185)
+
+### HavingExpressionType {#api-HavingExpressionType}
+
+```ts
+export enum HavingExpressionType {
+  CONDITION = 'CONDITION',
+  BETWEEN = 'BETWEEN',
+  IN = 'IN',
+  IS_NULL = 'IS_NULL',
+  AND = 'AND',
+  OR = 'OR',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:191](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L191)
+
+### ComparisonOperator {#api-ComparisonOperator}
+
+```ts
+export enum ComparisonOperator {
+  EQ = 'EQ',
+  NE = 'NE',
+  GT = 'GT',
+  GTE = 'GTE',
+  LT = 'LT',
+  LTE = 'LTE',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:200](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L200)
+
+### HavingExpression {#api-HavingExpression}
+
+```ts
+export type HavingExpression =
+  | {
+      type: HavingExpressionType.CONDITION;
+      metric: string;
+      operator: ComparisonOperator;
+      value: number;
+    }
+  | {
+      type: HavingExpressionType.BETWEEN;
+      metric: string;
+      lower: number;
+      upper: number;
+    }
+  | {
+      type: HavingExpressionType.IN;
+      metric: string;
+      values: [number, ...number[]];
+    }
+  | { type: HavingExpressionType.IS_NULL; metric: string; negated?: boolean }
+  | {
+      type: HavingExpressionType.AND | HavingExpressionType.OR;
+      operands: [HavingExpression, ...HavingExpression[]];
+    };
+```
+
+[packages/wow/src/query/aggregation.ts:210](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
 
 ### AggregationMetric {#api-AggregationMetric}
 
 ```ts
 export type AggregationMetric<FIELDS extends string = string> =
-  | CountAggregationMetric
+  | CountAggregationMetric<FIELDS>
   | NumericAggregationMetric<FIELDS>
-  | AnyAggregationMetric<FIELDS>;
+  | AnyAggregationMetric<FIELDS>
+  | DistinctCountAggregationMetric<FIELDS>
+  | PercentileAggregationMetric<FIELDS>
+  | DerivedAggregationMetric;
 ```
 
-[packages/wow/src/query/aggregation.ts:141](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L141)
+[packages/wow/src/query/aggregation.ts:234](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L234)
 
 ### AggregationQuery {#api-AggregationQuery}
 
@@ -13924,10 +14112,11 @@ export interface AggregationQuery<
   ];
   sort?: FieldSort[];
   limit?: number;
+  having?: HavingExpression;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:146](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L146)
+[packages/wow/src/query/aggregation.ts:242](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L242)
 
 ### HistogramAggregationOptions {#api-HistogramAggregationOptions}
 
@@ -13938,7 +14127,7 @@ export interface HistogramAggregationOptions {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:161](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L161)
+[packages/wow/src/query/aggregation.ts:258](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L258)
 
 ### DateHistogramAggregationOptions {#api-DateHistogramAggregationOptions}
 
@@ -13947,17 +14136,16 @@ export interface DateHistogramAggregationOptions {
   unit: AggregationDateUnit;
   alias: string;
   timeZone?: string;
+  dense?: boolean;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:166](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L166)
+[packages/wow/src/query/aggregation.ts:263](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L263)
 
 ### aggregation {#api-aggregation}
 
-::: details Expand all fields and members
-
 ```ts
-declare const aggregation: {
+export declare const aggregation: {
   element(
     path: string,
     predicate?: ElementFilterExpression,
@@ -13985,6 +14173,7 @@ declare const aggregation: {
   terms<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    missingKey?: string,
   ): TermsAggregationGroup<FIELDS>;
   histogram<FIELDS extends string>(
     field: FIELDS,
@@ -13992,39 +14181,66 @@ declare const aggregation: {
   ): HistogramAggregationGroup<FIELDS>;
   dateHistogram<FIELDS extends string>(
     field: FIELDS,
-    { unit, alias, timeZone }: DateHistogramAggregationOptions,
+    { unit, alias, timeZone, dense }: DateHistogramAggregationOptions,
   ): DateHistogramAggregationGroup<FIELDS>;
   any<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ): AnyAggregationMetric<FIELDS>;
-  count(alias: string): CountAggregationMetric;
+  count<FIELDS extends string = string>(
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): CountAggregationMetric<FIELDS>;
   sum: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   avg: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   min: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   max: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
+  stddev: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => NumericAggregationMetric<FIELDS>;
+  variance: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => NumericAggregationMetric<FIELDS>;
+  distinctCount<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): DistinctCountAggregationMetric<FIELDS>;
+  percentile<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    percentile: number,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): PercentileAggregationMetric<FIELDS>;
+  derived(
+    expression: DerivedExpression,
+    alias: string,
+  ): DerivedAggregationMetric;
 };
 ```
 
-:::
-
-[packages/wow/src/query/aggregation.ts:210](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
-
-## Related topics
-
-[Client configuration and metadata](./configuration) · [Commands and wait results](./commands) · [Snapshot queries](./snapshot-queries) · [Filter expressions and legacy conditions](./filters) · [Projection, sorting and pagination](./query-options) · [Cursor queries](./cursor-queries) · [Events and historical state](./events-and-history) · [Identity and resource attribution](./identity-and-attribution)
+[packages/wow/src/query/aggregation.ts:310](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L310)
 
 </doc>
 
@@ -14948,6 +15164,7 @@ Both dictionaries are declared as `export const <locale>: OperatorLocale`. The f
 | `CommandUrlParams`                     | [Commands and wait results](./commands#api-CommandUrlParams)                                    |
 | `ComparableFilterLiteral`              | [Filter expressions and legacy conditions](./filters#api-ComparableFilterLiteral)               |
 | `ComparisonFilter`                     | [Filter expressions and legacy conditions](./filters#api-ComparisonFilter)                      |
+| `ComparisonOperator`                   | [Aggregation builders](./aggregations#api-ComparisonOperator)                                   |
 | `CompensationTarget`                   | [Commands and wait results](./commands#api-CompensationTarget)                                  |
 | `Condition`                            | [Filter expressions and legacy conditions](./filters#api-Condition)                             |
 | `ConditionCapable`                     | [Filter expressions and legacy conditions](./filters#api-ConditionCapable)                      |
@@ -14970,7 +15187,11 @@ Both dictionaries are declared as `export const <locale>: OperatorLocale`. The f
 | `DeletedCapable`                       | [Message payloads and state metadata](./messages-and-state#api-DeletedCapable)                  |
 | `DeletionFilter`                       | [Filter expressions and legacy conditions](./filters#api-DeletionFilter)                        |
 | `DeletionState`                        | [Filter expressions and legacy conditions](./filters#api-DeletionState)                         |
+| `DerivedAggregationMetric`             | [Aggregation builders](./aggregations#api-DerivedAggregationMetric)                             |
+| `DerivedExpression`                    | [Aggregation builders](./aggregations#api-DerivedExpression)                                    |
+| `DerivedExpressionType`                | [Aggregation builders](./aggregations#api-DerivedExpressionType)                                |
 | `DescriptionCapable`                   | [Identity and resource attribution](./identity-and-attribution#api-DescriptionCapable)          |
+| `DistinctCountAggregationMetric`       | [Aggregation builders](./aggregations#api-DistinctCountAggregationMetric)                       |
 | `DomainEvent`                          | [Events and historical state](./events-and-history#api-DomainEvent)                             |
 | `DomainEventStream`                    | [Events and historical state](./events-and-history#api-DomainEventStream)                       |
 | `DomainEventStreamHeader`              | [Events and historical state](./events-and-history#api-DomainEventStreamHeader)                 |
@@ -15008,6 +15229,8 @@ Both dictionaries are declared as `export const <locale>: OperatorLocale`. The f
 | `FunctionInfo`                         | [Message payloads and state metadata](./messages-and-state#api-FunctionInfo)                    |
 | `FunctionInfoCapable`                  | [Message payloads and state metadata](./messages-and-state#api-FunctionInfoCapable)             |
 | `FunctionKind`                         | [Message payloads and state metadata](./messages-and-state#api-FunctionKind)                    |
+| `HavingExpression`                     | [Aggregation builders](./aggregations#api-HavingExpression)                                     |
+| `HavingExpressionType`                 | [Aggregation builders](./aggregations#api-HavingExpressionType)                                 |
 | `HistogramAggregationGroup`            | [Aggregation builders](./aggregations#api-HistogramAggregationGroup)                            |
 | `HistogramAggregationOptions`          | [Aggregation builders](./aggregations#api-HistogramAggregationOptions)                          |
 | `Identifier`                           | [Identity and resource attribution](./identity-and-attribution#api-Identifier)                  |
@@ -15042,6 +15265,7 @@ Both dictionaries are declared as `export const <locale>: OperatorLocale`. The f
 | `PagedQuery`                           | [Projection, sorting and pagination](./query-options#api-PagedQuery)                            |
 | `PagedQueryRequest`                    | [Projection, sorting and pagination](./query-options#api-PagedQueryRequest)                     |
 | `Pagination`                           | [Projection, sorting and pagination](./query-options#api-Pagination)                            |
+| `PercentileAggregationMetric`          | [Aggregation builders](./aggregations#api-PercentileAggregationMetric)                          |
 | `Projection`                           | [Projection, sorting and pagination](./query-options#api-Projection)                            |
 | `ProjectionCapable`                    | [Projection, sorting and pagination](./query-options#api-ProjectionCapable)                     |
 | `QueryApi`                             | [Snapshot queries](./snapshot-queries#api-QueryApi)                                             |
@@ -15924,7 +16148,7 @@ These names come from the current public entry exports and declarations. Import 
 | `validateDashboardExpression`     | [dashboardFilters.ts:91](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/dashboard/dashboardFilters.ts#L91)                          |
 | `validateFilterConfiguration`     | [filterConfigurationValidation.ts:120](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/filter/filterConfigurationValidation.ts#L120) |
 | `validateRecordRows`              | [recordData.ts:42](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/record/validation/recordData.ts#L42)                              |
-| `validateViewDefinition`          | [definitionValidation.ts:196](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/definitionValidation.ts#L196)     |
+| `validateViewDefinition`          | [definitionValidation.ts:195](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/definitionValidation.ts#L195)     |
 | `validateViewInstance`            | [instanceValidation.ts:22](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/instanceValidation.ts#L22)           |
 | `ViewCapabilities`                | [viewModel.ts:192](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/viewModel.ts#L192)                                      |
 | `ViewCreateContext`               | [viewServiceContract.ts:41](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/viewServiceContract.ts#L41)                    |
@@ -15961,7 +16185,7 @@ These names come from the current public entry exports and declarations. Import 
 | Symbol                            | Declaration                                                                                                                                              |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AnalysisComponentEditorProps`    | [analysisReactTypes.ts:22](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/analysisReactTypes.ts#L22)                   |
-| `AnalysisEditor`                  | [AnalysisEditor.tsx:739](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisEditor.tsx#L739)                       |
+| `AnalysisEditor`                  | [AnalysisEditor.tsx:743](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisEditor.tsx#L743)                       |
 | `AnalysisExtensions`              | [analysisReactTypes.ts:33](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/analysisReactTypes.ts#L33)                   |
 | `AnalysisPresentationEditor`      | [AnalysisPresentationEditor.tsx:52](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisPresentationEditor.tsx#L52) |
 | `AnalysisPresentationEditorProps` | [AnalysisPresentationEditor.tsx:40](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisPresentationEditor.tsx#L40) |
@@ -34124,19 +34348,19 @@ export interface CursorPage<T> {
 
 AggregationQuery 描述服务端聚合，不是 JavaScript reducer，至少提供一个 metric。`aggregate(query, attributes?, controller?)` 返回以 alias 为键的扁平行；`aggregateStream` 返回 JSON SSE 行，需要显式消费。泛型描述行但不校验内容。
 
-| 构造器                                         | 输入 / 结果                                                                                 |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| aggregation.element(path, predicate?)          | 选择数组/嵌套元素路径，可带元素相对 filter；predicate 内拒绝根元数据/search/deletion 过滤。 |
-| field(field)、constant(number)                 | 字段引用或有限数值常量表达式。                                                              |
-| add/subtract/multiply/divide(left, right)      | 二元表达式树，除法由后端求值，不在此执行。                                                  |
-| terms(field, alias)                            | terms 分组。                                                                                |
-| histogram(field, {interval, alias})            | interval 必须有限且大于 0。                                                                 |
-| dateHistogram(field, {unit, alias, timeZone?}) | AggregationDateUnit 从 YEAR 到 SECOND，时区默认 UTC；空时区或非法枚举抛错。                 |
-| count(alias)                                   | count 指标，没有字段参数。                                                                  |
-| any(field, alias)                              | 后端选择的值，不保证是确定性的第一行。                                                      |
-| sum/avg/min/max(expression, alias)             | 对表达式进行数值聚合。                                                                      |
+| 构造器                                                         | 输入 / 结果                                                                                 |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| aggregation.element(path, predicate?)                          | 选择数组/嵌套元素路径，可带元素相对 filter；predicate 内拒绝根元数据/search/deletion 过滤。 |
+| field(field)、constant(number)                                 | 字段引用或有限数值常量表达式。                                                              |
+| add/subtract/multiply/divide(left, right)                      | 二元表达式树，除法由后端求值，不在此执行。                                                  |
+| terms(field, alias, missingKey?)                               | terms 分组。                                                                                |
+| histogram(field, {interval, alias})                            | interval 必须有限且大于 0。                                                                 |
+| dateHistogram(field, {unit, alias, timeZone?, dense?})         | AggregationDateUnit 从 YEAR 到 SECOND，时区默认 UTC；空时区或非法枚举抛错。                 |
+| count(alias, predicate?)                                       | count 指标，没有字段参数。                                                                  |
+| any(field, alias, predicate?)                                  | 后端选择的值，不保证是确定性的第一行。                                                      |
+| sum/avg/min/max/stddev/variance(expression, alias, predicate?) | 对表达式进行数值聚合。                                                                      |
 
-查询字段为 filter、elements、groupBy、metrics（非空元组）、sort、limit。根 filter 选择源文档，elements 描述嵌套元素遍历/过滤，分组和指标字段相对于该聚合作用域。结果仍为扁平行，elements 不表示嵌套响应。sort 使用输出 alias。省略 filter/groupBy/sort/limit 保持 undefined，没有隐藏客户端 limit 或分组。
+查询字段为 filter、elements、groupBy、metrics（非空元组）、sort、limit、having。根 filter 选择源文档，elements 描述嵌套元素遍历/过滤，分组和指标字段相对于该聚合作用域。结果仍为扁平行，elements 不表示嵌套响应。sort 使用输出 alias。省略 filter/groupBy/sort/limit 保持 undefined，没有隐藏客户端 limit 或分组。
 
 字段语法由 filter 使用的逻辑字段校验器验证。alias 必须为合法单段，不能含点或以 `__wow` 开头。非法 alias、非有限常量、非法 histogram 选项抛 TypeError；不保证字段存在、为数值或后端支持，服务错误仍可拒绝。构造器无 I/O，无须清理；放弃流式读取时需取消并释放 reader。
 
@@ -34164,6 +34388,52 @@ export const revenue: AggregationQuery = {
 };
 ```
 
+## 扩展聚合协议
+
+对齐 Wow `main` 的 `fd1b3cd46`。旧构造器调用保持原 JSON 形状；未提供的指标过滤、`missingKey` 和 `dense` 不写入请求。
+
+- `aggregation.distinctCount(expression, alias, predicate?)` 统计不同的非空贡献值；`aggregation.percentile(expression, percentile, alias, predicate?)` 只接受严格介于 0 与 100 之间的有限数值（中位数使用 50）。`stddev`、`variance` 计算总体标准差、总体方差。两种后端的百分位均为近似结果；Elasticsearch 去重计数可能近似，MongoDB 去重计数为精确值。
+- 非派生指标可传入当前聚合范围内的 `FilterExpression`，只影响该指标。后端校验标量字段并拒绝不支持的过滤操作符。
+- `aggregation.derived(expression, alias)` 使用 `DerivedExpression` 树（`METRIC_REF`、`CONSTANT`、`BINARY`）。只能引用之前声明的指标，不能引用 `ANY`。派生指标没有记录过滤，应过滤它所引用的指标。空操作数或除零产生 null。
+- `having?: HavingExpression` 支持 `CONDITION`、`BETWEEN`、`IN`、`IS_NULL`、`AND`、`OR`，引用指标别名而非字段路径。`ComparisonOperator` 包含 `EQ`、`NE`、`GT`、`GTE`、`LT`、`LTE`。HAVING 必须有分组，不能引用 `ANY`，在排序与 limit 之前执行。非空集合/操作数由元组类型约束；有限数值、上下界、引用和深度由服务端校验。
+- `terms(field, alias, missingKey?)` 可将缺失/null 值合并到非空白字符串桶键，后端校验字段是否支持字符串分组。`dateHistogram(field, { unit, alias, timeZone?, dense? })` 在 `dense` 为 true 时填充日期内部缺口，要求它是唯一分组维度。没有结果行时不生成日期范围。
+
+仍需满足后端版本要求（日期补桶需要 MongoDB 5.1+，百分位需要 7.0+）；客户端不探测后端能力。直接构造的类型化表达式对象不提供运行时校验。
+
+```ts
+import {
+  aggregation,
+  AggregationExpressionOperator,
+  ComparisonOperator,
+  DerivedExpressionType,
+  HavingExpressionType,
+  type AggregationQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const query: AggregationQuery = {
+  groupBy: [aggregation.terms('state.status', 'status', 'Unknown')],
+  metrics: [
+    aggregation.count('orders'),
+    aggregation.sum(aggregation.field('state.amount'), 'revenue'),
+    aggregation.derived(
+      {
+        type: DerivedExpressionType.BINARY,
+        operator: AggregationExpressionOperator.DIVIDE,
+        left: { type: DerivedExpressionType.METRIC_REF, metric: 'revenue' },
+        right: { type: DerivedExpressionType.METRIC_REF, metric: 'orders' },
+      },
+      'averageOrderValue',
+    ),
+  ],
+  having: {
+    type: HavingExpressionType.CONDITION,
+    metric: 'averageOrderValue',
+    operator: ComparisonOperator.GTE,
+    value: 100,
+  },
+};
+```
+
 ## 公开签名与类型
 
 以下签名按当前根入口可达声明核对。`?` 表示可省略；泛型/接口只约束编译期，继承项与关联类型可从 [符号索引](./symbols) 定位。运行时默认值和失败行为以本页上文为准。
@@ -34187,6 +34457,9 @@ export enum AggregationMetricType {
   COUNT = 'COUNT',
   NUMERIC = 'NUMERIC',
   ANY = 'ANY',
+  DISTINCT_COUNT = 'DISTINCT_COUNT',
+  PERCENTILE = 'PERCENTILE',
+  DERIVED = 'DERIVED',
 }
 ```
 
@@ -34202,7 +34475,7 @@ export enum AggregationExpressionType {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:34](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L34)
+[packages/wow/src/query/aggregation.ts:37](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L37)
 
 ### AggregationExpressionOperator {#api-AggregationExpressionOperator}
 
@@ -34215,7 +34488,7 @@ export enum AggregationExpressionOperator {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:40](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L40)
+[packages/wow/src/query/aggregation.ts:43](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L43)
 
 ### AggregationDateUnit {#api-AggregationDateUnit}
 
@@ -34232,7 +34505,7 @@ export enum AggregationDateUnit {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:47](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L47)
+[packages/wow/src/query/aggregation.ts:50](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L50)
 
 ### AggregationFunction {#api-AggregationFunction}
 
@@ -34242,10 +34515,12 @@ export enum AggregationFunction {
   AVG = 'AVG',
   MIN = 'MIN',
   MAX = 'MAX',
+  STDDEV = 'STDDEV',
+  VARIANCE = 'VARIANCE',
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:58](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L58)
+[packages/wow/src/query/aggregation.ts:61](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L61)
 
 ### AggregationElement {#api-AggregationElement}
 
@@ -34256,7 +34531,7 @@ export interface AggregationElement {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:65](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L65)
+[packages/wow/src/query/aggregation.ts:70](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L70)
 
 ### TermsAggregationGroup {#api-TermsAggregationGroup}
 
@@ -34265,10 +34540,11 @@ export interface TermsAggregationGroup<
   FIELDS extends string = string,
 > extends AggregationGroupBase<FIELDS> {
   type: AggregationGroupType.TERMS;
+  missingKey?: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:75](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L75)
+[packages/wow/src/query/aggregation.ts:80](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L80)
 
 ### HistogramAggregationGroup {#api-HistogramAggregationGroup}
 
@@ -34281,7 +34557,7 @@ export interface HistogramAggregationGroup<
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:81](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L81)
+[packages/wow/src/query/aggregation.ts:87](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L87)
 
 ### DateHistogramAggregationGroup {#api-DateHistogramAggregationGroup}
 
@@ -34292,10 +34568,11 @@ export interface DateHistogramAggregationGroup<
   type: AggregationGroupType.DATE_HISTOGRAM;
   unit: AggregationDateUnit;
   timeZone?: string;
+  dense?: boolean;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:88](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L88)
+[packages/wow/src/query/aggregation.ts:94](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L94)
 
 ### AggregationGroup {#api-AggregationGroup}
 
@@ -34306,7 +34583,7 @@ export type AggregationGroup<FIELDS extends string = string> =
   | DateHistogramAggregationGroup<FIELDS>;
 ```
 
-[packages/wow/src/query/aggregation.ts:96](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L96)
+[packages/wow/src/query/aggregation.ts:103](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L103)
 
 ### FieldAggregationExpression {#api-FieldAggregationExpression}
 
@@ -34317,7 +34594,7 @@ export interface FieldAggregationExpression<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:101](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L101)
+[packages/wow/src/query/aggregation.ts:108](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L108)
 
 ### ConstantAggregationExpression {#api-ConstantAggregationExpression}
 
@@ -34328,7 +34605,7 @@ export interface ConstantAggregationExpression {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:106](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L106)
+[packages/wow/src/query/aggregation.ts:113](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L113)
 
 ### BinaryAggregationExpression {#api-BinaryAggregationExpression}
 
@@ -34341,7 +34618,7 @@ export interface BinaryAggregationExpression<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:111](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L111)
+[packages/wow/src/query/aggregation.ts:118](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L118)
 
 ### AggregationExpression {#api-AggregationExpression}
 
@@ -34352,23 +34629,25 @@ export type AggregationExpression<FIELDS extends string = string> =
   | BinaryAggregationExpression<FIELDS>;
 ```
 
-[packages/wow/src/query/aggregation.ts:118](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L118)
+[packages/wow/src/query/aggregation.ts:125](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L125)
 
 ### CountAggregationMetric {#api-CountAggregationMetric}
 
 ```ts
-export interface CountAggregationMetric {
+export interface CountAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.COUNT;
   alias: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:123](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L123)
+[packages/wow/src/query/aggregation.ts:130](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L130)
 
 ### NumericAggregationMetric {#api-NumericAggregationMetric}
 
 ```ts
 export interface NumericAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.NUMERIC;
   function: AggregationFunction;
   expression: AggregationExpression<FIELDS>;
@@ -34376,30 +34655,163 @@ export interface NumericAggregationMetric<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:128](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L128)
+[packages/wow/src/query/aggregation.ts:136](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L136)
 
 ### AnyAggregationMetric {#api-AnyAggregationMetric}
 
 ```ts
 export interface AnyAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.ANY;
   field: QueryField<FIELDS>;
   alias: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:135](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L135)
+[packages/wow/src/query/aggregation.ts:144](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L144)
+
+### DistinctCountAggregationMetric {#api-DistinctCountAggregationMetric}
+
+```ts
+export interface DistinctCountAggregationMetric<
+  FIELDS extends string = string,
+> {
+  type: AggregationMetricType.DISTINCT_COUNT;
+  expression: AggregationExpression<FIELDS>;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:151](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L151)
+
+### PercentileAggregationMetric {#api-PercentileAggregationMetric}
+
+```ts
+export interface PercentileAggregationMetric<FIELDS extends string = string> {
+  type: AggregationMetricType.PERCENTILE;
+  expression: AggregationExpression<FIELDS>;
+  percentile: number;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:160](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L160)
+
+### DerivedExpressionType {#api-DerivedExpressionType}
+
+```ts
+export enum DerivedExpressionType {
+  METRIC_REF = 'METRIC_REF',
+  CONSTANT = 'CONSTANT',
+  BINARY = 'BINARY',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:168](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L168)
+
+### DerivedExpression {#api-DerivedExpression}
+
+```ts
+export type DerivedExpression =
+  | { type: DerivedExpressionType.METRIC_REF; metric: string }
+  | { type: DerivedExpressionType.CONSTANT; value: number }
+  | {
+      type: DerivedExpressionType.BINARY;
+      operator: AggregationExpressionOperator;
+      left: DerivedExpression;
+      right: DerivedExpression;
+    };
+```
+
+[packages/wow/src/query/aggregation.ts:175](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L175)
+
+### DerivedAggregationMetric {#api-DerivedAggregationMetric}
+
+```ts
+export interface DerivedAggregationMetric {
+  type: AggregationMetricType.DERIVED;
+  expression: DerivedExpression;
+  alias: string;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:185](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L185)
+
+### HavingExpressionType {#api-HavingExpressionType}
+
+```ts
+export enum HavingExpressionType {
+  CONDITION = 'CONDITION',
+  BETWEEN = 'BETWEEN',
+  IN = 'IN',
+  IS_NULL = 'IS_NULL',
+  AND = 'AND',
+  OR = 'OR',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:191](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L191)
+
+### ComparisonOperator {#api-ComparisonOperator}
+
+```ts
+export enum ComparisonOperator {
+  EQ = 'EQ',
+  NE = 'NE',
+  GT = 'GT',
+  GTE = 'GTE',
+  LT = 'LT',
+  LTE = 'LTE',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:200](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L200)
+
+### HavingExpression {#api-HavingExpression}
+
+```ts
+export type HavingExpression =
+  | {
+      type: HavingExpressionType.CONDITION;
+      metric: string;
+      operator: ComparisonOperator;
+      value: number;
+    }
+  | {
+      type: HavingExpressionType.BETWEEN;
+      metric: string;
+      lower: number;
+      upper: number;
+    }
+  | {
+      type: HavingExpressionType.IN;
+      metric: string;
+      values: [number, ...number[]];
+    }
+  | { type: HavingExpressionType.IS_NULL; metric: string; negated?: boolean }
+  | {
+      type: HavingExpressionType.AND | HavingExpressionType.OR;
+      operands: [HavingExpression, ...HavingExpression[]];
+    };
+```
+
+[packages/wow/src/query/aggregation.ts:210](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
 
 ### AggregationMetric {#api-AggregationMetric}
 
 ```ts
 export type AggregationMetric<FIELDS extends string = string> =
-  | CountAggregationMetric
+  | CountAggregationMetric<FIELDS>
   | NumericAggregationMetric<FIELDS>
-  | AnyAggregationMetric<FIELDS>;
+  | AnyAggregationMetric<FIELDS>
+  | DistinctCountAggregationMetric<FIELDS>
+  | PercentileAggregationMetric<FIELDS>
+  | DerivedAggregationMetric;
 ```
 
-[packages/wow/src/query/aggregation.ts:141](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L141)
+[packages/wow/src/query/aggregation.ts:234](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L234)
 
 ### AggregationQuery {#api-AggregationQuery}
 
@@ -34417,10 +34829,11 @@ export interface AggregationQuery<
   ];
   sort?: FieldSort[];
   limit?: number;
+  having?: HavingExpression;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:146](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L146)
+[packages/wow/src/query/aggregation.ts:242](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L242)
 
 ### HistogramAggregationOptions {#api-HistogramAggregationOptions}
 
@@ -34431,7 +34844,7 @@ export interface HistogramAggregationOptions {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:161](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L161)
+[packages/wow/src/query/aggregation.ts:258](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L258)
 
 ### DateHistogramAggregationOptions {#api-DateHistogramAggregationOptions}
 
@@ -34440,17 +34853,16 @@ export interface DateHistogramAggregationOptions {
   unit: AggregationDateUnit;
   alias: string;
   timeZone?: string;
+  dense?: boolean;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:166](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L166)
+[packages/wow/src/query/aggregation.ts:263](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L263)
 
 ### aggregation {#api-aggregation}
 
-::: details 展开完整字段与成员
-
 ```ts
-declare const aggregation: {
+export declare const aggregation: {
   element(
     path: string,
     predicate?: ElementFilterExpression,
@@ -34478,6 +34890,7 @@ declare const aggregation: {
   terms<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    missingKey?: string,
   ): TermsAggregationGroup<FIELDS>;
   histogram<FIELDS extends string>(
     field: FIELDS,
@@ -34485,39 +34898,66 @@ declare const aggregation: {
   ): HistogramAggregationGroup<FIELDS>;
   dateHistogram<FIELDS extends string>(
     field: FIELDS,
-    { unit, alias, timeZone }: DateHistogramAggregationOptions,
+    { unit, alias, timeZone, dense }: DateHistogramAggregationOptions,
   ): DateHistogramAggregationGroup<FIELDS>;
   any<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ): AnyAggregationMetric<FIELDS>;
-  count(alias: string): CountAggregationMetric;
+  count<FIELDS extends string = string>(
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): CountAggregationMetric<FIELDS>;
   sum: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   avg: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   min: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   max: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
+  stddev: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => NumericAggregationMetric<FIELDS>;
+  variance: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => NumericAggregationMetric<FIELDS>;
+  distinctCount<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): DistinctCountAggregationMetric<FIELDS>;
+  percentile<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    percentile: number,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): PercentileAggregationMetric<FIELDS>;
+  derived(
+    expression: DerivedExpression,
+    alias: string,
+  ): DerivedAggregationMetric;
 };
 ```
 
-:::
-
-[packages/wow/src/query/aggregation.ts:210](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
-
-## 相关专题
-
-[客户端配置与元数据](./configuration) · [命令与等待结果](./commands) · [快照查询](./snapshot-queries) · [过滤表达式与旧条件](./filters) · [投影、排序与分页](./query-options) · [游标查询](./cursor-queries) · [事件与历史状态](./events-and-history) · [身份与资源归属](./identity-and-attribution)
+[packages/wow/src/query/aggregation.ts:310](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L310)
 
 </doc>
 
@@ -35441,6 +35881,7 @@ console.log(zh_CN.EQ);
 | `CommandUrlParams`                     | [命令与等待结果](./commands#api-CommandUrlParams)                               |
 | `ComparableFilterLiteral`              | [过滤表达式与旧条件](./filters#api-ComparableFilterLiteral)                     |
 | `ComparisonFilter`                     | [过滤表达式与旧条件](./filters#api-ComparisonFilter)                            |
+| `ComparisonOperator`                   | [聚合构造器](./aggregations#api-ComparisonOperator)                             |
 | `CompensationTarget`                   | [命令与等待结果](./commands#api-CompensationTarget)                             |
 | `Condition`                            | [过滤表达式与旧条件](./filters#api-Condition)                                   |
 | `ConditionCapable`                     | [过滤表达式与旧条件](./filters#api-ConditionCapable)                            |
@@ -35463,7 +35904,11 @@ console.log(zh_CN.EQ);
 | `DeletedCapable`                       | [消息载荷与状态元数据](./messages-and-state#api-DeletedCapable)                 |
 | `DeletionFilter`                       | [过滤表达式与旧条件](./filters#api-DeletionFilter)                              |
 | `DeletionState`                        | [过滤表达式与旧条件](./filters#api-DeletionState)                               |
+| `DerivedAggregationMetric`             | [聚合构造器](./aggregations#api-DerivedAggregationMetric)                       |
+| `DerivedExpression`                    | [聚合构造器](./aggregations#api-DerivedExpression)                              |
+| `DerivedExpressionType`                | [聚合构造器](./aggregations#api-DerivedExpressionType)                          |
 | `DescriptionCapable`                   | [身份与资源归属](./identity-and-attribution#api-DescriptionCapable)             |
+| `DistinctCountAggregationMetric`       | [聚合构造器](./aggregations#api-DistinctCountAggregationMetric)                 |
 | `DomainEvent`                          | [事件与历史状态](./events-and-history#api-DomainEvent)                          |
 | `DomainEventStream`                    | [事件与历史状态](./events-and-history#api-DomainEventStream)                    |
 | `DomainEventStreamHeader`              | [事件与历史状态](./events-and-history#api-DomainEventStreamHeader)              |
@@ -35501,6 +35946,8 @@ console.log(zh_CN.EQ);
 | `FunctionInfo`                         | [消息载荷与状态元数据](./messages-and-state#api-FunctionInfo)                   |
 | `FunctionInfoCapable`                  | [消息载荷与状态元数据](./messages-and-state#api-FunctionInfoCapable)            |
 | `FunctionKind`                         | [消息载荷与状态元数据](./messages-and-state#api-FunctionKind)                   |
+| `HavingExpression`                     | [聚合构造器](./aggregations#api-HavingExpression)                               |
+| `HavingExpressionType`                 | [聚合构造器](./aggregations#api-HavingExpressionType)                           |
 | `HistogramAggregationGroup`            | [聚合构造器](./aggregations#api-HistogramAggregationGroup)                      |
 | `HistogramAggregationOptions`          | [聚合构造器](./aggregations#api-HistogramAggregationOptions)                    |
 | `Identifier`                           | [身份与资源归属](./identity-and-attribution#api-Identifier)                     |
@@ -35535,6 +35982,7 @@ console.log(zh_CN.EQ);
 | `PagedQuery`                           | [投影、排序与分页](./query-options#api-PagedQuery)                              |
 | `PagedQueryRequest`                    | [投影、排序与分页](./query-options#api-PagedQueryRequest)                       |
 | `Pagination`                           | [投影、排序与分页](./query-options#api-Pagination)                              |
+| `PercentileAggregationMetric`          | [聚合构造器](./aggregations#api-PercentileAggregationMetric)                    |
 | `Projection`                           | [投影、排序与分页](./query-options#api-Projection)                              |
 | `ProjectionCapable`                    | [投影、排序与分页](./query-options#api-ProjectionCapable)                       |
 | `QueryApi`                             | [快照查询](./snapshot-queries#api-QueryApi)                                     |
@@ -36415,7 +36863,7 @@ console.log(compiled.plan.query, result.rows);
 | `validateDashboardExpression`     | [dashboardFilters.ts:91](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/dashboard/dashboardFilters.ts#L91)                          |
 | `validateFilterConfiguration`     | [filterConfigurationValidation.ts:120](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/filter/filterConfigurationValidation.ts#L120) |
 | `validateRecordRows`              | [recordData.ts:42](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/record/validation/recordData.ts#L42)                              |
-| `validateViewDefinition`          | [definitionValidation.ts:196](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/definitionValidation.ts#L196)     |
+| `validateViewDefinition`          | [definitionValidation.ts:195](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/definitionValidation.ts#L195)     |
 | `validateViewInstance`            | [instanceValidation.ts:22](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/instanceValidation.ts#L22)           |
 | `ViewCapabilities`                | [viewModel.ts:192](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/viewModel.ts#L192)                                      |
 | `ViewCreateContext`               | [viewServiceContract.ts:41](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/viewServiceContract.ts#L41)                    |
@@ -36452,7 +36900,7 @@ console.log(compiled.plan.query, result.rows);
 | 符号                              | 声明                                                                                                                                                     |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AnalysisComponentEditorProps`    | [analysisReactTypes.ts:22](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/analysisReactTypes.ts#L22)                   |
-| `AnalysisEditor`                  | [AnalysisEditor.tsx:739](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisEditor.tsx#L739)                       |
+| `AnalysisEditor`                  | [AnalysisEditor.tsx:743](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisEditor.tsx#L743)                       |
 | `AnalysisExtensions`              | [analysisReactTypes.ts:33](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/analysisReactTypes.ts#L33)                   |
 | `AnalysisPresentationEditor`      | [AnalysisPresentationEditor.tsx:52](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisPresentationEditor.tsx#L52) |
 | `AnalysisPresentationEditorProps` | [AnalysisPresentationEditor.tsx:40](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisPresentationEditor.tsx#L40) |

--- a/wiki/reference/view-engine/symbols.md
+++ b/wiki/reference/view-engine/symbols.md
@@ -144,7 +144,7 @@ These names come from the current public entry exports and declarations. Import 
 | `validateDashboardExpression`     | [dashboardFilters.ts:91](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/dashboard/dashboardFilters.ts#L91)                          |
 | `validateFilterConfiguration`     | [filterConfigurationValidation.ts:120](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/filter/filterConfigurationValidation.ts#L120) |
 | `validateRecordRows`              | [recordData.ts:42](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/record/validation/recordData.ts#L42)                              |
-| `validateViewDefinition`          | [definitionValidation.ts:196](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/definitionValidation.ts#L196)     |
+| `validateViewDefinition`          | [definitionValidation.ts:195](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/definitionValidation.ts#L195)     |
 | `validateViewInstance`            | [instanceValidation.ts:22](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/instanceValidation.ts#L22)           |
 | `ViewCapabilities`                | [viewModel.ts:192](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/viewModel.ts#L192)                                      |
 | `ViewCreateContext`               | [viewServiceContract.ts:41](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/viewServiceContract.ts#L41)                    |
@@ -181,7 +181,7 @@ These names come from the current public entry exports and declarations. Import 
 | Symbol                            | Declaration                                                                                                                                              |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AnalysisComponentEditorProps`    | [analysisReactTypes.ts:22](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/analysisReactTypes.ts#L22)                   |
-| `AnalysisEditor`                  | [AnalysisEditor.tsx:739](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisEditor.tsx#L739)                       |
+| `AnalysisEditor`                  | [AnalysisEditor.tsx:743](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisEditor.tsx#L743)                       |
 | `AnalysisExtensions`              | [analysisReactTypes.ts:33](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/analysisReactTypes.ts#L33)                   |
 | `AnalysisPresentationEditor`      | [AnalysisPresentationEditor.tsx:52](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisPresentationEditor.tsx#L52) |
 | `AnalysisPresentationEditorProps` | [AnalysisPresentationEditor.tsx:40](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisPresentationEditor.tsx#L40) |

--- a/wiki/reference/wow/aggregations.md
+++ b/wiki/reference/wow/aggregations.md
@@ -7,19 +7,19 @@ description: 'Aggregation builders — @ahoo-wang/fetcher-wow 5.0.0'
 
 AggregationQuery describes a server aggregation, not a JavaScript reducer. Supply at least one metric. `aggregate(query, attributes?, controller?)` returns flat rows keyed by your aliases; `aggregateStream` returns JSON SSE rows and needs explicit stream consumption. Generics describe rows but do not validate their contents.
 
-| Builder                                        | Inputs / result                                                                                                                                  |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| aggregation.element(path, predicate?)          | Select an array/nested element path, with optional element-relative filter; root metadata/search/deletion filters are rejected inside predicate. |
-| field(field), constant(number)                 | Field reference or finite numeric constant expression.                                                                                           |
-| add/subtract/multiply/divide(left, right)      | Binary expression tree; division is evaluated by the backend, not here.                                                                          |
-| terms(field, alias)                            | Terms grouping.                                                                                                                                  |
-| histogram(field, {interval, alias})            | Finite interval &gt; 0.                                                                                                                          |
-| dateHistogram(field, {unit, alias, timeZone?}) | AggregationDateUnit from YEAR to SECOND, timeZone defaults UTC; empty zone and invalid enum throw.                                               |
-| count(alias)                                   | Count metric; no field argument.                                                                                                                 |
-| any(field, alias)                              | Backend-selected value; do not treat it as a deterministic first row.                                                                            |
-| sum/avg/min/max(expression, alias)             | Numeric metric over an expression.                                                                                                               |
+| Builder                                                        | Inputs / result                                                                                                                                  |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| aggregation.element(path, predicate?)                          | Select an array/nested element path, with optional element-relative filter; root metadata/search/deletion filters are rejected inside predicate. |
+| field(field), constant(number)                                 | Field reference or finite numeric constant expression.                                                                                           |
+| add/subtract/multiply/divide(left, right)                      | Binary expression tree; division is evaluated by the backend, not here.                                                                          |
+| terms(field, alias, missingKey?)                               | Terms grouping.                                                                                                                                  |
+| histogram(field, {interval, alias})                            | Finite interval &gt; 0.                                                                                                                          |
+| dateHistogram(field, {unit, alias, timeZone?, dense?})         | AggregationDateUnit from YEAR to SECOND, timeZone defaults UTC; empty zone and invalid enum throw.                                               |
+| count(alias, predicate?)                                       | Count metric; no field argument.                                                                                                                 |
+| any(field, alias, predicate?)                                  | Backend-selected value; do not treat it as a deterministic first row.                                                                            |
+| sum/avg/min/max/stddev/variance(expression, alias, predicate?) | Numeric metric over an expression.                                                                                                               |
 
-Query fields are filter, elements, groupBy, metrics (nonempty tuple), sort, limit. Root filter selects source documents; elements describes nested element traversal/filtering, and group/metric fields refer to that aggregation scope. Output stays flat; elements does not mean a nested output response. Sort fields refer to output aliases. Omitted filter/groupBy/sort/limit are left undefined; there is no hidden client limit or grouping.
+Query fields are filter, elements, groupBy, metrics (nonempty tuple), sort, limit, having. Root filter selects source documents; elements describes nested element traversal/filtering, and group/metric fields refer to that aggregation scope. Output stays flat; elements does not mean a nested output response. Sort fields refer to output aliases. Omitted filter/groupBy/sort/limit are left undefined; there is no hidden client limit or grouping.
 
 Field syntax is validated by the same logical-field validator as filter. Aliases must be one valid segment, cannot contain dots or begin `__wow`. Invalid aliases, nonfinite constants and invalid histogram options throw TypeError. These checks do not guarantee fields exist, are numeric, or that a backend supports the query; service errors still reject. Builders perform no I/O or cleanup. Streaming readers must be cancelled and released when abandoned.
 
@@ -47,6 +47,52 @@ export const revenue: AggregationQuery = {
 };
 ```
 
+## Extended aggregation protocol
+
+Aligned with Wow `main` at `fd1b3cd46`. Existing builder calls keep their JSON shape; optional metric filters, `missingKey`, and `dense` are omitted unless supplied.
+
+- `aggregation.distinctCount(expression, alias, predicate?)` counts distinct non-null contributions; `aggregation.percentile(expression, percentile, alias, predicate?)` accepts finite values strictly between 0 and 100 (use 50 for the median). `stddev` and `variance` compute population statistics. Percentiles are approximate on both backends; Elasticsearch distinct counts may be approximate, while MongoDB counts distinct values exactly.
+- Non-derived metrics accept an optional `FilterExpression` in the current aggregation scope. It affects only that metric. The backend validates scalar fields and rejects unsupported filter operators.
+- `aggregation.derived(expression, alias)` uses a `DerivedExpression` tree (`METRIC_REF`, `CONSTANT`, `BINARY`). References must name earlier metrics and cannot reference `ANY`. Derived metrics have no record filter; filter the referenced metrics instead. Null operands or division by zero produce null.
+- `having?: HavingExpression` supports `CONDITION`, `BETWEEN`, `IN`, `IS_NULL`, `AND`, and `OR`, using metric aliases, not field paths. `ComparisonOperator` contains `EQ`, `NE`, `GT`, `GTE`, `LT`, `LTE`. HAVING requires grouping and cannot reference `ANY`; it runs before sorting and limit. Non-empty sets/operands are enforced by tuple types; finite values, bounds, references and depth are validated by the server.
+- `terms(field, alias, missingKey?)` optionally merges missing/null values into a nonblank string bucket key; the backend validates string field support. `dateHistogram(field, { unit, alias, timeZone?, dense? })` fills interior date gaps when `dense` is true; it requires the only group dimension. No rows means no generated date range.
+
+Backend requirements still apply (MongoDB 5.1+ for dense groups, 7.0+ for percentiles); the client performs no backend capability probing. Raw typed expression objects are not runtime validators.
+
+```ts
+import {
+  aggregation,
+  AggregationExpressionOperator,
+  ComparisonOperator,
+  DerivedExpressionType,
+  HavingExpressionType,
+  type AggregationQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const query: AggregationQuery = {
+  groupBy: [aggregation.terms('state.status', 'status', 'Unknown')],
+  metrics: [
+    aggregation.count('orders'),
+    aggregation.sum(aggregation.field('state.amount'), 'revenue'),
+    aggregation.derived(
+      {
+        type: DerivedExpressionType.BINARY,
+        operator: AggregationExpressionOperator.DIVIDE,
+        left: { type: DerivedExpressionType.METRIC_REF, metric: 'revenue' },
+        right: { type: DerivedExpressionType.METRIC_REF, metric: 'orders' },
+      },
+      'averageOrderValue',
+    ),
+  ],
+  having: {
+    type: HavingExpressionType.CONDITION,
+    metric: 'averageOrderValue',
+    operator: ComparisonOperator.GTE,
+    value: 100,
+  },
+};
+```
+
 ## Public signatures and types
 
 These signatures follow declarations reachable from the current root entry. `?` marks optional input; generics/interfaces only constrain compile-time types. Locate inherited and related types through the [symbol index](./symbols). Runtime defaults and failure behavior are described above.
@@ -70,6 +116,9 @@ export enum AggregationMetricType {
   COUNT = 'COUNT',
   NUMERIC = 'NUMERIC',
   ANY = 'ANY',
+  DISTINCT_COUNT = 'DISTINCT_COUNT',
+  PERCENTILE = 'PERCENTILE',
+  DERIVED = 'DERIVED',
 }
 ```
 
@@ -85,7 +134,7 @@ export enum AggregationExpressionType {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:34](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L34)
+[packages/wow/src/query/aggregation.ts:37](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L37)
 
 ### AggregationExpressionOperator {#api-AggregationExpressionOperator}
 
@@ -98,7 +147,7 @@ export enum AggregationExpressionOperator {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:40](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L40)
+[packages/wow/src/query/aggregation.ts:43](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L43)
 
 ### AggregationDateUnit {#api-AggregationDateUnit}
 
@@ -115,7 +164,7 @@ export enum AggregationDateUnit {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:47](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L47)
+[packages/wow/src/query/aggregation.ts:50](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L50)
 
 ### AggregationFunction {#api-AggregationFunction}
 
@@ -125,10 +174,12 @@ export enum AggregationFunction {
   AVG = 'AVG',
   MIN = 'MIN',
   MAX = 'MAX',
+  STDDEV = 'STDDEV',
+  VARIANCE = 'VARIANCE',
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:58](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L58)
+[packages/wow/src/query/aggregation.ts:61](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L61)
 
 ### AggregationElement {#api-AggregationElement}
 
@@ -139,7 +190,7 @@ export interface AggregationElement {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:65](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L65)
+[packages/wow/src/query/aggregation.ts:70](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L70)
 
 ### TermsAggregationGroup {#api-TermsAggregationGroup}
 
@@ -148,10 +199,11 @@ export interface TermsAggregationGroup<
   FIELDS extends string = string,
 > extends AggregationGroupBase<FIELDS> {
   type: AggregationGroupType.TERMS;
+  missingKey?: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:75](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L75)
+[packages/wow/src/query/aggregation.ts:80](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L80)
 
 ### HistogramAggregationGroup {#api-HistogramAggregationGroup}
 
@@ -164,7 +216,7 @@ export interface HistogramAggregationGroup<
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:81](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L81)
+[packages/wow/src/query/aggregation.ts:87](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L87)
 
 ### DateHistogramAggregationGroup {#api-DateHistogramAggregationGroup}
 
@@ -175,10 +227,11 @@ export interface DateHistogramAggregationGroup<
   type: AggregationGroupType.DATE_HISTOGRAM;
   unit: AggregationDateUnit;
   timeZone?: string;
+  dense?: boolean;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:88](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L88)
+[packages/wow/src/query/aggregation.ts:94](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L94)
 
 ### AggregationGroup {#api-AggregationGroup}
 
@@ -189,7 +242,7 @@ export type AggregationGroup<FIELDS extends string = string> =
   | DateHistogramAggregationGroup<FIELDS>;
 ```
 
-[packages/wow/src/query/aggregation.ts:96](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L96)
+[packages/wow/src/query/aggregation.ts:103](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L103)
 
 ### FieldAggregationExpression {#api-FieldAggregationExpression}
 
@@ -200,7 +253,7 @@ export interface FieldAggregationExpression<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:101](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L101)
+[packages/wow/src/query/aggregation.ts:108](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L108)
 
 ### ConstantAggregationExpression {#api-ConstantAggregationExpression}
 
@@ -211,7 +264,7 @@ export interface ConstantAggregationExpression {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:106](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L106)
+[packages/wow/src/query/aggregation.ts:113](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L113)
 
 ### BinaryAggregationExpression {#api-BinaryAggregationExpression}
 
@@ -224,7 +277,7 @@ export interface BinaryAggregationExpression<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:111](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L111)
+[packages/wow/src/query/aggregation.ts:118](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L118)
 
 ### AggregationExpression {#api-AggregationExpression}
 
@@ -235,23 +288,25 @@ export type AggregationExpression<FIELDS extends string = string> =
   | BinaryAggregationExpression<FIELDS>;
 ```
 
-[packages/wow/src/query/aggregation.ts:118](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L118)
+[packages/wow/src/query/aggregation.ts:125](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L125)
 
 ### CountAggregationMetric {#api-CountAggregationMetric}
 
 ```ts
-export interface CountAggregationMetric {
+export interface CountAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.COUNT;
   alias: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:123](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L123)
+[packages/wow/src/query/aggregation.ts:130](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L130)
 
 ### NumericAggregationMetric {#api-NumericAggregationMetric}
 
 ```ts
 export interface NumericAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.NUMERIC;
   function: AggregationFunction;
   expression: AggregationExpression<FIELDS>;
@@ -259,30 +314,163 @@ export interface NumericAggregationMetric<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:128](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L128)
+[packages/wow/src/query/aggregation.ts:136](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L136)
 
 ### AnyAggregationMetric {#api-AnyAggregationMetric}
 
 ```ts
 export interface AnyAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.ANY;
   field: QueryField<FIELDS>;
   alias: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:135](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L135)
+[packages/wow/src/query/aggregation.ts:144](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L144)
+
+### DistinctCountAggregationMetric {#api-DistinctCountAggregationMetric}
+
+```ts
+export interface DistinctCountAggregationMetric<
+  FIELDS extends string = string,
+> {
+  type: AggregationMetricType.DISTINCT_COUNT;
+  expression: AggregationExpression<FIELDS>;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:151](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L151)
+
+### PercentileAggregationMetric {#api-PercentileAggregationMetric}
+
+```ts
+export interface PercentileAggregationMetric<FIELDS extends string = string> {
+  type: AggregationMetricType.PERCENTILE;
+  expression: AggregationExpression<FIELDS>;
+  percentile: number;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:160](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L160)
+
+### DerivedExpressionType {#api-DerivedExpressionType}
+
+```ts
+export enum DerivedExpressionType {
+  METRIC_REF = 'METRIC_REF',
+  CONSTANT = 'CONSTANT',
+  BINARY = 'BINARY',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:168](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L168)
+
+### DerivedExpression {#api-DerivedExpression}
+
+```ts
+export type DerivedExpression =
+  | { type: DerivedExpressionType.METRIC_REF; metric: string }
+  | { type: DerivedExpressionType.CONSTANT; value: number }
+  | {
+      type: DerivedExpressionType.BINARY;
+      operator: AggregationExpressionOperator;
+      left: DerivedExpression;
+      right: DerivedExpression;
+    };
+```
+
+[packages/wow/src/query/aggregation.ts:175](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L175)
+
+### DerivedAggregationMetric {#api-DerivedAggregationMetric}
+
+```ts
+export interface DerivedAggregationMetric {
+  type: AggregationMetricType.DERIVED;
+  expression: DerivedExpression;
+  alias: string;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:185](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L185)
+
+### HavingExpressionType {#api-HavingExpressionType}
+
+```ts
+export enum HavingExpressionType {
+  CONDITION = 'CONDITION',
+  BETWEEN = 'BETWEEN',
+  IN = 'IN',
+  IS_NULL = 'IS_NULL',
+  AND = 'AND',
+  OR = 'OR',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:191](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L191)
+
+### ComparisonOperator {#api-ComparisonOperator}
+
+```ts
+export enum ComparisonOperator {
+  EQ = 'EQ',
+  NE = 'NE',
+  GT = 'GT',
+  GTE = 'GTE',
+  LT = 'LT',
+  LTE = 'LTE',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:200](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L200)
+
+### HavingExpression {#api-HavingExpression}
+
+```ts
+export type HavingExpression =
+  | {
+      type: HavingExpressionType.CONDITION;
+      metric: string;
+      operator: ComparisonOperator;
+      value: number;
+    }
+  | {
+      type: HavingExpressionType.BETWEEN;
+      metric: string;
+      lower: number;
+      upper: number;
+    }
+  | {
+      type: HavingExpressionType.IN;
+      metric: string;
+      values: [number, ...number[]];
+    }
+  | { type: HavingExpressionType.IS_NULL; metric: string; negated?: boolean }
+  | {
+      type: HavingExpressionType.AND | HavingExpressionType.OR;
+      operands: [HavingExpression, ...HavingExpression[]];
+    };
+```
+
+[packages/wow/src/query/aggregation.ts:210](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
 
 ### AggregationMetric {#api-AggregationMetric}
 
 ```ts
 export type AggregationMetric<FIELDS extends string = string> =
-  | CountAggregationMetric
+  | CountAggregationMetric<FIELDS>
   | NumericAggregationMetric<FIELDS>
-  | AnyAggregationMetric<FIELDS>;
+  | AnyAggregationMetric<FIELDS>
+  | DistinctCountAggregationMetric<FIELDS>
+  | PercentileAggregationMetric<FIELDS>
+  | DerivedAggregationMetric;
 ```
 
-[packages/wow/src/query/aggregation.ts:141](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L141)
+[packages/wow/src/query/aggregation.ts:234](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L234)
 
 ### AggregationQuery {#api-AggregationQuery}
 
@@ -300,10 +488,11 @@ export interface AggregationQuery<
   ];
   sort?: FieldSort[];
   limit?: number;
+  having?: HavingExpression;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:146](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L146)
+[packages/wow/src/query/aggregation.ts:242](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L242)
 
 ### HistogramAggregationOptions {#api-HistogramAggregationOptions}
 
@@ -314,7 +503,7 @@ export interface HistogramAggregationOptions {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:161](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L161)
+[packages/wow/src/query/aggregation.ts:258](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L258)
 
 ### DateHistogramAggregationOptions {#api-DateHistogramAggregationOptions}
 
@@ -323,17 +512,16 @@ export interface DateHistogramAggregationOptions {
   unit: AggregationDateUnit;
   alias: string;
   timeZone?: string;
+  dense?: boolean;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:166](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L166)
+[packages/wow/src/query/aggregation.ts:263](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L263)
 
 ### aggregation {#api-aggregation}
 
-::: details Expand all fields and members
-
 ```ts
-declare const aggregation: {
+export declare const aggregation: {
   element(
     path: string,
     predicate?: ElementFilterExpression,
@@ -361,6 +549,7 @@ declare const aggregation: {
   terms<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    missingKey?: string,
   ): TermsAggregationGroup<FIELDS>;
   histogram<FIELDS extends string>(
     field: FIELDS,
@@ -368,36 +557,63 @@ declare const aggregation: {
   ): HistogramAggregationGroup<FIELDS>;
   dateHistogram<FIELDS extends string>(
     field: FIELDS,
-    { unit, alias, timeZone }: DateHistogramAggregationOptions,
+    { unit, alias, timeZone, dense }: DateHistogramAggregationOptions,
   ): DateHistogramAggregationGroup<FIELDS>;
   any<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ): AnyAggregationMetric<FIELDS>;
-  count(alias: string): CountAggregationMetric;
+  count<FIELDS extends string = string>(
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): CountAggregationMetric<FIELDS>;
   sum: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   avg: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   min: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   max: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
+  stddev: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => NumericAggregationMetric<FIELDS>;
+  variance: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => NumericAggregationMetric<FIELDS>;
+  distinctCount<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): DistinctCountAggregationMetric<FIELDS>;
+  percentile<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    percentile: number,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): PercentileAggregationMetric<FIELDS>;
+  derived(
+    expression: DerivedExpression,
+    alias: string,
+  ): DerivedAggregationMetric;
 };
 ```
 
-:::
-
-[packages/wow/src/query/aggregation.ts:210](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
-
-## Related topics
-
-[Client configuration and metadata](./configuration) · [Commands and wait results](./commands) · [Snapshot queries](./snapshot-queries) · [Filter expressions and legacy conditions](./filters) · [Projection, sorting and pagination](./query-options) · [Cursor queries](./cursor-queries) · [Events and historical state](./events-and-history) · [Identity and resource attribution](./identity-and-attribution)
+[packages/wow/src/query/aggregation.ts:310](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L310)

--- a/wiki/reference/wow/symbols.md
+++ b/wiki/reference/wow/symbols.md
@@ -58,6 +58,7 @@ description: 'Wow symbol index — @ahoo-wang/fetcher-wow 5.0.0'
 | `CommandUrlParams`                     | [Commands and wait results](./commands#api-CommandUrlParams)                                    |
 | `ComparableFilterLiteral`              | [Filter expressions and legacy conditions](./filters#api-ComparableFilterLiteral)               |
 | `ComparisonFilter`                     | [Filter expressions and legacy conditions](./filters#api-ComparisonFilter)                      |
+| `ComparisonOperator`                   | [Aggregation builders](./aggregations#api-ComparisonOperator)                                   |
 | `CompensationTarget`                   | [Commands and wait results](./commands#api-CompensationTarget)                                  |
 | `Condition`                            | [Filter expressions and legacy conditions](./filters#api-Condition)                             |
 | `ConditionCapable`                     | [Filter expressions and legacy conditions](./filters#api-ConditionCapable)                      |
@@ -80,7 +81,11 @@ description: 'Wow symbol index — @ahoo-wang/fetcher-wow 5.0.0'
 | `DeletedCapable`                       | [Message payloads and state metadata](./messages-and-state#api-DeletedCapable)                  |
 | `DeletionFilter`                       | [Filter expressions and legacy conditions](./filters#api-DeletionFilter)                        |
 | `DeletionState`                        | [Filter expressions and legacy conditions](./filters#api-DeletionState)                         |
+| `DerivedAggregationMetric`             | [Aggregation builders](./aggregations#api-DerivedAggregationMetric)                             |
+| `DerivedExpression`                    | [Aggregation builders](./aggregations#api-DerivedExpression)                                    |
+| `DerivedExpressionType`                | [Aggregation builders](./aggregations#api-DerivedExpressionType)                                |
 | `DescriptionCapable`                   | [Identity and resource attribution](./identity-and-attribution#api-DescriptionCapable)          |
+| `DistinctCountAggregationMetric`       | [Aggregation builders](./aggregations#api-DistinctCountAggregationMetric)                       |
 | `DomainEvent`                          | [Events and historical state](./events-and-history#api-DomainEvent)                             |
 | `DomainEventStream`                    | [Events and historical state](./events-and-history#api-DomainEventStream)                       |
 | `DomainEventStreamHeader`              | [Events and historical state](./events-and-history#api-DomainEventStreamHeader)                 |
@@ -118,6 +123,8 @@ description: 'Wow symbol index — @ahoo-wang/fetcher-wow 5.0.0'
 | `FunctionInfo`                         | [Message payloads and state metadata](./messages-and-state#api-FunctionInfo)                    |
 | `FunctionInfoCapable`                  | [Message payloads and state metadata](./messages-and-state#api-FunctionInfoCapable)             |
 | `FunctionKind`                         | [Message payloads and state metadata](./messages-and-state#api-FunctionKind)                    |
+| `HavingExpression`                     | [Aggregation builders](./aggregations#api-HavingExpression)                                     |
+| `HavingExpressionType`                 | [Aggregation builders](./aggregations#api-HavingExpressionType)                                 |
 | `HistogramAggregationGroup`            | [Aggregation builders](./aggregations#api-HistogramAggregationGroup)                            |
 | `HistogramAggregationOptions`          | [Aggregation builders](./aggregations#api-HistogramAggregationOptions)                          |
 | `Identifier`                           | [Identity and resource attribution](./identity-and-attribution#api-Identifier)                  |
@@ -152,6 +159,7 @@ description: 'Wow symbol index — @ahoo-wang/fetcher-wow 5.0.0'
 | `PagedQuery`                           | [Projection, sorting and pagination](./query-options#api-PagedQuery)                            |
 | `PagedQueryRequest`                    | [Projection, sorting and pagination](./query-options#api-PagedQueryRequest)                     |
 | `Pagination`                           | [Projection, sorting and pagination](./query-options#api-Pagination)                            |
+| `PercentileAggregationMetric`          | [Aggregation builders](./aggregations#api-PercentileAggregationMetric)                          |
 | `Projection`                           | [Projection, sorting and pagination](./query-options#api-Projection)                            |
 | `ProjectionCapable`                    | [Projection, sorting and pagination](./query-options#api-ProjectionCapable)                     |
 | `QueryApi`                             | [Snapshot queries](./snapshot-queries#api-QueryApi)                                             |

--- a/wiki/zh/reference/view-engine/symbols.md
+++ b/wiki/zh/reference/view-engine/symbols.md
@@ -144,7 +144,7 @@ description: 全部公开核心与 React 导出名称及源码声明。
 | `validateDashboardExpression`     | [dashboardFilters.ts:91](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/dashboard/dashboardFilters.ts#L91)                          |
 | `validateFilterConfiguration`     | [filterConfigurationValidation.ts:120](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/filter/filterConfigurationValidation.ts#L120) |
 | `validateRecordRows`              | [recordData.ts:42](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/record/validation/recordData.ts#L42)                              |
-| `validateViewDefinition`          | [definitionValidation.ts:196](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/definitionValidation.ts#L196)     |
+| `validateViewDefinition`          | [definitionValidation.ts:195](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/definitionValidation.ts#L195)     |
 | `validateViewInstance`            | [instanceValidation.ts:22](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/validation/instanceValidation.ts#L22)           |
 | `ViewCapabilities`                | [viewModel.ts:192](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/viewModel.ts#L192)                                      |
 | `ViewCreateContext`               | [viewServiceContract.ts:41](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/contracts/viewServiceContract.ts#L41)                    |
@@ -181,7 +181,7 @@ description: 全部公开核心与 React 导出名称及源码声明。
 | 符号                              | 声明                                                                                                                                                     |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AnalysisComponentEditorProps`    | [analysisReactTypes.ts:22](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/analysisReactTypes.ts#L22)                   |
-| `AnalysisEditor`                  | [AnalysisEditor.tsx:739](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisEditor.tsx#L739)                       |
+| `AnalysisEditor`                  | [AnalysisEditor.tsx:743](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisEditor.tsx#L743)                       |
 | `AnalysisExtensions`              | [analysisReactTypes.ts:33](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/analysisReactTypes.ts#L33)                   |
 | `AnalysisPresentationEditor`      | [AnalysisPresentationEditor.tsx:52](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisPresentationEditor.tsx#L52) |
 | `AnalysisPresentationEditorProps` | [AnalysisPresentationEditor.tsx:40](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/view-engine/src/analysis/AnalysisPresentationEditor.tsx#L40) |

--- a/wiki/zh/reference/wow/aggregations.md
+++ b/wiki/zh/reference/wow/aggregations.md
@@ -7,19 +7,19 @@ description: '聚合构造器 — @ahoo-wang/fetcher-wow 5.0.0'
 
 AggregationQuery 描述服务端聚合，不是 JavaScript reducer，至少提供一个 metric。`aggregate(query, attributes?, controller?)` 返回以 alias 为键的扁平行；`aggregateStream` 返回 JSON SSE 行，需要显式消费。泛型描述行但不校验内容。
 
-| 构造器                                         | 输入 / 结果                                                                                 |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| aggregation.element(path, predicate?)          | 选择数组/嵌套元素路径，可带元素相对 filter；predicate 内拒绝根元数据/search/deletion 过滤。 |
-| field(field)、constant(number)                 | 字段引用或有限数值常量表达式。                                                              |
-| add/subtract/multiply/divide(left, right)      | 二元表达式树，除法由后端求值，不在此执行。                                                  |
-| terms(field, alias)                            | terms 分组。                                                                                |
-| histogram(field, {interval, alias})            | interval 必须有限且大于 0。                                                                 |
-| dateHistogram(field, {unit, alias, timeZone?}) | AggregationDateUnit 从 YEAR 到 SECOND，时区默认 UTC；空时区或非法枚举抛错。                 |
-| count(alias)                                   | count 指标，没有字段参数。                                                                  |
-| any(field, alias)                              | 后端选择的值，不保证是确定性的第一行。                                                      |
-| sum/avg/min/max(expression, alias)             | 对表达式进行数值聚合。                                                                      |
+| 构造器                                                         | 输入 / 结果                                                                                 |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| aggregation.element(path, predicate?)                          | 选择数组/嵌套元素路径，可带元素相对 filter；predicate 内拒绝根元数据/search/deletion 过滤。 |
+| field(field)、constant(number)                                 | 字段引用或有限数值常量表达式。                                                              |
+| add/subtract/multiply/divide(left, right)                      | 二元表达式树，除法由后端求值，不在此执行。                                                  |
+| terms(field, alias, missingKey?)                               | terms 分组。                                                                                |
+| histogram(field, {interval, alias})                            | interval 必须有限且大于 0。                                                                 |
+| dateHistogram(field, {unit, alias, timeZone?, dense?})         | AggregationDateUnit 从 YEAR 到 SECOND，时区默认 UTC；空时区或非法枚举抛错。                 |
+| count(alias, predicate?)                                       | count 指标，没有字段参数。                                                                  |
+| any(field, alias, predicate?)                                  | 后端选择的值，不保证是确定性的第一行。                                                      |
+| sum/avg/min/max/stddev/variance(expression, alias, predicate?) | 对表达式进行数值聚合。                                                                      |
 
-查询字段为 filter、elements、groupBy、metrics（非空元组）、sort、limit。根 filter 选择源文档，elements 描述嵌套元素遍历/过滤，分组和指标字段相对于该聚合作用域。结果仍为扁平行，elements 不表示嵌套响应。sort 使用输出 alias。省略 filter/groupBy/sort/limit 保持 undefined，没有隐藏客户端 limit 或分组。
+查询字段为 filter、elements、groupBy、metrics（非空元组）、sort、limit、having。根 filter 选择源文档，elements 描述嵌套元素遍历/过滤，分组和指标字段相对于该聚合作用域。结果仍为扁平行，elements 不表示嵌套响应。sort 使用输出 alias。省略 filter/groupBy/sort/limit 保持 undefined，没有隐藏客户端 limit 或分组。
 
 字段语法由 filter 使用的逻辑字段校验器验证。alias 必须为合法单段，不能含点或以 `__wow` 开头。非法 alias、非有限常量、非法 histogram 选项抛 TypeError；不保证字段存在、为数值或后端支持，服务错误仍可拒绝。构造器无 I/O，无须清理；放弃流式读取时需取消并释放 reader。
 
@@ -47,6 +47,52 @@ export const revenue: AggregationQuery = {
 };
 ```
 
+## 扩展聚合协议
+
+对齐 Wow `main` 的 `fd1b3cd46`。旧构造器调用保持原 JSON 形状；未提供的指标过滤、`missingKey` 和 `dense` 不写入请求。
+
+- `aggregation.distinctCount(expression, alias, predicate?)` 统计不同的非空贡献值；`aggregation.percentile(expression, percentile, alias, predicate?)` 只接受严格介于 0 与 100 之间的有限数值（中位数使用 50）。`stddev`、`variance` 计算总体标准差、总体方差。两种后端的百分位均为近似结果；Elasticsearch 去重计数可能近似，MongoDB 去重计数为精确值。
+- 非派生指标可传入当前聚合范围内的 `FilterExpression`，只影响该指标。后端校验标量字段并拒绝不支持的过滤操作符。
+- `aggregation.derived(expression, alias)` 使用 `DerivedExpression` 树（`METRIC_REF`、`CONSTANT`、`BINARY`）。只能引用之前声明的指标，不能引用 `ANY`。派生指标没有记录过滤，应过滤它所引用的指标。空操作数或除零产生 null。
+- `having?: HavingExpression` 支持 `CONDITION`、`BETWEEN`、`IN`、`IS_NULL`、`AND`、`OR`，引用指标别名而非字段路径。`ComparisonOperator` 包含 `EQ`、`NE`、`GT`、`GTE`、`LT`、`LTE`。HAVING 必须有分组，不能引用 `ANY`，在排序与 limit 之前执行。非空集合/操作数由元组类型约束；有限数值、上下界、引用和深度由服务端校验。
+- `terms(field, alias, missingKey?)` 可将缺失/null 值合并到非空白字符串桶键，后端校验字段是否支持字符串分组。`dateHistogram(field, { unit, alias, timeZone?, dense? })` 在 `dense` 为 true 时填充日期内部缺口，要求它是唯一分组维度。没有结果行时不生成日期范围。
+
+仍需满足后端版本要求（日期补桶需要 MongoDB 5.1+，百分位需要 7.0+）；客户端不探测后端能力。直接构造的类型化表达式对象不提供运行时校验。
+
+```ts
+import {
+  aggregation,
+  AggregationExpressionOperator,
+  ComparisonOperator,
+  DerivedExpressionType,
+  HavingExpressionType,
+  type AggregationQuery,
+} from '@ahoo-wang/fetcher-wow';
+
+const query: AggregationQuery = {
+  groupBy: [aggregation.terms('state.status', 'status', 'Unknown')],
+  metrics: [
+    aggregation.count('orders'),
+    aggregation.sum(aggregation.field('state.amount'), 'revenue'),
+    aggregation.derived(
+      {
+        type: DerivedExpressionType.BINARY,
+        operator: AggregationExpressionOperator.DIVIDE,
+        left: { type: DerivedExpressionType.METRIC_REF, metric: 'revenue' },
+        right: { type: DerivedExpressionType.METRIC_REF, metric: 'orders' },
+      },
+      'averageOrderValue',
+    ),
+  ],
+  having: {
+    type: HavingExpressionType.CONDITION,
+    metric: 'averageOrderValue',
+    operator: ComparisonOperator.GTE,
+    value: 100,
+  },
+};
+```
+
 ## 公开签名与类型
 
 以下签名按当前根入口可达声明核对。`?` 表示可省略；泛型/接口只约束编译期，继承项与关联类型可从 [符号索引](./symbols) 定位。运行时默认值和失败行为以本页上文为准。
@@ -70,6 +116,9 @@ export enum AggregationMetricType {
   COUNT = 'COUNT',
   NUMERIC = 'NUMERIC',
   ANY = 'ANY',
+  DISTINCT_COUNT = 'DISTINCT_COUNT',
+  PERCENTILE = 'PERCENTILE',
+  DERIVED = 'DERIVED',
 }
 ```
 
@@ -85,7 +134,7 @@ export enum AggregationExpressionType {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:34](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L34)
+[packages/wow/src/query/aggregation.ts:37](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L37)
 
 ### AggregationExpressionOperator {#api-AggregationExpressionOperator}
 
@@ -98,7 +147,7 @@ export enum AggregationExpressionOperator {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:40](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L40)
+[packages/wow/src/query/aggregation.ts:43](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L43)
 
 ### AggregationDateUnit {#api-AggregationDateUnit}
 
@@ -115,7 +164,7 @@ export enum AggregationDateUnit {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:47](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L47)
+[packages/wow/src/query/aggregation.ts:50](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L50)
 
 ### AggregationFunction {#api-AggregationFunction}
 
@@ -125,10 +174,12 @@ export enum AggregationFunction {
   AVG = 'AVG',
   MIN = 'MIN',
   MAX = 'MAX',
+  STDDEV = 'STDDEV',
+  VARIANCE = 'VARIANCE',
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:58](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L58)
+[packages/wow/src/query/aggregation.ts:61](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L61)
 
 ### AggregationElement {#api-AggregationElement}
 
@@ -139,7 +190,7 @@ export interface AggregationElement {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:65](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L65)
+[packages/wow/src/query/aggregation.ts:70](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L70)
 
 ### TermsAggregationGroup {#api-TermsAggregationGroup}
 
@@ -148,10 +199,11 @@ export interface TermsAggregationGroup<
   FIELDS extends string = string,
 > extends AggregationGroupBase<FIELDS> {
   type: AggregationGroupType.TERMS;
+  missingKey?: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:75](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L75)
+[packages/wow/src/query/aggregation.ts:80](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L80)
 
 ### HistogramAggregationGroup {#api-HistogramAggregationGroup}
 
@@ -164,7 +216,7 @@ export interface HistogramAggregationGroup<
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:81](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L81)
+[packages/wow/src/query/aggregation.ts:87](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L87)
 
 ### DateHistogramAggregationGroup {#api-DateHistogramAggregationGroup}
 
@@ -175,10 +227,11 @@ export interface DateHistogramAggregationGroup<
   type: AggregationGroupType.DATE_HISTOGRAM;
   unit: AggregationDateUnit;
   timeZone?: string;
+  dense?: boolean;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:88](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L88)
+[packages/wow/src/query/aggregation.ts:94](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L94)
 
 ### AggregationGroup {#api-AggregationGroup}
 
@@ -189,7 +242,7 @@ export type AggregationGroup<FIELDS extends string = string> =
   | DateHistogramAggregationGroup<FIELDS>;
 ```
 
-[packages/wow/src/query/aggregation.ts:96](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L96)
+[packages/wow/src/query/aggregation.ts:103](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L103)
 
 ### FieldAggregationExpression {#api-FieldAggregationExpression}
 
@@ -200,7 +253,7 @@ export interface FieldAggregationExpression<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:101](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L101)
+[packages/wow/src/query/aggregation.ts:108](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L108)
 
 ### ConstantAggregationExpression {#api-ConstantAggregationExpression}
 
@@ -211,7 +264,7 @@ export interface ConstantAggregationExpression {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:106](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L106)
+[packages/wow/src/query/aggregation.ts:113](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L113)
 
 ### BinaryAggregationExpression {#api-BinaryAggregationExpression}
 
@@ -224,7 +277,7 @@ export interface BinaryAggregationExpression<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:111](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L111)
+[packages/wow/src/query/aggregation.ts:118](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L118)
 
 ### AggregationExpression {#api-AggregationExpression}
 
@@ -235,23 +288,25 @@ export type AggregationExpression<FIELDS extends string = string> =
   | BinaryAggregationExpression<FIELDS>;
 ```
 
-[packages/wow/src/query/aggregation.ts:118](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L118)
+[packages/wow/src/query/aggregation.ts:125](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L125)
 
 ### CountAggregationMetric {#api-CountAggregationMetric}
 
 ```ts
-export interface CountAggregationMetric {
+export interface CountAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.COUNT;
   alias: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:123](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L123)
+[packages/wow/src/query/aggregation.ts:130](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L130)
 
 ### NumericAggregationMetric {#api-NumericAggregationMetric}
 
 ```ts
 export interface NumericAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.NUMERIC;
   function: AggregationFunction;
   expression: AggregationExpression<FIELDS>;
@@ -259,30 +314,163 @@ export interface NumericAggregationMetric<FIELDS extends string = string> {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:128](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L128)
+[packages/wow/src/query/aggregation.ts:136](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L136)
 
 ### AnyAggregationMetric {#api-AnyAggregationMetric}
 
 ```ts
 export interface AnyAggregationMetric<FIELDS extends string = string> {
+  filter?: FilterExpression<FIELDS>;
   type: AggregationMetricType.ANY;
   field: QueryField<FIELDS>;
   alias: string;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:135](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L135)
+[packages/wow/src/query/aggregation.ts:144](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L144)
+
+### DistinctCountAggregationMetric {#api-DistinctCountAggregationMetric}
+
+```ts
+export interface DistinctCountAggregationMetric<
+  FIELDS extends string = string,
+> {
+  type: AggregationMetricType.DISTINCT_COUNT;
+  expression: AggregationExpression<FIELDS>;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:151](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L151)
+
+### PercentileAggregationMetric {#api-PercentileAggregationMetric}
+
+```ts
+export interface PercentileAggregationMetric<FIELDS extends string = string> {
+  type: AggregationMetricType.PERCENTILE;
+  expression: AggregationExpression<FIELDS>;
+  percentile: number;
+  alias: string;
+  filter?: FilterExpression<FIELDS>;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:160](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L160)
+
+### DerivedExpressionType {#api-DerivedExpressionType}
+
+```ts
+export enum DerivedExpressionType {
+  METRIC_REF = 'METRIC_REF',
+  CONSTANT = 'CONSTANT',
+  BINARY = 'BINARY',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:168](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L168)
+
+### DerivedExpression {#api-DerivedExpression}
+
+```ts
+export type DerivedExpression =
+  | { type: DerivedExpressionType.METRIC_REF; metric: string }
+  | { type: DerivedExpressionType.CONSTANT; value: number }
+  | {
+      type: DerivedExpressionType.BINARY;
+      operator: AggregationExpressionOperator;
+      left: DerivedExpression;
+      right: DerivedExpression;
+    };
+```
+
+[packages/wow/src/query/aggregation.ts:175](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L175)
+
+### DerivedAggregationMetric {#api-DerivedAggregationMetric}
+
+```ts
+export interface DerivedAggregationMetric {
+  type: AggregationMetricType.DERIVED;
+  expression: DerivedExpression;
+  alias: string;
+}
+```
+
+[packages/wow/src/query/aggregation.ts:185](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L185)
+
+### HavingExpressionType {#api-HavingExpressionType}
+
+```ts
+export enum HavingExpressionType {
+  CONDITION = 'CONDITION',
+  BETWEEN = 'BETWEEN',
+  IN = 'IN',
+  IS_NULL = 'IS_NULL',
+  AND = 'AND',
+  OR = 'OR',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:191](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L191)
+
+### ComparisonOperator {#api-ComparisonOperator}
+
+```ts
+export enum ComparisonOperator {
+  EQ = 'EQ',
+  NE = 'NE',
+  GT = 'GT',
+  GTE = 'GTE',
+  LT = 'LT',
+  LTE = 'LTE',
+}
+```
+
+[packages/wow/src/query/aggregation.ts:200](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L200)
+
+### HavingExpression {#api-HavingExpression}
+
+```ts
+export type HavingExpression =
+  | {
+      type: HavingExpressionType.CONDITION;
+      metric: string;
+      operator: ComparisonOperator;
+      value: number;
+    }
+  | {
+      type: HavingExpressionType.BETWEEN;
+      metric: string;
+      lower: number;
+      upper: number;
+    }
+  | {
+      type: HavingExpressionType.IN;
+      metric: string;
+      values: [number, ...number[]];
+    }
+  | { type: HavingExpressionType.IS_NULL; metric: string; negated?: boolean }
+  | {
+      type: HavingExpressionType.AND | HavingExpressionType.OR;
+      operands: [HavingExpression, ...HavingExpression[]];
+    };
+```
+
+[packages/wow/src/query/aggregation.ts:210](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
 
 ### AggregationMetric {#api-AggregationMetric}
 
 ```ts
 export type AggregationMetric<FIELDS extends string = string> =
-  | CountAggregationMetric
+  | CountAggregationMetric<FIELDS>
   | NumericAggregationMetric<FIELDS>
-  | AnyAggregationMetric<FIELDS>;
+  | AnyAggregationMetric<FIELDS>
+  | DistinctCountAggregationMetric<FIELDS>
+  | PercentileAggregationMetric<FIELDS>
+  | DerivedAggregationMetric;
 ```
 
-[packages/wow/src/query/aggregation.ts:141](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L141)
+[packages/wow/src/query/aggregation.ts:234](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L234)
 
 ### AggregationQuery {#api-AggregationQuery}
 
@@ -300,10 +488,11 @@ export interface AggregationQuery<
   ];
   sort?: FieldSort[];
   limit?: number;
+  having?: HavingExpression;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:146](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L146)
+[packages/wow/src/query/aggregation.ts:242](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L242)
 
 ### HistogramAggregationOptions {#api-HistogramAggregationOptions}
 
@@ -314,7 +503,7 @@ export interface HistogramAggregationOptions {
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:161](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L161)
+[packages/wow/src/query/aggregation.ts:258](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L258)
 
 ### DateHistogramAggregationOptions {#api-DateHistogramAggregationOptions}
 
@@ -323,17 +512,16 @@ export interface DateHistogramAggregationOptions {
   unit: AggregationDateUnit;
   alias: string;
   timeZone?: string;
+  dense?: boolean;
 }
 ```
 
-[packages/wow/src/query/aggregation.ts:166](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L166)
+[packages/wow/src/query/aggregation.ts:263](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L263)
 
 ### aggregation {#api-aggregation}
 
-::: details 展开完整字段与成员
-
 ```ts
-declare const aggregation: {
+export declare const aggregation: {
   element(
     path: string,
     predicate?: ElementFilterExpression,
@@ -361,6 +549,7 @@ declare const aggregation: {
   terms<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    missingKey?: string,
   ): TermsAggregationGroup<FIELDS>;
   histogram<FIELDS extends string>(
     field: FIELDS,
@@ -368,36 +557,63 @@ declare const aggregation: {
   ): HistogramAggregationGroup<FIELDS>;
   dateHistogram<FIELDS extends string>(
     field: FIELDS,
-    { unit, alias, timeZone }: DateHistogramAggregationOptions,
+    { unit, alias, timeZone, dense }: DateHistogramAggregationOptions,
   ): DateHistogramAggregationGroup<FIELDS>;
   any<FIELDS extends string>(
     field: FIELDS,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ): AnyAggregationMetric<FIELDS>;
-  count(alias: string): CountAggregationMetric;
+  count<FIELDS extends string = string>(
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): CountAggregationMetric<FIELDS>;
   sum: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   avg: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   min: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
   max: <FIELDS extends string>(
     expression: AggregationExpression<FIELDS>,
     alias: string,
+    predicate?: FilterExpression<FIELDS>,
   ) => NumericAggregationMetric<FIELDS>;
+  stddev: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => NumericAggregationMetric<FIELDS>;
+  variance: <FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ) => NumericAggregationMetric<FIELDS>;
+  distinctCount<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): DistinctCountAggregationMetric<FIELDS>;
+  percentile<FIELDS extends string>(
+    expression: AggregationExpression<FIELDS>,
+    percentile: number,
+    alias: string,
+    predicate?: FilterExpression<FIELDS>,
+  ): PercentileAggregationMetric<FIELDS>;
+  derived(
+    expression: DerivedExpression,
+    alias: string,
+  ): DerivedAggregationMetric;
 };
 ```
 
-:::
-
-[packages/wow/src/query/aggregation.ts:210](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L210)
-
-## 相关专题
-
-[客户端配置与元数据](./configuration) · [命令与等待结果](./commands) · [快照查询](./snapshot-queries) · [过滤表达式与旧条件](./filters) · [投影、排序与分页](./query-options) · [游标查询](./cursor-queries) · [事件与历史状态](./events-and-history) · [身份与资源归属](./identity-and-attribution)
+[packages/wow/src/query/aggregation.ts:310](https://github.com/Ahoo-Wang/fetcher/blob/main/packages/wow/src/query/aggregation.ts#L310)

--- a/wiki/zh/reference/wow/symbols.md
+++ b/wiki/zh/reference/wow/symbols.md
@@ -58,6 +58,7 @@ description: 'Wow 完整符号索引 — @ahoo-wang/fetcher-wow 5.0.0'
 | `CommandUrlParams`                     | [命令与等待结果](./commands#api-CommandUrlParams)                               |
 | `ComparableFilterLiteral`              | [过滤表达式与旧条件](./filters#api-ComparableFilterLiteral)                     |
 | `ComparisonFilter`                     | [过滤表达式与旧条件](./filters#api-ComparisonFilter)                            |
+| `ComparisonOperator`                   | [聚合构造器](./aggregations#api-ComparisonOperator)                             |
 | `CompensationTarget`                   | [命令与等待结果](./commands#api-CompensationTarget)                             |
 | `Condition`                            | [过滤表达式与旧条件](./filters#api-Condition)                                   |
 | `ConditionCapable`                     | [过滤表达式与旧条件](./filters#api-ConditionCapable)                            |
@@ -80,7 +81,11 @@ description: 'Wow 完整符号索引 — @ahoo-wang/fetcher-wow 5.0.0'
 | `DeletedCapable`                       | [消息载荷与状态元数据](./messages-and-state#api-DeletedCapable)                 |
 | `DeletionFilter`                       | [过滤表达式与旧条件](./filters#api-DeletionFilter)                              |
 | `DeletionState`                        | [过滤表达式与旧条件](./filters#api-DeletionState)                               |
+| `DerivedAggregationMetric`             | [聚合构造器](./aggregations#api-DerivedAggregationMetric)                       |
+| `DerivedExpression`                    | [聚合构造器](./aggregations#api-DerivedExpression)                              |
+| `DerivedExpressionType`                | [聚合构造器](./aggregations#api-DerivedExpressionType)                          |
 | `DescriptionCapable`                   | [身份与资源归属](./identity-and-attribution#api-DescriptionCapable)             |
+| `DistinctCountAggregationMetric`       | [聚合构造器](./aggregations#api-DistinctCountAggregationMetric)                 |
 | `DomainEvent`                          | [事件与历史状态](./events-and-history#api-DomainEvent)                          |
 | `DomainEventStream`                    | [事件与历史状态](./events-and-history#api-DomainEventStream)                    |
 | `DomainEventStreamHeader`              | [事件与历史状态](./events-and-history#api-DomainEventStreamHeader)              |
@@ -118,6 +123,8 @@ description: 'Wow 完整符号索引 — @ahoo-wang/fetcher-wow 5.0.0'
 | `FunctionInfo`                         | [消息载荷与状态元数据](./messages-and-state#api-FunctionInfo)                   |
 | `FunctionInfoCapable`                  | [消息载荷与状态元数据](./messages-and-state#api-FunctionInfoCapable)            |
 | `FunctionKind`                         | [消息载荷与状态元数据](./messages-and-state#api-FunctionKind)                   |
+| `HavingExpression`                     | [聚合构造器](./aggregations#api-HavingExpression)                               |
+| `HavingExpressionType`                 | [聚合构造器](./aggregations#api-HavingExpressionType)                           |
 | `HistogramAggregationGroup`            | [聚合构造器](./aggregations#api-HistogramAggregationGroup)                      |
 | `HistogramAggregationOptions`          | [聚合构造器](./aggregations#api-HistogramAggregationOptions)                    |
 | `Identifier`                           | [身份与资源归属](./identity-and-attribution#api-Identifier)                     |
@@ -152,6 +159,7 @@ description: 'Wow 完整符号索引 — @ahoo-wang/fetcher-wow 5.0.0'
 | `PagedQuery`                           | [投影、排序与分页](./query-options#api-PagedQuery)                              |
 | `PagedQueryRequest`                    | [投影、排序与分页](./query-options#api-PagedQueryRequest)                       |
 | `Pagination`                           | [投影、排序与分页](./query-options#api-Pagination)                              |
+| `PercentileAggregationMetric`          | [聚合构造器](./aggregations#api-PercentileAggregationMetric)                    |
 | `Projection`                           | [投影、排序与分页](./query-options#api-Projection)                              |
 | `ProjectionCapable`                    | [投影、排序与分页](./query-options#api-ProjectionCapable)                       |
 | `QueryApi`                             | [快照查询](./snapshot-queries#api-QueryApi)                                     |


### PR DESCRIPTION
## Changes and motivation

Align Fetcher’s aggregation request types and builders with Wow main (`fd1b3cd46`). Clients can now send metric-level filters, distinct counts, percentiles, population standard deviation/variance, derived metrics, HAVING expressions, missing terms keys, and dense date histograms.

Preserve existing builder calls and their default JSON shape. Add Chinese labels for the numeric functions exposed by View Engine, and update the bilingual API reference and agent documentation.

## Validation

- All workspace package builds.
- `npm_config_workspace_concurrency=1 pnpm test:unit` (including package entry checks and declared type checks).
- Default package-parallel execution hit four View Engine timing failures; package-serial execution keeps the same assertions and timeouts. The first run also required building the generator’s published entries.
- View Engine source and compiled-mode regression tests: 1,661 passed in each mode; 3 skipped in each.
- File-scoped ESLint and Prettier checks; `git diff --check`.
- Wiki documentation tests: 11 passed; `pnpm --dir wiki build` passed.
- No live Wow backend integration test was run.

## Compatibility

Additive client API changes; existing calls remain valid. Query-wide semantic validation and backend capability/version checks remain server responsibilities. Derived metrics do not accept record filters. Percentiles and Elasticsearch distinct counts retain backend approximation semantics.
