### PR TITLE
refactor(view-engine): isolate dashboard panel lifecycle

### DIFF
--- a/docs/superpowers/plans/2026-09-13-dashboard-panel-lifecycle.md
+++ b/docs/superpowers/plans/2026-09-13-dashboard-panel-lifecycle.md
@@ -1,0 +1,135 @@
+# Dashboard Panel Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans in the current session, as selected by the user. Steps use checkbox syntax for tracking.
+
+**Goal:** Give panel references and query positions a single lifecycle owner without introducing a library.
+
+**Architecture:** DashboardPanelRuntime privately owns the lifecycle of one immutable panel/reference identity. DashboardRuntime coordinates configuration and applied scope using panel commands and read-only snapshots. Existing RequestRunner, DataViewPosition and aggregate budgets remain authoritative.
+
+**Tech Stack:** TypeScript, existing Fetcher view engine, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-09-13-dashboard-panel-lifecycle-design.md`
+
+## Global Constraints
+
+- Package version 5.0.0, Node >=20.20.2, pnpm 10.34.5.
+- No dependency, build configuration or public API change.
+- Current session sequential execution; one PR, CI/review then squash merge.
+- Preserve the four pre-existing untracked dashboard documents.
+- Run heavy build/test/browser checks serially. Before every commit root `pnpm test:unit` must pass.
+
+## Task 1: Encapsulate panel lifecycle and verify runtime boundaries
+
+**Files:**
+
+- Create `packages/view-engine/src/dashboard/DashboardPanelRuntime.ts`: private panel resources and transitions; panel snapshot type.
+- Modify `packages/view-engine/src/dashboard/DashboardRuntime.ts`: replace mutable PanelState records with owners; retain config/scope orchestration and re-export the existing snapshot type.
+- Modify `packages/view-engine/test/dashboard/recovery.test.ts`: ignored-abort replacement at instance and definition loading boundaries.
+- Create `packages/view-engine/test/dashboard/reload.test.ts`: reset observer replacement, overlapping same-owner reloads, parallel sibling reloads and prompt settlement of obsolete reloads.
+- Create `docs/superpowers/reviews/2026-09-13-dashboard-panel-lifecycle.md`: actual validation and architecture results.
+
+**Interfaces:**
+
+- `DashboardPanelRuntime` consumes immutable `id`/`instanceId`, existing engine/store/host/loader, and activity/publication/budget callbacks.
+- `getSnapshot(): DashboardPanelSnapshot`, `metadataBytes: number`, `needsPreparation: boolean` are read-only observations.
+- `load(): Promise<void>` deduplicates current loading and skips an existing resolver; `applyScope(expression: FilterExpression, dashboardId: string): boolean` returns whether the position needs execution.
+- `refresh(): Promise<void>`, `block(error: unknown, filterId?: string): void`, `reloadReference(ready: () => Promise<void>): Promise<void>`, `suspend(): void`, `dispose(): void` own all resource and status mutations.
+
+- [x] Run baseline dashboard runtime/recovery/resources/embedding tests.
+- [x] Add a deferred host-load probe: start panel `a` at `child`, replace with `other`, wait for `other` to query, then settle the old success/FORBIDDEN; assert the new position remains successful and only one position session survives. Run with the gate at instance and definition boundaries.
+
+```ts
+it.each([
+  ['instance', false],
+  ['instance', true],
+  ['definition', false],
+  ['definition', true],
+] as const)(
+  'isolates a same-ID replacement from obsolete %s completion (denied: %s)',
+  async (stage, denied) => {
+    const oldInstance = deferred<ReturnType<typeof instance>>();
+    const oldDefinition = deferred<typeof definition>();
+    let oldSignal: AbortSignal | undefined;
+    const load = vi.fn(async (id: string, signal?: AbortSignal) => {
+      if (id === 'child' && stage === 'instance') {
+        oldSignal = signal;
+        return oldInstance.promise;
+      }
+      return { ...instance(id), definitionId: id };
+    });
+    const loadDefinition = vi.fn(async (id: string, signal?: AbortSignal) => {
+      if (id === 'child') {
+        oldSignal = signal;
+        return oldDefinition.promise;
+      }
+      return { ...definition, id };
+    });
+    const { engine, paged } = dashboardSetup(
+      { ...configured(), filters: [] },
+      {
+        instance: { load, save: async value => value },
+        definition: { load: loadDefinition },
+      },
+    );
+    try {
+      await engine.load();
+      const runtime = engine.dashboard('dashboard');
+      await vi.waitFor(() =>
+        expect(
+          stage === 'instance' ? load : loadDefinition,
+        ).toHaveBeenCalledOnce(),
+      );
+      expect(oldSignal?.aborted).toBe(false);
+      runtime.edit(config => ({
+        ...config,
+        panels: config.panels.map(panel => ({ ...panel, instanceId: 'other' })),
+      }));
+      expect(oldSignal?.aborted).toBe(true);
+      await vi.waitFor(() => expect(paged).toHaveBeenCalledOnce());
+      const position = runtime.getSnapshot().panels.a.position!;
+      const gate = stage === 'instance' ? oldInstance : oldDefinition;
+      if (denied)
+        gate.reject(new ViewServiceError('FORBIDDEN', 'obsolete owner'));
+      else if (stage === 'instance')
+        oldInstance.resolve({ ...instance('child'), definitionId: 'child' });
+      else oldDefinition.resolve({ ...definition, id: 'child' });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(runtime.getSnapshot().panels.a).toMatchObject({
+        status: 'ready',
+        instance: { id: 'other' },
+        position,
+      });
+      expect(position.getSnapshot().queryStatus).toBe('success');
+      expect(
+        Object.keys(engine.getSnapshot().sessions).filter(id =>
+          id.startsWith('position:'),
+        ),
+      ).toEqual([position.identity.id]);
+      expect(paged).toHaveBeenCalledOnce();
+    } finally {
+      engine.dispose();
+    }
+  },
+);
+```
+
+- [x] Introduce the internal owner; move load/close/block/query/position transitions. Group loaded reference metadata, remove duplicated stored panel geometry, and keep generation checking private.
+- [x] Update runtime reconciliation to dispose replaced owners, retain unchanged owners, and instantiate new ones. Replace direct field writes with commands and snapshot reads.
+- [x] Keep batch scope decisions in runtime; call `applyScope` per owner and refresh only changed positions after publication. A reference reload uses a generation-guarded owner callback to commit only that owner; capture invalidation before notifying observers. Invalidate owners before any callback that can reenter.
+- [x] Run focused tests, then check a deliberate stale-owner mutation against the new deferred-host tests; restore immediately and rerun. Fix any observed regression at the ownership boundary.
+- [x] Measure before/after combined runtime production size and inspect every parent-to-panel interaction. Reject mere forwarding or duplicated state.
+- [x] Run affected dependency/package build, root tests with CI concurrency, lint/format, and Storybook interactions. Obtain independent read-only review and resolve findings.
+
+```sh
+pnpm --filter @ahoo-wang/fetcher-view-engine... build
+VITEST_MAX_WORKERS=2 npm_config_workspace_concurrency=1 pnpm test:unit
+pnpm lint:view-engine
+pnpm test:storybook
+git diff --check
+```
+
+- [x] Record local validation and prepare scoped files and the PR description.
+
+Delivery: commit scoped files, create PR, inspect all CI and review threads, squash
+merge only the validated head, then synchronize this worktree to main. The PR records
+the final remote checks and merge status.

--- a/docs/superpowers/reviews/2026-09-13-dashboard-panel-lifecycle.md
+++ b/docs/superpowers/reviews/2026-09-13-dashboard-panel-lifecycle.md
@@ -1,0 +1,69 @@
+# Dashboard panel lifecycle review
+
+Base: `d19054e981f3f21762338a410351a94e97d11f93` (main after PR #1458).
+
+## Architecture outcome
+
+DashboardRuntime now owns dashboard configuration, applied filters, panel identity
+reconciliation and aggregate coordination. DashboardPanelRuntime owns the retained
+instance, live definition, resolver, position, load promise, generation and errors.
+The parent reads snapshots and metadata byte counts; it does not mutate panel fields.
+
+Raw production lines: DashboardRuntime 1,103 -> 818; internal panel owner 328;
+combined 1,146 (+43, 3.9%). This is not a code-size reduction. The former runtime had
+45 direct `entry` field assignment/increment sites; the new parent has zero.
+Stored geometry is no longer duplicated in lifecycle state. The panel owner uses
+three callbacks (activity, publication, prospective metadata admission), existing
+RequestRunner and DataViewPosition. No dependency, public API or build change.
+
+## Adversarial findings and resolution
+
+- Same-ID replacement after reset publication could let an obsolete reload block
+  the replacement. This was a regression in the initial refactor and is fixed.
+- Same-owner overlapping reloads and simultaneous sibling reloads could interfere
+  through dashboard-wide commit. Independent baseline probes confirmed these two
+  failures already existed on main. Reload now commits only the current panel.
+- Abort callbacks can synchronously start replacement work. Close now clears private
+  resource pointers before cancelling/disposal, and returns the generation captured
+  before callbacks. A load returns its own promise rather than rereading a pointer
+  that a subscriber may have replaced. No additional lifecycle counter was added.
+- If an abort callback disposes an embedding, the obsolete reload must not reserve
+  metadata again. Check generation/disposal immediately after close. A tight-budget
+  embedding can now be reopened after disposal.
+
+The initial budget probe used the selected managed dashboard. Opening another
+position legitimately recreates that selected runtime, so its budget failure was
+not reliable leak evidence. The final probe isolates a non-selected embedding.
+Removing the post-close guard makes the final probe fail on the next embedding's
+budget admission; restoring it passes.
+
+## Validation evidence
+
+- Baseline runtime/recovery/resources/embedding tests: 44 passed.
+- Four same-ID replacement cases cover instance/definition loading, ignored abort,
+  late success/FORBIDDEN, query identity and cancellation. Removing cancellation
+  made all four fail; restoring it passes.
+- Seven reload cases cover reset/loading observers, overlapping reloads, sibling
+  isolation, abort-observer deduplication and post-disposal budget reuse. All seven
+  passed after fixes; individual failures were reproduced before their fixes.
+- Existing applied-versus-draft, exact retained reference, FORBIDDEN cleanup,
+  position-opening reentry, metadata/result budgets, saved identity transfer and
+  independent embedding tests remain the behavioral acceptance surface.
+- Final affected dependency/package build and root `pnpm test:unit` passed using
+  `VITEST_MAX_WORKERS=2 npm_config_workspace_concurrency=1`. View-engine source and
+  compiled modes each passed 1,672 tests with 3 existing skips; type checks passed.
+  Coverage: statements 95.60%, branches 91.56%, functions 97.23%, lines 97.48%.
+- `pnpm lint:view-engine` passed, including shared stories; scoped formatting and
+  `git diff --check` passed. The final Chrome-channel Storybook run passed all 381
+  interactions (94 files passed, 2 skipped). The default Playwright launch initially
+  lacked its downloaded browser; the existing `VIEW_ENGINE_BROWSER_CHANNEL=chrome`
+  option used installed Chrome without changing repository configuration.
+- Independent read-only review: all findings resolved; ready to merge subject to
+  the full checks and CI. The reviewer did not mutate the checkout.
+
+## Delivery gate
+
+Local build, unit/compiled/coverage/type, lint/format, browser checks and independent
+review are complete. The PR must pass all remote checks and have no unresolved
+review findings before squash merge. The PR remains the authoritative record for
+subsequent CI and merge status.

--- a/docs/superpowers/specs/2026-09-13-dashboard-panel-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-13-dashboard-panel-lifecycle-design.md
@@ -1,0 +1,68 @@
+# Dashboard panel lifecycle ownership
+
+## Approved scope
+
+The user approved concentrating panel reference loading, cancellation, replacement,
+position ownership and disposal behind an internal boundary. DashboardRuntime keeps
+configuration drafts, applied filters and dashboard-wide coordination. No new
+dependency, build change, compatibility layer or generic state-machine framework.
+
+## Decision
+
+Introduce one internal DashboardPanelRuntime per data panel. Its immutable identity
+is the panel ID and referenced instance ID; geometry remains solely in DashboardConfig.
+Replacing either identity retires the old owner. Layout-only changes retain it.
+
+The panel owner privately holds loaded reference metadata, the retained instance,
+source resolver, position, request generation, scope and status. DashboardRuntime
+reads an immutable panel snapshot and metadata byte count, and invokes load,
+applyScope, refresh, block, reloadReference, suspend and dispose. It never writes
+panel lifecycle fields. Loaded instance/definition metadata is published together.
+
+Keep the existing RequestRunner and DataViewPosition. The runtime lends its shared
+loader to panels and retains candidate search. Small callbacks report publication,
+dashboard activity and prospective metadata admission; they do not expose parent
+configuration or mutable state. The existing store owns aggregate budgets and
+dashboard-position registration. The dashboard identity is supplied when a position
+is scoped, so saving a new draft does not freeze the old identity into a panel.
+
+Scope compilation stays in DashboardRuntime and existing dashboardFilters functions.
+All panel scope decisions are computed before committing them. Query execution starts
+after scope publication, using the existing applied snapshot rather than editor drafts.
+A reference reload scopes only its own panel after the owner confirms that its private
+generation still matches; it cannot block a sibling that is still loading. Reset callbacks
+may reenter, so invalidation is captured before position release and notification.
+Generation advances only on resource invalidation, not on each deduplicated load.
+
+## Invariants
+
+- Retiring an owner invalidates its requests before releasing its position. Late
+  success or FORBIDDEN from an old owner cannot affect a replacement with the same ID.
+- Suspending retains the admitted instance configuration but releases its live
+  definition, resolver and position. Resuming reauthorizes before displaying data.
+- FORBIDDEN removes retained metadata and live position data; transient errors retain
+  recoverable metadata. Explicit reference reload clears retained data before loading.
+- Budget admission precedes metadata publication. Cleared metadata frees budget even
+  if a subsequent load fails. Sibling panels and embeddings retain their allocations.
+- Observer callbacks can synchronously suspend, replace or dispose panels during
+  position creation or scope updates. Recheck ownership after those calls; dispose
+  positions that were opened after their owner became obsolete.
+- Refresh uses applied filters; saving, geometry and content edits do not trigger
+  unscoped queries or reset unaffected panel positions.
+
+## Acceptance
+
+Run existing dashboard lifetime, resources, runtime, persistence and embedding tests.
+Add a same-panel-ID replacement probe at both instance and definition load boundaries,
+including ignored abort and obsolete authorization failure. Exercise runtime behavior,
+not private property names. Compare old and new behavior before accepting the refactor.
+
+Review that DashboardRuntime no longer mutates panel state and that the new module
+owns real transitions rather than forwarding writes. Record combined production code
+size; more files or a smaller original file alone are not success. Reject additional
+mirrored activity flags, controller registries and generic extension points.
+
+Before commit: affected build, root pnpm test:unit, lint/format checks and independent
+review. Deliver one PR; await all CI and review results, squash merge, then sync main.
+The package remains version 5.0.0, Node >=20.20.2 and pnpm 10.34.5. No dependency or
+public API change is planned; update public documentation if that scope changes.

--- a/packages/view-engine/src/dashboard/DashboardPanelRuntime.ts
+++ b/packages/view-engine/src/dashboard/DashboardPanelRuntime.ts
@@ -1,0 +1,328 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FilterExpression } from '@ahoo-wang/fetcher-wow';
+import type { ViewHost } from '../contracts/ViewHost.js';
+import type {
+  ViewDefinition,
+  ViewInstance,
+  ViewSource,
+} from '../contracts/viewModel.js';
+import { ViewServiceError } from '../contracts/viewServiceContract.js';
+import { validateViewDefinition } from '../contracts/validation/definitionValidation.js';
+import { validateViewInstance } from '../contracts/validation/instanceValidation.js';
+import type { RequestRunner } from '../engine/RequestRunner.js';
+import type { SessionStore } from '../engine/SessionStore.js';
+import type { DataViewPosition, ViewEngine } from '../engine/ViewEngine.js';
+import { copy, message, sameJsonState } from '../lib/snapshot.js';
+import type { DeepReadonly } from '../lib/types.js';
+
+type ReferenceInstance = Exclude<ViewInstance, { kind: 'dashboard' }>;
+
+export interface DashboardPanelSnapshot {
+  readonly panelId: string;
+  readonly status: 'loading' | 'ready' | 'blocked' | 'error' | 'suspended';
+  readonly loading: boolean;
+  readonly blocked: boolean;
+  readonly error: string | null;
+  readonly instance?: DeepReadonly<ReferenceInstance>;
+  readonly definition?: DeepReadonly<ViewDefinition>;
+  readonly position?: DataViewPosition;
+  readonly scopeVersion: number;
+  readonly referenceVersion: number;
+  readonly filterId?: string;
+}
+
+/** Owns one panel/reference identity. Configuration and scope planning belong to the dashboard. */
+export class DashboardPanelRuntime {
+  private retained?: {
+    instance: DeepReadonly<ReferenceInstance>;
+    bytes: number;
+  };
+  private definition?: { value: DeepReadonly<ViewDefinition>; bytes: number };
+  private source?: (controller: AbortController) => Promise<ViewSource>;
+  private currentPosition?: DataViewPosition;
+  private scope?: FilterExpression;
+  private scopeVersion = 0;
+  private referenceVersion = 0;
+  private generation = 0;
+  private status: DashboardPanelSnapshot['status'] = 'suspended';
+  private error: string | null = null;
+  private filterId?: string;
+  private loading?: Promise<void>;
+  private disposed = false;
+
+  constructor(
+    readonly id: string,
+    readonly instanceId: string,
+    private readonly engine: ViewEngine,
+    private readonly store: SessionStore,
+    private readonly host: ViewHost,
+    private readonly loads: RequestRunner,
+    private readonly events: {
+      isActive(): boolean;
+      publish(): void;
+      reserveMetadata(bytes: number): void;
+    },
+  ) {}
+
+  get position(): DataViewPosition | undefined {
+    return this.currentPosition;
+  }
+  get metadataBytes(): number {
+    return (this.retained?.bytes ?? 0) + (this.definition?.bytes ?? 0);
+  }
+  get needsPreparation(): boolean {
+    return !this.position && !this.source && this.status !== 'blocked';
+  }
+  getSnapshot(): DashboardPanelSnapshot {
+    const session = this.position
+      ? this.store.find(this.position.identity.id)
+      : undefined;
+    const data = session?.kind !== 'dashboard' ? session : undefined;
+    return Object.freeze({
+      panelId: this.id,
+      status: data?.queryStatus === 'error' ? 'error' : this.status,
+      loading:
+        this.status === 'loading' ||
+        data?.queryStatus === 'loading' ||
+        data?.queryStatus === 'waiting',
+      blocked: this.status === 'blocked',
+      error: this.error,
+      instance: this.definition ? this.retained?.instance : undefined,
+      definition: this.definition?.value,
+      position: this.position,
+      scopeVersion: this.scopeVersion,
+      referenceVersion: this.referenceVersion,
+      filterId: this.filterId,
+    });
+  }
+  private current(generation = this.generation): boolean {
+    return (
+      !this.disposed && this.events.isActive() && generation === this.generation
+    );
+  }
+  private close(): number {
+    const generation = ++this.generation;
+    const position = this.position;
+    this.loading = undefined;
+    this.currentPosition = undefined;
+    this.source = undefined;
+    // Abort and position observers may start a new load synchronously.
+    for (const stage of ['instance', 'definition'])
+      this.loads.cancel(`panel:${this.id}:${stage}`);
+    position?.dispose();
+    return generation;
+  }
+  block(error: unknown, filterId?: string): void {
+    if (this.disposed) return;
+    this.scope = undefined;
+    this.scopeVersion++;
+    this.status = 'blocked';
+    this.error = message(error);
+    this.filterId = filterId;
+    if (error instanceof ViewServiceError && error.code === 'FORBIDDEN') {
+      this.retained = this.definition = undefined;
+      this.events.reserveMetadata(0);
+    }
+    this.close();
+    this.events.publish();
+  }
+  async load(): Promise<void> {
+    if (!this.current() || this.source) return;
+    if (this.loading) return this.loading;
+    const generation = this.generation;
+    this.status = 'loading';
+    this.error = null;
+    const request = <T>(
+      stage: string,
+      run: (signal: AbortSignal) => Promise<T> | T,
+    ) =>
+      this.loads.submit({
+        key: `panel:${this.id}:${stage}`,
+        policy: 'queue',
+        timeoutMs: this.store.limits.loadTimeoutMs,
+        run: async signal => {
+          if (!this.current(generation)) throw new Error('引用加载已取消');
+          return run(signal);
+        },
+      }).completion;
+    const operation = Promise.resolve().then(async () => {
+      if (!this.current(generation)) return;
+      if (!this.host.instance?.load || !this.host.definition?.load)
+        throw new Error('宿主未提供引用加载服务');
+      const loaded = await request('instance', signal =>
+        this.host.instance!.load!(this.instanceId, signal),
+      );
+      if (!this.current(generation)) return;
+      if (loaded.id !== this.instanceId || loaded.kind === 'dashboard')
+        throw new Error('引用身份无效或仪表盘嵌套');
+      const definition = await request('definition', signal =>
+        this.host.definition!.load!(loaded.definitionId, signal),
+      );
+      if (!this.current(generation)) return;
+      if (definition.id !== loaded.definitionId)
+        throw new Error('引用定义身份无效');
+      validateViewDefinition(definition);
+      validateViewInstance(loaded, definition, this.instanceId);
+      const instance = this.retained?.instance ?? loaded;
+      validateViewInstance(instance, definition, this.instanceId);
+      if (!definition.sourceId) throw new Error('引用缺少查询源');
+      const bytes = (value: unknown) =>
+        new TextEncoder().encode(JSON.stringify(value)).byteLength;
+      const retainedBytes = bytes(instance),
+        definitionBytes = bytes(definition);
+      this.events.reserveMetadata(retainedBytes + definitionBytes);
+      if (!this.retained) this.referenceVersion++;
+      this.retained = { instance: copy(instance), bytes: retainedBytes };
+      this.definition = { value: copy(definition), bytes: definitionBytes };
+      this.source = async controller => {
+        const deny = (error: unknown, aborted: boolean) => {
+          if (
+            !aborted &&
+            this.current(generation) &&
+            error instanceof ViewServiceError &&
+            error.code === 'FORBIDDEN'
+          )
+            this.block(error);
+          throw error;
+        };
+        let source: ViewSource;
+        try {
+          source = await this.host.resolveSource(definition.sourceId!);
+        } catch (error) {
+          return deny(error, controller.signal.aborted);
+        }
+        return new Proxy(source, {
+          get: (target, key) => {
+            const value: unknown = Reflect.get(target, key, target);
+            if (typeof value !== 'function') return value;
+            return (...args: unknown[]) =>
+              Promise.resolve()
+                .then(() =>
+                  (value as (...args: unknown[]) => unknown).apply(
+                    target,
+                    args,
+                  ),
+                )
+                .catch((error: unknown) =>
+                  deny(
+                    error,
+                    args[2] instanceof AbortController &&
+                      args[2].signal.aborted,
+                  ),
+                );
+          },
+        });
+      };
+      this.status = 'ready';
+    });
+    const loading = operation
+      .catch((error: unknown) => {
+        if (this.current(generation)) this.block(error);
+      })
+      .finally(() => {
+        if (this.generation === generation) this.loading = undefined;
+        if (!this.disposed) this.events.publish();
+      });
+    this.loading = loading;
+    this.events.publish();
+    return loading;
+  }
+  applyScope(expression: FilterExpression, dashboardId: string): boolean {
+    if (
+      !this.current() ||
+      (this.position && sameJsonState(this.scope, expression))
+    )
+      return false;
+    const generation = this.generation;
+    try {
+      if (!this.currentPosition) {
+        if (!this.retained || !this.definition || !this.source) return false;
+        const opened = this.engine.openPosition(
+          copy(this.retained.instance) as ReferenceInstance,
+          copy(this.definition.value),
+          { queryPolicy: 'queue', source: this.source },
+        );
+        if (!this.current(generation)) {
+          opened.dispose();
+          return false;
+        }
+        this.currentPosition = opened;
+      }
+      this.store.registerDashboardPosition(
+        this.currentPosition.identity.id,
+        dashboardId,
+      );
+      this.engine.setPositionScope(
+        this.currentPosition.identity.id,
+        expression,
+      );
+      if (!this.current(generation)) return false;
+      this.scope = expression;
+      this.scopeVersion++;
+      this.status = 'ready';
+      this.error = null;
+      this.filterId = undefined;
+      return true;
+    } catch (error) {
+      if (this.current(generation)) this.block(error);
+      return false;
+    }
+  }
+  async refresh(): Promise<void> {
+    const position = this.position;
+    if (!position || !this.current()) return;
+    this.error = null;
+    this.events.publish();
+    if (!this.current() || this.position !== position) return;
+    try {
+      if (position.kind === 'record') await position.commands.refresh();
+      else await position.commands.run();
+    } catch (error) {
+      // Published query errors belong to the result; unexpected failures reach the caller.
+      if (
+        this.position === position &&
+        this.current() &&
+        position.getSnapshot().queryStatus !== 'error'
+      )
+        throw error;
+    }
+  }
+  async reloadReference(ready: () => Promise<void>): Promise<void> {
+    if (this.disposed) return;
+    this.retained = this.definition = undefined;
+    this.scope = undefined;
+    this.status = 'suspended';
+    const generation = this.close();
+    if (this.disposed || this.generation !== generation) return;
+    this.events.reserveMetadata(0);
+    this.events.publish();
+    // Reset notifications can synchronously replace or reload this owner.
+    if (!this.current(generation)) return;
+    await this.load();
+    if (this.current(generation) && this.source) await ready();
+  }
+  suspend(): void {
+    if (this.disposed) return;
+    this.status = 'suspended';
+    this.definition = undefined;
+    this.close();
+  }
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.retained = this.definition = undefined;
+    this.close();
+  }
+}

--- a/packages/view-engine/src/dashboard/DashboardRuntime.ts
+++ b/packages/view-engine/src/dashboard/DashboardRuntime.ts
@@ -12,15 +12,16 @@
  */
 
 import { dashboardEditorKey } from './dashboardEditorKey.js';
+import {
+  DashboardPanelRuntime,
+  type DashboardPanelSnapshot,
+} from './DashboardPanelRuntime.js';
+export type { DashboardPanelSnapshot } from './DashboardPanelRuntime.js';
 import { filter, type FilterExpression } from '@ahoo-wang/fetcher-wow';
-import type { ViewEngine, DataViewPosition } from '../engine/ViewEngine.js';
+import type { ViewEngine } from '../engine/ViewEngine.js';
 import type { SessionStore } from '../engine/SessionStore.js';
 import type { DashboardCandidate, ViewHost } from '../contracts/ViewHost.js';
-import type {
-  ViewDefinition,
-  ViewInstance,
-  ViewSource,
-} from '../contracts/viewModel.js';
+import type { ViewDefinition } from '../contracts/viewModel.js';
 import type { DeepReadonly } from '../lib/types.js';
 import type {
   FilterConfiguration,
@@ -31,12 +32,7 @@ import { withQueryScope } from '../filter/filterScope.js';
 import { copy, sameJsonState, message } from '../lib/snapshot.js';
 import { RequestRunner } from '../engine/RequestRunner.js';
 import { RuntimeLimitError } from '../lib/runtimeLimits.js';
-import {
-  ViewServiceError,
-  encodeViewResourceId,
-} from '../contracts/viewServiceContract.js';
-import { validateViewDefinition } from '../contracts/validation/definitionValidation.js';
-import { validateViewInstance } from '../contracts/validation/instanceValidation.js';
+import { encodeViewResourceId } from '../contracts/viewServiceContract.js';
 import { validateDashboardConfig } from './dashboardValidation.js';
 import {
   compileDashboardScope,
@@ -44,26 +40,10 @@ import {
 } from './dashboardFilters.js';
 import type {
   DashboardConfig,
-  DashboardViewPanel,
   DashboardSession,
   DashboardTransforms,
 } from './dashboardModel.js';
 
-export interface DashboardPanelSnapshot {
-  readonly panelId: string;
-  readonly status: 'loading' | 'ready' | 'blocked' | 'error' | 'suspended';
-  readonly loading: boolean;
-  readonly blocked: boolean;
-  readonly error: string | null;
-  readonly instance?: DeepReadonly<
-    Exclude<ViewInstance, { kind: 'dashboard' }>
-  >;
-  readonly definition?: DeepReadonly<ViewDefinition>;
-  readonly position?: DataViewPosition;
-  readonly scopeVersion: number;
-  readonly referenceVersion: number;
-  readonly filterId?: string;
-}
 export interface DashboardSnapshot {
   readonly session: DashboardSession;
   readonly config: DeepReadonly<DashboardConfig>;
@@ -75,25 +55,6 @@ export interface DashboardSnapshot {
   readonly error: string | null;
   readonly panels: Readonly<Record<string, DashboardPanelSnapshot>>;
 }
-interface PanelState {
-  panel: DeepReadonly<DashboardViewPanel>;
-  retainedBytes?: number;
-  definitionBytes?: number;
-  retained?: DeepReadonly<Exclude<ViewInstance, { kind: 'dashboard' }>>;
-  instance?: DashboardPanelSnapshot['instance'];
-  definition?: DashboardPanelSnapshot['definition'];
-  source?: (controller: AbortController) => Promise<ViewSource>;
-  position?: DataViewPosition;
-  scope?: FilterExpression;
-  scopeVersion: number;
-  referenceVersion: number;
-  generation: number;
-  status: DashboardPanelSnapshot['status'];
-  error: string | null;
-  filterId?: string;
-  loading?: Promise<void>;
-}
-
 class BindingError extends Error {
   constructor(
     readonly filterId: string,
@@ -115,7 +76,7 @@ export class DashboardRuntime {
   private observedCanOpenOriginal = false;
   private observedState: ReturnType<SessionStore['getSnapshot']>;
   private temporaryValidity: Record<string, boolean> = {};
-  private readonly panels = new Map<string, PanelState>();
+  private readonly panels = new Map<string, DashboardPanelRuntime>();
   private readonly listeners = new Set<() => void>();
   private readonly loads: RequestRunner;
   private readonly unsubscribe: () => void;
@@ -156,7 +117,7 @@ export class DashboardRuntime {
   private reserveMetadata(
     config = this.config,
     applied = this.applied,
-    candidate?: { entry: PanelState; bytes: number },
+    candidate?: { entry: DashboardPanelRuntime; bytes: number },
   ): void {
     let bytes =
       this.jsonBytes(config) +
@@ -166,15 +127,13 @@ export class DashboardRuntime {
         !config.panels.some(
           panel =>
             panel.kind === 'view' &&
-            panel.id === entry.panel.id &&
-            panel.instanceId === entry.panel.instanceId,
+            panel.id === entry.id &&
+            panel.instanceId === entry.instanceId,
         )
       )
         continue;
       bytes +=
-        candidate?.entry === entry
-          ? candidate.bytes
-          : (entry.retainedBytes ?? 0) + (entry.definitionBytes ?? 0);
+        candidate?.entry === entry ? candidate.bytes : entry.metadataBytes;
     }
     this.store.reserveDashboardMetadata(this.id, bytes);
   }
@@ -287,7 +246,7 @@ export class DashboardRuntime {
   }
   openOriginal(panelId: string): void {
     this.assert();
-    const panel = this.panels.get(panelId);
+    const panel = this.panels.get(panelId)?.getSnapshot();
     if (
       !this.active ||
       !panel?.instance ||
@@ -382,38 +341,7 @@ export class DashboardRuntime {
     this.observedCanDiscover = this.canDiscover;
     this.observedCanOpenOriginal = this.canOpenOriginal;
     const panels = Object.fromEntries(
-      [...this.panels].map(([id, entry]) => {
-        const session = entry.position
-          ? this.store.find(entry.position.identity.id)
-          : undefined;
-        const queryLoading =
-          session &&
-          session.kind !== 'dashboard' &&
-          (session.queryStatus === 'loading' ||
-            session.queryStatus === 'waiting');
-        const queryError =
-          session &&
-          session.kind !== 'dashboard' &&
-          session.queryStatus === 'error'
-            ? session.queryError
-            : null;
-        return [
-          id,
-          Object.freeze({
-            panelId: id,
-            status: queryError ? ('error' as const) : entry.status,
-            loading: entry.status === 'loading' || !!queryLoading,
-            blocked: entry.status === 'blocked',
-            error: entry.error,
-            instance: entry.instance,
-            definition: entry.definition,
-            position: entry.position,
-            scopeVersion: entry.scopeVersion,
-            referenceVersion: entry.referenceVersion,
-            filterId: entry.filterId,
-          }),
-        ];
-      }),
+      [...this.panels].map(([id, entry]) => [id, entry.getSnapshot()]),
     );
     this.snapshot = Object.freeze({
       session:
@@ -620,16 +548,6 @@ export class DashboardRuntime {
         this.publish();
       });
   }
-  private close(entry: PanelState): void {
-    entry.generation++;
-    for (const stage of ['instance', 'definition'])
-      this.loads.cancel(`panel:${entry.panel.id}:${stage}`);
-    entry.loading = undefined;
-    const position = entry.position;
-    entry.position = undefined;
-    entry.source = undefined;
-    position?.dispose();
-  }
   private reconciledApplied(
     config: DeepReadonly<DashboardConfig>,
   ): DeepReadonly<DashboardConfig> {
@@ -639,7 +557,7 @@ export class DashboardRuntime {
       if (
         !panel ||
         panel.kind !== 'view' ||
-        panel.instanceId !== entry.panel.instanceId
+        panel.instanceId !== entry.instanceId
       ) {
         applied = copy({
           ...applied,
@@ -665,185 +583,54 @@ export class DashboardRuntime {
       if (
         !panel ||
         panel.kind !== 'view' ||
-        panel.instanceId !== entry.panel.instanceId
+        panel.instanceId !== entry.instanceId
       ) {
         this.panels.delete(id);
-        this.close(entry);
+        entry.dispose();
       }
     }
     for (const panel of this.config.panels) {
-      if (panel.kind !== 'view') continue;
-      const entry = this.panels.get(panel.id);
-      if (entry) entry.panel = panel;
-      else
-        this.panels.set(panel.id, {
-          panel,
-          generation: 0,
-          referenceVersion: 0,
-          scopeVersion: 0,
-          status: 'suspended',
-          error: null,
-        });
-    }
-  }
-  private current(entry: PanelState, generation: number): boolean {
-    return (
-      !this.disposed &&
-      this.active &&
-      this.panels.get(entry.panel.id) === entry &&
-      entry.generation === generation
-    );
-  }
-  private block(entry: PanelState, error: unknown, denied = false): void {
-    this.close(entry);
-    entry.scope = undefined;
-    entry.scopeVersion++;
-    entry.status = 'blocked';
-    entry.error = message(error);
-    entry.filterId = error instanceof BindingError ? error.filterId : undefined;
-    if (denied) {
-      entry.instance = entry.retained = entry.definition = undefined;
-      entry.retainedBytes = entry.definitionBytes = 0;
-      this.reserveMetadata();
-    }
-    this.publish();
-  }
-  private async load(entry: PanelState, reload = false): Promise<void> {
-    if (entry.loading) return entry.loading;
-    const generation = ++entry.generation;
-    entry.status = 'loading';
-    entry.error = null;
-    const request = <T>(
-      stage: string,
-      run: (signal: AbortSignal) => Promise<T> | T,
-    ) =>
-      this.loads.submit({
-        key: `panel:${entry.panel.id}:${stage}`,
-        policy: 'queue',
-        timeoutMs: this.store.limits.loadTimeoutMs,
-        run: async signal => {
-          if (!this.current(entry, generation))
-            throw new Error('引用加载已取消');
-          return run(signal);
+      if (panel.kind !== 'view' || this.panels.has(panel.id)) continue;
+      const entry = new DashboardPanelRuntime(
+        panel.id,
+        panel.instanceId,
+        this.engine,
+        this.store,
+        this.host,
+        this.loads,
+        {
+          isActive: () => this.active && !this.disposed,
+          publish: () => this.publish(),
+          reserveMetadata: bytes =>
+            this.reserveMetadata(this.config, this.applied, { entry, bytes }),
         },
-      }).completion;
-    const operation = Promise.resolve().then(async () => {
-      if (!this.current(entry, generation)) return;
-      if (!this.host.instance?.load || !this.host.definition?.load)
-        throw new Error('宿主未提供引用加载服务');
-      const loaded = await request('instance', signal =>
-        this.host.instance!.load!(entry.panel.instanceId, signal),
       );
-      if (!this.current(entry, generation)) return;
-      if (loaded.id !== entry.panel.instanceId || loaded.kind === 'dashboard')
-        throw new Error('引用身份无效或仪表盘嵌套');
-      const definition = await request('definition', signal =>
-        this.host.definition!.load!(loaded.definitionId, signal),
-      );
-      if (!this.current(entry, generation)) return;
-      if (definition.id !== loaded.definitionId)
-        throw new Error('引用定义身份无效');
-      validateViewDefinition(definition);
-      validateViewInstance(loaded, definition, entry.panel.instanceId);
-      const instance = reload || !entry.retained ? loaded : entry.retained;
-      validateViewInstance(instance, definition, entry.panel.instanceId);
-      if (!definition.sourceId) throw new Error('引用缺少查询源');
-      const retainedBytes = this.jsonBytes(instance),
-        definitionBytes = this.jsonBytes(definition);
-      this.reserveMetadata(this.config, this.applied, {
-        entry,
-        bytes: retainedBytes + definitionBytes,
-      });
-      entry.retainedBytes = retainedBytes;
-      entry.definitionBytes = definitionBytes;
-      if (reload || !entry.retained) entry.referenceVersion++;
-      entry.instance = entry.retained = copy(instance);
-      entry.definition = copy(definition);
-      entry.source = async controller => {
-        let source: ViewSource;
-        try {
-          source = await this.host.resolveSource(definition.sourceId!);
-        } catch (error) {
-          if (
-            !controller.signal.aborted &&
-            this.current(entry, generation) &&
-            error instanceof ViewServiceError &&
-            error.code === 'FORBIDDEN'
-          )
-            this.block(entry, error, true);
-          throw error;
-        }
-        return new Proxy(source, {
-          get: (target, key) => {
-            const value: unknown = Reflect.get(target, key, target);
-            if (typeof value !== 'function') return value;
-            return (...args: unknown[]) =>
-              Promise.resolve()
-                .then(() =>
-                  (value as (...args: unknown[]) => unknown).apply(
-                    target,
-                    args,
-                  ),
-                )
-                .catch((error: unknown) => {
-                  if (
-                    !(
-                      args[2] instanceof AbortController &&
-                      args[2].signal.aborted
-                    ) &&
-                    this.current(entry, generation) &&
-                    error instanceof ViewServiceError &&
-                    error.code === 'FORBIDDEN'
-                  )
-                    this.block(entry, error, true);
-                  throw error;
-                });
-          },
-        });
-      };
-      entry.status = 'ready';
-    });
-    entry.loading = operation
-      .catch((error: unknown) => {
-        if (this.current(entry, generation))
-          this.block(
-            entry,
-            error,
-            error instanceof ViewServiceError && error.code === 'FORBIDDEN',
-          );
-      })
-      .finally(() => {
-        if (entry.generation === generation) entry.loading = undefined;
-        if (!this.disposed) this.publish();
-      });
-    this.publish();
-    return entry.loading;
+      this.panels.set(panel.id, entry);
+    }
   }
   private scope(
-    entry: PanelState,
+    entry: DashboardPanelRuntime,
     config: DeepReadonly<DashboardConfig>,
   ): FilterExpression {
-    if (!entry.instance || !entry.definition)
-      throw new Error(entry.error ?? '引用尚未加载');
-    if (
-      !config.panels.some(
-        panel =>
-          panel.kind === 'view' &&
-          panel.id === entry.panel.id &&
-          panel.instanceId === entry.panel.instanceId,
-      )
-    )
-      throw new Error('面板等待配置并查询');
+    const { instance, definition, error } = entry.getSnapshot();
+    if (!instance || !definition) throw new Error(error ?? '引用尚未加载');
+    const panel = config.panels.find(
+      panel =>
+        panel.kind === 'view' &&
+        panel.id === entry.id &&
+        panel.instanceId === entry.instanceId,
+    );
+    if (!panel || panel.kind !== 'view') throw new Error('面板等待配置并查询');
     const expressions = config.filters
-      .filter(item => !item.excludedPanelIds.includes(entry.panel.id))
+      .filter(item => !item.excludedPanelIds.includes(entry.id))
       .map(item => {
         try {
           return compileDashboardScope(
             item,
-            entry.panel,
+            panel,
             this.store.definition(this.id),
-            entry.definition!,
-            entry.instance!,
+            definition,
+            instance,
             this.transforms,
             this.engine.filterCompilers,
           );
@@ -857,49 +644,29 @@ export class DashboardRuntime {
         : expressions.length
           ? filter.and(expressions)
           : filter.matchAll();
-    validateDashboardExpression(expression, entry.definition);
+    validateDashboardExpression(expression, definition);
     const own = compileFilterConfiguration(
-      entry.instance.config.filters,
-      entry.definition.fields,
-      entry.definition.allowedOperators,
+      instance.config.filters,
+      definition.fields,
+      definition.allowedOperators,
       this.engine.filterCompilers,
-      entry.definition.timeZone,
+      definition.timeZone,
     );
     if (own.errors.length || !own.expression)
       throw new Error('引用筛选配置无效');
     validateDashboardExpression(
       withQueryScope(own.expression, expression),
-      entry.definition,
+      definition,
     );
     return expression;
   }
-  private async execute(entry: PanelState): Promise<void> {
-    const position = entry.position;
-    if (!position || !this.active || this.disposed) return;
-    entry.error = null;
-    this.publish();
-    if (!this.active || this.disposed || entry.position !== position) return;
-    try {
-      if (position.kind === 'record') await position.commands.refresh();
-      else await position.commands.run();
-    } catch (error) {
-      // Published query errors belong to the result; unexpected failures must reach the caller.
-      if (
-        entry.position === position &&
-        this.active &&
-        !this.disposed &&
-        position.getSnapshot().queryStatus !== 'error'
-      )
-        throw error;
-    }
-  }
-
   private async commit(
     config: DeepReadonly<DashboardConfig>,
     apply: boolean,
+    entries = [...this.panels.values()],
   ): Promise<void> {
     const lifetime = this.lifetime;
-    const decisions = [...this.panels.values()].map(entry => {
+    const decisions = entries.map(entry => {
       try {
         return { entry, expression: this.scope(entry, config) };
       } catch (error) {
@@ -909,59 +676,25 @@ export class DashboardRuntime {
     if (apply) this.reserveMetadata(this.config, config);
     this.batching = true;
     if (apply) this.applied = config;
-    const changed: PanelState[] = [];
+    const changed: DashboardPanelRuntime[] = [];
     for (const decision of decisions) {
       if (!this.active || this.disposed || lifetime !== this.lifetime) break;
       const { entry } = decision;
-      const generation = entry.generation;
-      if (this.panels.get(entry.panel.id) !== entry) continue;
+      if (this.panels.get(entry.id) !== entry) continue;
       if (!decision.expression) {
-        this.block(entry, decision.error);
+        entry.block(
+          decision.error,
+          decision.error instanceof BindingError
+            ? decision.error.filterId
+            : undefined,
+        );
         continue;
       }
-      const unchanged =
-        entry.position && sameJsonState(entry.scope, decision.expression);
-      if (unchanged) continue;
-      try {
-        if (!entry.position) {
-          if (!entry.instance || !entry.definition || !entry.source) continue;
-          const opened = this.engine.openPosition(
-            copy(entry.instance) as Exclude<
-              ViewInstance,
-              { kind: 'dashboard' }
-            >,
-            copy(entry.definition),
-            { queryPolicy: 'queue', source: entry.source },
-          );
-          if (!this.current(entry, generation) || lifetime !== this.lifetime) {
-            opened.dispose();
-            break;
-          }
-          entry.position = opened;
-        }
-        this.store.registerDashboardPosition(
-          entry.position.identity.id,
-          this.id,
-        );
-        this.engine.setPositionScope(
-          entry.position.identity.id,
-          decision.expression,
-        );
-        if (!this.current(entry, generation) || lifetime !== this.lifetime)
-          break;
-        entry.scope = decision.expression;
-        entry.scopeVersion++;
-        entry.status = 'ready';
-        entry.error = null;
-        entry.filterId = undefined;
-        changed.push(entry);
-      } catch (error) {
-        this.block(entry, error);
-      }
+      if (entry.applyScope(decision.expression, this.id)) changed.push(entry);
     }
     this.batching = false;
     this.publish();
-    await Promise.all(changed.map(entry => this.execute(entry)));
+    await Promise.all(changed.map(entry => entry.refresh()));
   }
   private async prepare(): Promise<void> {
     if (!this.active || this.disposed) return;
@@ -969,11 +702,8 @@ export class DashboardRuntime {
     const preparation = ++this.preparing;
     await Promise.all(
       [...this.panels.values()]
-        .filter(
-          entry =>
-            !entry.position && !entry.source && entry.status !== 'blocked',
-        )
-        .map(entry => this.load(entry)),
+        .filter(entry => entry.needsPreparation)
+        .map(entry => entry.load()),
     );
     if (
       !this.active ||
@@ -986,7 +716,7 @@ export class DashboardRuntime {
     const issues = this.validation(this.applied, false);
     if (issues.length) {
       this.error = issues.map(issue => issue.message).join('；');
-      for (const entry of this.panels.values()) this.block(entry, this.error);
+      for (const entry of this.panels.values()) entry.block(this.error);
       return;
     }
     await this.commit(this.applied, false);
@@ -1010,8 +740,10 @@ export class DashboardRuntime {
         )
           throw new Error(`缺少筛选转换器：${binding.name}`);
       }
-    for (const entry of this.panels.values())
-      if (entry.instance && entry.definition) this.scope(entry, config);
+    for (const entry of this.panels.values()) {
+      const { instance, definition } = entry.getSnapshot();
+      if (instance && definition) this.scope(entry, config);
+    }
   }
   async apply(): Promise<void> {
     this.assert();
@@ -1033,11 +765,7 @@ export class DashboardRuntime {
       this.publish();
       return;
     }
-    await Promise.all(
-      [...this.panels.values()]
-        .filter(entry => !entry.source)
-        .map(entry => this.load(entry)),
-    );
+    await Promise.all([...this.panels.values()].map(entry => entry.load()));
     if (!this.active || this.disposed || this.applying !== transaction) return;
     this.committing = false;
     await this.commit(config, true);
@@ -1046,27 +774,18 @@ export class DashboardRuntime {
     this.assert();
     const entries = panelId
       ? [this.panels.get(panelId)].filter(
-          (entry): entry is PanelState => !!entry,
+          (entry): entry is DashboardPanelRuntime => !!entry,
         )
       : [...this.panels.values()];
-    await Promise.all(entries.map(entry => this.execute(entry)));
+    await Promise.all(entries.map(entry => entry.refresh()));
   }
   async reloadReference(panelId: string): Promise<void> {
     this.assert();
     const entry = this.panels.get(panelId);
     if (!entry) throw new Error('面板不存在');
-    this.close(entry);
-    entry.instance = entry.definition = entry.retained = undefined;
-    entry.retainedBytes = entry.definitionBytes = 0;
-    this.reserveMetadata();
-    entry.scope = undefined;
-    if (!this.active) {
-      entry.status = 'suspended';
-      this.publish();
-      return;
-    }
-    await this.load(entry, true);
-    if (this.active && !this.disposed) await this.commit(this.applied, false);
+    await entry.reloadReference(() =>
+      this.commit(this.applied, false, [entry]),
+    );
   }
   suspend(): void {
     if (this.disposed || !this.active) return;
@@ -1074,12 +793,7 @@ export class DashboardRuntime {
     ++this.lifetime;
     this.loads.cancel('search');
     ++this.applying;
-    for (const entry of this.panels.values()) {
-      this.close(entry);
-      entry.status = 'suspended';
-      entry.instance = entry.definition = undefined;
-      entry.definitionBytes = 0;
-    }
+    for (const entry of this.panels.values()) entry.suspend();
     this.reserveMetadata();
     this.publish();
   }
@@ -1096,6 +810,7 @@ export class DashboardRuntime {
     this.disposed = true;
     this.unsubscribe();
     this.loads.dispose();
+    for (const entry of this.panels.values()) entry.dispose();
     this.panels.clear();
     this.store.releaseDashboardMetadata(this.id);
     this.listeners.clear();

--- a/packages/view-engine/test/dashboard/recovery.test.ts
+++ b/packages/view-engine/test/dashboard/recovery.test.ts
@@ -336,3 +336,76 @@ it('ignores a cancelled source resolver FORBIDDEN after a replacement scope succ
   expect(position.getSnapshot().queryStatus).toBe('success');
   engine.dispose();
 });
+
+it.each([
+  ['instance', false],
+  ['instance', true],
+  ['definition', false],
+  ['definition', true],
+] as const)(
+  'isolates a same-ID replacement from obsolete %s completion (denied: %s)',
+  async (stage, denied) => {
+    const oldInstance = deferred<ReturnType<typeof instance>>();
+    const oldDefinition = deferred<typeof definition>();
+    let oldSignal: AbortSignal | undefined;
+    const load = vi.fn(async (id: string, signal?: AbortSignal) => {
+      if (id === 'child' && stage === 'instance') {
+        oldSignal = signal;
+        return oldInstance.promise;
+      }
+      return { ...instance(id), definitionId: id };
+    });
+    const loadDefinition = vi.fn(async (id: string, signal?: AbortSignal) => {
+      if (id === 'child') {
+        oldSignal = signal;
+        return oldDefinition.promise;
+      }
+      return { ...definition, id };
+    });
+    const { engine, paged } = dashboardSetup(
+      { ...configured(), filters: [] },
+      {
+        instance: { load, save: async value => value },
+        definition: { load: loadDefinition },
+      },
+    );
+    try {
+      await engine.load();
+      const runtime = engine.dashboard('dashboard');
+      await vi.waitFor(() =>
+        expect(
+          stage === 'instance' ? load : loadDefinition,
+        ).toHaveBeenCalledOnce(),
+      );
+      expect(oldSignal?.aborted).toBe(false);
+      runtime.edit(config => ({
+        ...config,
+        panels: config.panels.map(panel => ({ ...panel, instanceId: 'other' })),
+      }));
+      expect(oldSignal?.aborted).toBe(true);
+      await vi.waitFor(() => expect(paged).toHaveBeenCalledOnce());
+      const position = runtime.getSnapshot().panels.a.position!;
+      const gate = stage === 'instance' ? oldInstance : oldDefinition;
+      if (denied)
+        gate.reject(new ViewServiceError('FORBIDDEN', 'obsolete owner'));
+      else if (stage === 'instance')
+        oldInstance.resolve({ ...instance('child'), definitionId: 'child' });
+      else oldDefinition.resolve({ ...definition, id: 'child' });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(runtime.getSnapshot().panels.a).toMatchObject({
+        status: 'ready',
+        instance: { id: 'other' },
+        position,
+      });
+      expect(position.getSnapshot().queryStatus).toBe('success');
+      expect(
+        Object.keys(engine.getSnapshot().sessions).filter(id =>
+          id.startsWith('position:'),
+        ),
+      ).toEqual([position.identity.id]);
+      expect(paged).toHaveBeenCalledOnce();
+    } finally {
+      engine.dispose();
+    }
+  },
+);

--- a/packages/view-engine/test/dashboard/reload.test.ts
+++ b/packages/view-engine/test/dashboard/reload.test.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it, vi } from 'vitest';
+import { dashboardSetup } from './runtimeFixtures.js';
+import {
+  instance,
+  deferred,
+  setup,
+  definition as recordDefinition,
+} from '../engine/fixtures.js';
+const config = {
+  schemaVersion: 1 as const,
+  filters: [],
+  panels: [
+    {
+      kind: 'view' as const,
+      id: 'a',
+      instanceId: 'child',
+      layout: { x: 0, y: 0, w: 12, h: 18 },
+    },
+  ],
+};
+it('reload survives synchronous replacement during reset publication', async () => {
+  const gate = deferred<ReturnType<typeof instance>>();
+  const load = vi.fn((id: string) =>
+    id === 'other' ? gate.promise : Promise.resolve(instance(id)),
+  );
+  const { engine, paged } = dashboardSetup(config, {
+    instance: { load, save: async v => v },
+  });
+  await engine.load();
+  const runtime = engine.dashboard('dashboard');
+  await vi.waitFor(() => expect(paged).toHaveBeenCalledOnce());
+  let replaced = false;
+  const off = runtime.subscribe(() => {
+    if (!replaced && runtime.getSnapshot().panels.a.status === 'suspended') {
+      replaced = true;
+      runtime.edit(c => ({
+        ...c,
+        panels: c.panels.map(p => ({ ...p, instanceId: 'other' })),
+      }));
+    }
+  });
+  try {
+    await runtime.reloadReference('a');
+    expect(replaced).toBe(true);
+    gate.resolve(instance('other'));
+    await vi.waitFor(() =>
+      expect(runtime.getSnapshot().panels.a).toMatchObject({
+        status: 'ready',
+        instance: { id: 'other' },
+      }),
+    );
+    expect(paged).toHaveBeenCalledTimes(2);
+  } finally {
+    off();
+    engine.dispose();
+  }
+});
+
+it('overlapping reloads preserve the newer request on the same owner', async () => {
+  const { engine, paged, load } = dashboardSetup(config);
+  await engine.load();
+  const runtime = engine.dashboard('dashboard');
+  await vi.waitFor(() => expect(paged).toHaveBeenCalledOnce());
+  const old = deferred<ReturnType<typeof instance>>(),
+    fresh = deferred<ReturnType<typeof instance>>();
+  load
+    .mockImplementationOnce(() => old.promise)
+    .mockImplementationOnce(() => fresh.promise);
+  try {
+    const first = runtime.reloadReference('a');
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+    const second = runtime.reloadReference('a');
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(3));
+    fresh.resolve(instance('child'));
+    await Promise.all([first, second]);
+    expect(runtime.getSnapshot().panels.a.status).toBe('ready');
+  } finally {
+    engine.dispose();
+  }
+});
+it('reloading a panel does not cancel a sibling reload', async () => {
+  const cfg = {
+    ...config,
+    panels: [...config.panels, { ...config.panels[0], id: 'b' }],
+  };
+  const { engine, paged, load } = dashboardSetup(cfg);
+  await engine.load();
+  const runtime = engine.dashboard('dashboard');
+  await vi.waitFor(() => expect(paged).toHaveBeenCalledTimes(2));
+  const a = deferred<ReturnType<typeof instance>>(),
+    b = deferred<ReturnType<typeof instance>>();
+  load
+    .mockImplementationOnce(() => a.promise)
+    .mockImplementationOnce(() => b.promise);
+  try {
+    const first = runtime.reloadReference('a');
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(3));
+    const second = runtime.reloadReference('b');
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(4));
+    a.resolve(instance('child'));
+    await first;
+    b.resolve(instance('child'));
+    await second;
+    expect(runtime.getSnapshot().panels.b.status).toBe('ready');
+  } finally {
+    engine.dispose();
+  }
+});
+
+it.each(['suspended', 'loading'] as const)(
+  'settles an obsolete reload without joining a reload started by its %s observer',
+  async phase => {
+    const { engine, paged, load } = dashboardSetup(config);
+    await engine.load();
+    const runtime = engine.dashboard('dashboard');
+    await vi.waitFor(() => expect(paged).toHaveBeenCalledOnce());
+    const gate = deferred<ReturnType<typeof instance>>();
+    load.mockImplementationOnce(() => gate.promise);
+    let replacement: Promise<void> | undefined;
+    let started = false;
+    const off = runtime.subscribe(() => {
+      if (!started && runtime.getSnapshot().panels.a.status === phase) {
+        started = true;
+        replacement = runtime.reloadReference('a');
+      }
+    });
+    try {
+      let settled = false;
+      const obsolete = runtime.reloadReference('a').then(() => {
+        settled = true;
+      });
+      await vi.waitFor(() => expect(settled).toBe(true));
+      expect(load).toHaveBeenCalledTimes(2);
+      expect(runtime.getSnapshot().panels.a.status).toBe('loading');
+      gate.resolve(instance('child'));
+      await Promise.all([obsolete, replacement]);
+      expect(paged).toHaveBeenCalledTimes(2);
+      expect(runtime.getSnapshot().panels.a.status).toBe('ready');
+    } finally {
+      off();
+      engine.dispose();
+    }
+  },
+);
+
+it('keeps a reload started by an abort observer deduplicated across configuration changes', async () => {
+  const old = deferred<ReturnType<typeof instance>>();
+  const fresh = deferred<ReturnType<typeof instance>>();
+  const load = vi.fn<
+    (id: string, signal?: AbortSignal) => Promise<ReturnType<typeof instance>>
+  >(() => Promise.resolve(instance('child')));
+  const { engine, paged } = dashboardSetup(config, {
+    instance: { load, save: async value => value },
+  });
+  await engine.load();
+  const runtime = engine.dashboard('dashboard');
+  await vi.waitFor(() => expect(paged).toHaveBeenCalledOnce());
+  let nested: Promise<void> | undefined;
+  load
+    .mockImplementationOnce((_id, signal) => {
+      signal!.addEventListener(
+        'abort',
+        () => {
+          nested = runtime.reloadReference('a');
+        },
+        { once: true },
+      );
+      return old.promise;
+    })
+    .mockImplementationOnce(() => fresh.promise);
+  try {
+    const first = runtime.reloadReference('a');
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+    const superseded = runtime.reloadReference('a');
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(3));
+    runtime.edit(current => ({
+      ...current,
+      panels: current.panels.map(panel => ({
+        ...panel,
+        layout: { ...panel.layout, w: 6 },
+      })),
+    }));
+    const applied = runtime.apply();
+    fresh.resolve(instance('child'));
+    await Promise.all([first, superseded, nested, applied]);
+    expect(runtime.getSnapshot().panels.a.status).toBe('ready');
+    expect(load).toHaveBeenCalledTimes(3);
+    expect(paged).toHaveBeenCalledTimes(2);
+  } finally {
+    engine.dispose();
+  }
+});
+
+it('does not reacquire metadata after an abort observer disposes its embedding', async () => {
+  const gate = deferred<ReturnType<typeof instance>>();
+  let dispose = () => {};
+  const load = vi.fn((_id: string, signal?: AbortSignal) => {
+    signal!.addEventListener('abort', () => dispose(), { once: true });
+    return gate.promise;
+  });
+  const { engine } = setup({
+    host: {
+      resolveSource: () => ({ paged: async () => ({ total: 0, list: [] }) }),
+      instance: { load },
+      definition: { load: async () => recordDefinition },
+    },
+    limits: {
+      maxDashboardMetadataBytes:
+        2 * new TextEncoder().encode(JSON.stringify(config)).byteLength,
+    },
+  });
+  const saved = {
+    id: 'copy',
+    definitionId: 'root',
+    kind: 'dashboard' as const,
+    title: 'Copy',
+    revision: 'r1',
+    scope: { type: 'personal' as const },
+    config,
+  };
+  const definition = {
+    id: 'root',
+    title: 'Root',
+    dashboard: true as const,
+    fields: [],
+  };
+  try {
+    await engine.load();
+    const position = engine.openPosition(saved, definition);
+    dispose = () => position.dispose();
+    const loading = position.runtime.resume();
+    await vi.waitFor(() => expect(load).toHaveBeenCalledOnce());
+    await position.runtime.reloadReference('a');
+    await loading;
+    expect(position.runtime.isDisposed).toBe(true);
+    const reopened = engine.openPosition(saved, definition);
+    reopened.dispose();
+    expect(load).toHaveBeenCalledOnce();
+  } finally {
+    engine.dispose();
+  }
+});


### PR DESCRIPTION
DashboardRuntime mixed configuration coordination with direct mutations of panel references, load promises, query positions and cleanup state. Concurrent reference reloads could also commit every panel, blocking a sibling that was still loading.

Move panel resources and transitions into an internal DashboardPanelRuntime. The dashboard now reads snapshots and coordinates applied scopes; each panel owns cancellation, retained metadata, source access and position disposal. Geometry remains only in dashboard configuration. Reference reloads commit only their current owner, with generation checks across asynchronous completion and synchronous reset, loading, abort and disposal callbacks.

This adds no library, public API or build configuration. Combined runtime source grows from 1,103 to 1,146 raw lines (+43); the benefit is removing all 45 direct panel-state writes from the dashboard coordinator, not claiming a code-size reduction.

Validation:
- Eleven new runtime cases cover same-ID replacement, ignored abort, obsolete FORBIDDEN, overlapping/sibling reloads, synchronous observer reentry and post-disposal budget reuse. Targeted fault injection confirms cancellation and budget guards are exercised.
- Independent architecture review completed; all findings resolved.
- Affected package/dependency build, root unit/compiled/coverage/type checks, `pnpm lint:view-engine` and formatting passed. View-engine passed 1,672 tests plus 3 existing skips in each source/compiled mode; final Chrome-channel Storybook run passed 381 interactions.
- Final validation results are recorded in `docs/superpowers/reviews/2026-09-13-dashboard-panel-lifecycle.md`.
